### PR TITLE
Initialize DataModel._asdf early in __init__()

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -156,6 +156,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # Provide the object as context to other classes and functions
         self._ctx = self
 
+        self._asdf = AsdfFile()
+
         # Determine what kind of input we have (init) and execute the
         # proper code to intiailize the model
         self._files_to_close = []

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -156,6 +156,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # Provide the object as context to other classes and functions
         self._ctx = self
 
+        # Initialize with an empty AsdfFile instance as this is needed for
+        # reading in FITS files where validate._check_value() gets called, and
+        # ctx needs to have an _asdf attribute.
         self._asdf = AsdfFile()
 
         # Determine what kind of input we have (init) and execute the


### PR DESCRIPTION
This solves an issue we are seeing in the `jwst.datamodels` subclass of `DataModel` where the `_asdf` attribute doesn't exist due to some changes made here in `stdatamodels`

https://github.com/spacetelescope/stdatamodels/pull/4/files#diff-28744f508b621b779032bc4f0f0542d33778e66674941ec524d213cea968c24eR21

where `ctx._asdf` doesn't exist yet when needed in reading a FITS file.

```
$ pytest jwst/datamodels/tests/test_models.py::test_subarray
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.8.5, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /Users/jdavies/dev/jwst, configfile: setup.cfg
plugins: asdf-2.7.1, requests-mock-1.8.0, doctestplus-0.8.0, ci-watson-0.5, cov-2.10.1, openfiles-0.5.0
collected 1 item                                                                                                                                                         

jwst/datamodels/tests/test_models.py F                                                                                                                             [100%]

================================================================================ FAILURES ================================================================================
_____________________________________________________________________________ test_subarray ______________________________________________________________________________

    def test_subarray():
>       with JwstDataModel(FITS_FILE) as dm:

jwst/datamodels/tests/test_models.py:184: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/model_base.py:217: in __init__
    asdffile = fits_support.from_fits(
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/fits_support.py:585: in from_fits
    known_keywords, known_datas = _load_from_schema(
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/fits_support.py:506: in _load_from_schema
    mschema.walk_schema(schema, callback)
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/schema.py:209: in walk_schema
    recurse(schema, [], None, ctx)
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/schema.py:197: in recurse
    recurse(val, path + [key], combiner, ctx)
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/schema.py:197: in recurse
    recurse(val, path + [key], combiner, ctx)
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/schema.py:184: in recurse
    if callback(schema, path, combiner, ctx, recurse):
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/fits_support.py:482: in callback
    if validate.value_change(path, result, schema, context):
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/validate.py:21: in value_change
    _check_value(value, schema, ctx)
../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/validate.py:49: in _check_value
    value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError('No attribute _instance') raised in repr()] JwstDataModel object at 0x7ffd5dbd0f70>, attr = '_asdf'

    def __getattr__(self, attr):
        from . import ndmodel
    
        if attr.startswith('_'):
>           raise AttributeError('No attribute {0}'.format(attr))
E           AttributeError: No attribute _asdf

../../miniconda3/envs/jwst/lib/python3.8/site-packages/stdatamodels/properties.py:283: AttributeError
```