### PR TITLE
Add test coverage of validation code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,9 @@ setup_requires =
     setuptools_scm
 install_requires =
     jsonschema>=3.0.2
+    # The tests require code that is in asdf master
+    # but not yet released.  The package itself
+    # is compatible with asdf 2.7.
     asdf>=2.7.1
     psutil>=5.7.2
     numpy>=1.16

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -477,13 +477,9 @@ def _load_from_schema(hdulist, schema, tree, context, skip_fits_update=False):
                 ctx.get('hdu_index'), known_keywords)
 
             if result is None:
-                validate.value_change(path, result, schema,
-                                      context._pass_invalid_values,
-                                      context._strict_validation)
+                validate.value_change(path, result, schema, context)
             else:
-                if validate.value_change(path, result, schema,
-                                         context._pass_invalid_values,
-                                         context._strict_validation):
+                if validate.value_change(path, result, schema, context):
                     properties.put_value(path, result, tree)
 
         elif 'fits_hdu' in schema and (
@@ -492,13 +488,9 @@ def _load_from_schema(hdulist, schema, tree, context, skip_fits_update=False):
                 hdulist, schema, ctx.get('hdu_index'), known_datas)
 
             if result is None:
-                validate.value_change(path, result, schema,
-                                      context._pass_invalid_values,
-                                      context._strict_validation)
+                validate.value_change(path, result, schema, context)
             else:
-                if validate.value_change(path, result, schema,
-                                         context._pass_invalid_values,
-                                         context._strict_validation):
+                if validate.value_change(path, result, schema, context):
                     properties.put_value(path, result, tree)
 
         if schema.get('type') == 'array':

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -389,9 +389,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Re-validate the model instance againsst its schema
         """
-        validate.value_change(str(self), self._instance, self._schema,
-                              self._pass_invalid_values,
-                              self._strict_validation)
+        validate.value_change(str(self), self._instance, self._schema, self)
 
     def validate_required_fields(self):
         """
@@ -411,9 +409,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 if node is None:
                     break
 
-            validate.value_change(path, node, schema,
-                                  ctx._pass_invalid_values,
-                                  ctx._strict_validation)
+            validate.value_change(path, node, schema, self)
 
         mschema.walk_schema(self._schema, callback, ctx=self)
 

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -42,6 +42,9 @@ def _check_value(value, schema, ctx):
             name = schema.get("fits_keyword") or schema.get("fits_hdu")
             raise jsonschema.ValidationError("%s is a required value"
                                               % name)
+        # Unless fits_required is set, do not validate None values.  These are
+        # regarded as missing in DataModel, and will eventually be stripped out
+        # when the model is saved to FITS or ASDF.
     else:
         value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
         asdf_schema.validate(value, schema=schema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 """Project default for pytest"""
+from pathlib import Path
+
 import pytest
+
+import asdf
 
 import helpers
 from stdatamodels import s3_utils
@@ -18,3 +22,24 @@ def monkey_patch_s3_client(monkeypatch, request):
 @pytest.fixture
 def s3_root_dir(tmpdir):
     return tmpdir
+
+
+@pytest.fixture(scope="session", autouse=True)
+def register_schemas():
+    schemas_root = Path(__file__).parent/"schemas"
+    with asdf.config_context() as config:
+        config.add_resource_mapping(
+            asdf.resource.DirectoryResourceMapping(schemas_root, "http://example.com/schemas")
+        )
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_env_variables(monkeypatch):
+    """
+    Make sure the environment doesn't initially contain these so
+    that test results are consistent.
+    """
+    for var in ["PASS_INVALID_VALUES", "STRICT_VALIDATION"]:
+        monkeypatch.delenv(var, raising=False)
+

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,35 @@
+"""
+Dummy models for testing.
+"""
+from stdatamodels import DataModel
+
+
+class BasicModel(DataModel):
+    """
+    Model with minimal metadata and a single 2D float32
+    data array.
+    """
+    schema_url = "http://example.com/schemas/basic_model"
+
+
+class ValidationModel(DataModel):
+    """
+    Model with various kinds of validated attributes.
+    """
+    schema_url = "http://example.com/schemas/validation_model"
+
+
+class FitsRequiredModel(DataModel):
+    """
+    Model that includes fits_required attributes.
+    """
+    schema_url = "http://example.com/schemas/fits_required_model"
+
+
+class RequiredModel(DataModel):
+    """
+    Model that includes a required attribute.  Uses JSON Schema's
+    built-in 'required' property rather than the custom fits_required.
+    """
+    schema_url = "http://example.com/schemas/required_model"
+

--- a/tests/schemas/basic_model.yaml
+++ b/tests/schemas/basic_model.yaml
@@ -1,0 +1,11 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/basic_model
+title: Basic model with a data array and minimal metadata.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      data:
+        ndim: 2
+        datatype: float32

--- a/tests/schemas/core_metadata.yaml
+++ b/tests/schemas/core_metadata.yaml
@@ -1,0 +1,15 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/core_metadata
+title: Core metadata required of every model schema.
+
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      filename:
+        type: string
+      date:
+        type: string
+      model_type:
+        type: string

--- a/tests/schemas/fits_required_model.yaml
+++ b/tests/schemas/fits_required_model.yaml
@@ -1,0 +1,19 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/fits_required_model
+title: Model with fits_required keywords and HDUs.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          required_keyword:
+            type: string
+            fits_required: true
+            fits_keyword: REQKWRD
+
+      required_hdu:
+        fits_required: true
+        fits_hdu: 1

--- a/tests/schemas/required_model.yaml
+++ b/tests/schemas/required_model.yaml
@@ -1,0 +1,14 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/validation_model
+title: Model with a required attribute.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          required_attribute:
+            type: string
+        required: [required_attribute]

--- a/tests/schemas/validation_model.yaml
+++ b/tests/schemas/validation_model.yaml
@@ -1,0 +1,27 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/validation_model
+title: Model with various kinds of validated properties.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          string_attribute:
+            type: string
+          integer_attribute:
+            type: integer
+          object_attribute:
+            type: object
+            properties:
+              string_attribute:
+                type: string
+          list_attribute:
+            type: array
+            items:
+              type: object
+              properties:
+                string_attribute:
+                  type: string

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,237 @@
+import pytest
+
+import asdf
+import numpy as np
+from numpy.testing import assert_array_equal
+from jsonschema import ValidationError
+
+from stdatamodels.validate import ValidationWarning
+
+from models import ValidationModel, FitsRequiredModel, RequiredModel
+
+
+def test_scalar_attribute_assignment():
+    model = ValidationModel()
+
+    assert model.meta.string_attribute is None
+    with pytest.warns(None) as warnings:
+        model.meta.string_attribute = "foo"
+    assert len(warnings) == 0
+    assert model.meta.string_attribute == "foo"
+
+    with pytest.warns(ValidationWarning):
+        model.meta.string_attribute = 42
+    assert model.meta.string_attribute == "foo"
+
+    with pytest.warns(None) as warnings:
+        model.meta.string_attribute = None
+    assert len(warnings) == 0
+    assert model.meta.string_attribute is None
+
+
+def test_object_attribute_assignment():
+    model = ValidationModel()
+
+    assert model.meta.object_attribute.string_attribute is None
+    with pytest.warns(None) as warnings:
+        model.meta.object_attribute = {"string_attribute": "foo"}
+    assert len(warnings) == 0
+    assert model.meta.object_attribute.string_attribute == "foo"
+
+    with pytest.warns(ValidationWarning):
+        model.meta.object_attribute = "bar"
+    assert model.meta.object_attribute.string_attribute == "foo"
+
+    with pytest.warns(ValidationWarning):
+        model.meta.object_attribute = {"string_attribute": 42}
+    assert model.meta.object_attribute.string_attribute == "foo"
+
+    with pytest.warns(None) as warnings:
+        model.meta.object_attribute = None
+    assert len(warnings) == 0
+    assert model.meta.object_attribute.string_attribute is None
+
+
+def test_list_attribute_ssignment():
+    model = ValidationModel()
+
+    assert len(model.meta.list_attribute) == 0
+    with pytest.warns(None) as warnings:
+        model.meta.list_attribute.append({"string_attribute": "foo"})
+    assert len(warnings) == 0
+    assert model.meta.list_attribute[0].string_attribute == "foo"
+
+    with pytest.warns(ValidationWarning):
+        model.meta.list_attribute.append({"string_attribute": 42})
+    assert len(model.meta.list_attribute) == 1
+    assert model.meta.list_attribute[0].string_attribute == "foo"
+
+    with pytest.warns(None) as warnings:
+        model.meta.list_attribute = None
+    assert len(warnings) == 0
+    assert len(model.meta.list_attribute) == 0
+
+
+@pytest.mark.xfail(reason="validation of a required attribute not yet implemented", strict=True)
+def test_required_attribute_assignment():
+    model = RequiredModel()
+
+    with pytest.warns(None) as warnings:
+        model.meta.required_attribute = "foo"
+
+    with pytest.warns(ValidationWarning):
+        model.meta.required_attribute = None
+
+
+def test_fits_required_attribute_assignment():
+    model = FitsRequiredModel()
+
+    with pytest.warns(None) as warnings:
+        model.meta.required_keyword = "foo"
+    assert len(warnings) == 0
+    assert model.meta.required_keyword == "foo"
+
+    with pytest.warns(ValidationWarning, match="REQKWRD is a required value"):
+        model.meta.required_keyword = None
+    assert model.meta.required_keyword == "foo"
+
+    with pytest.warns(None) as warnings:
+        model.required_hdu = np.zeros((2, 2))
+    assert len(warnings) == 0
+    assert_array_equal(model.required_hdu, np.zeros((2, 2)))
+
+    with pytest.warns(ValidationWarning, match="1 is a required value"):
+        model.required_hdu = None
+    assert_array_equal(model.required_hdu, np.zeros((2, 2)))
+
+
+@pytest.mark.xfail(reason="validation of required attributes not yet implemented", strict=True)
+def test_validation_on_delete():
+    model = RequiredModel()
+
+    with pytest.warns(None) as warnings:
+        model.meta.required_keyword = "foo"
+    assert len(warnings) == 0
+
+    with pytest.warns(ValidationWarning):
+        del model.meta.required_keyword
+    assert model.meta.required_keyword == "foo"
+
+    model = RequiredModel(pass_invalid_values=True)
+
+    with pytest.warns(None) as warnings:
+        model.meta.required_keyword = "foo"
+    assert len(warnings) == 0
+
+    with pytest.warns(ValidationWarning):
+        del model.meta.required_keyword
+    assert model.meta.required_keyword is None
+
+
+def test_pass_invalid_values_attribute_assignment(monkeypatch):
+    def assert_passed(model, passed):
+        with pytest.warns(ValidationWarning):
+            model.meta.string_attribute = 42
+        if passed:
+            assert model.meta.string_attribute == 42
+        else:
+            assert model.meta.string_attribute is None
+
+    assert_passed(ValidationModel(), False)
+    assert_passed(ValidationModel(pass_invalid_values=True), True)
+    assert_passed(ValidationModel(pass_invalid_values=False), False)
+
+    monkeypatch.setenv("PASS_INVALID_VALUES", "true")
+    assert_passed(ValidationModel(), True)
+
+    monkeypatch.setenv("PASS_INVALID_VALUES", "false")
+    assert_passed(ValidationModel(), False)
+
+
+@pytest.mark.xfail(reason="validation on write not yet implemented for ASDF files", strict=True)
+def test_pass_invalid_values_on_write(tmp_path):
+    file_path = tmp_path/"test.asdf"
+    model = ValidationModel(pass_invalid_values=True)
+    with pytest.warns(ValidationWarning):
+        model.meta.string_attribute = 42
+    with pytest.warns(ValidationWarning):
+        model.save(file_path)
+
+    with asdf.open(file_path) as af:
+        assert af["meta"]["string_attribute"] == 42
+
+
+def test_strict_validation_attribute_assignment(monkeypatch):
+    def assert_strict(model, strict):
+        if strict:
+            with pytest.raises(ValidationError):
+                model.meta.string_attribute = 42
+            assert model.meta.string_attribute is None
+        else:
+            with pytest.warns(ValidationWarning):
+                model.meta.string_attribute = 42
+            assert model.meta.string_attribute is None
+
+    assert_strict(ValidationModel(), False)
+    assert_strict(ValidationModel(strict_validation=True), True)
+    assert_strict(ValidationModel(strict_validation=False), False)
+
+    monkeypatch.setenv("STRICT_VALIDATION", "true")
+    assert_strict(ValidationModel(), True)
+
+    monkeypatch.setenv("STRICT_VALIDATION", "false")
+    assert_strict(ValidationModel(), False)
+
+
+def test_validate():
+    model = ValidationModel(pass_invalid_values=True)
+
+    with pytest.warns(None) as warnings:
+        model.meta.string_attribute = "foo"
+        model.validate()
+
+    with pytest.warns(ValidationWarning):
+        model.meta.string_attribute = 42
+    assert model.meta.string_attribute == 42
+
+    with pytest.warns(ValidationWarning):
+        model.validate()
+
+
+def test_validate_required_fields():
+    model = FitsRequiredModel()
+
+    with pytest.warns(ValidationWarning):
+        model.validate_required_fields()
+
+    model.meta.required_keyword = "foo"
+    model.required_hdu = np.zeros((0, 0))
+    with pytest.warns(None) as warnings:
+        model.validate_required_fields()
+    assert len(warnings) == 0
+
+
+@pytest.mark.xfail(reason="validation on read not yet implemented for ASDF files", strict=True)
+def test_validation_on_read(tmp_path):
+    file_path = tmp_path/"test.asdf"
+    with asdf.AsdfFile() as af:
+        af["meta"] = {"string_attribute": "foo"}
+
+        with pytest.warns(None) as warnings:
+            ValidationModel(af)
+        assert len(warnings) == 0
+
+        af["meta"]["string_attribute"] = 42
+        with pytest.warns(ValidationWarning):
+            ValidationModel(af)
+
+
+@pytest.mark.xfail(reason="validation on write not yet implemented for ASDF files", strict=True)
+def test_validation_on_write(tmp_path):
+    file_path = tmp_path/"test.asdf"
+    model = ValidationModel(pass_invalid_values=True)
+    with pytest.warns(ValidationWarning):
+        model.meta.string_attribute = 42
+
+    with pytest.warns(ValidationWarning):
+        model.save(file_path)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ usedevelop= true
 extras= test
 # astropy will complain if the home directory is missing
 passenv= HOME
+deps=
+    # The tests require code that is in asdf
+    # master but not yet released.  This can
+    # be removed once asdf 2.8 is available.
+    asdf @ git+https://github.com/asdf-format/asdf
 commands=
     pytest
 
@@ -33,6 +38,10 @@ usedevelop= true
 deps=
     codecov
     coverage
+    # The tests require code that is in asdf
+    # master but not yet released.  This can
+    # be removed once asdf 2.8 is available.
+    asdf @ git+https://github.com/asdf-format/asdf
 commands=
     coverage run --source=stdatamodels -m pytest
     coverage report -m


### PR DESCRIPTION
This adds new tests for the validation features of DataModel, and makes the following changes:

- Make attribute updates respond to pass_invalid_values
- Remove unreachable code in validate.py relating to type validation
- Remove unnecessary call to custom_tree_to_tagged_tree

The testing exposed some bugs/missing features that I'll open issues for:

- Validation on read does not occur for ASDF files
- Validation on write does not occur for ASDF files
- The JSON Schema `required` property is ignored

