### PR TITLE
Compare model type as string when verifying FITS hash

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -670,16 +670,9 @@ def _verify_skip_fits_update(skip_fits_update, hdulist, asdf_struct, context):
         return False
 
     # Ensure model types match
-    # TODO: This doesn't work as written in stdatamodels because
-    # we don't have access to the jwst DataModel subclasses.
-    # hdulist_class = util._class_from_model_type(hdulist)
-    hdulist_class = None
-    if hdulist_class is None:
-        log.debug('Cannot determine model of the FITS file.'
-                  ' Cannot skip updating from FITS headers.')
-        return False
-    if not isinstance(context, hdulist_class):
-        log.debug(f'Input model {hdulist_class} does not match the'
+    hdulist_model_type = util.get_model_type(hdulist)
+    if hdulist_model_type != context.__class__.__name__:
+        log.debug(f'Input model type {hdulist_model_type} does not match the'
                   f' requested model {type(context)}.'
                   ' Cannot skip updating from FITS headers.')
         return False

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -6,6 +6,7 @@ import os
 
 import numpy as np
 from astropy.io import fits
+import asdf
 
 import logging
 log = logging.getLogger(__name__)
@@ -165,3 +166,26 @@ def get_envar_as_boolean(name, default=False):
 
     log.debug(f'Environmental "{name}" cannot be found. Using default value of "{default}".')
     return default
+
+
+def get_model_type(init):
+    """
+    Fetch the model type string from the underlying file object.
+
+    Parameters
+    ----------
+    init : asdf.AsdfFile or astropy.io.fits.HDUList
+
+    Returns
+    -------
+    str or None
+    """
+    if isinstance(init, asdf.AsdfFile):
+        if "meta" in init:
+            return init["meta"].get("model_type")
+        else:
+            return None
+    elif isinstance(init, fits.HDUList):
+        return init[0].header.get("DATAMODL")
+    else:
+        raise TypeError(f"Unhandled init type: {init.__class__.__name__}")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+import asdf
 from astropy.io import fits
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -200,3 +201,14 @@ def test_get_envar_as_boolean_invalid(monkeypatch):
     monkeypatch.setenv("TEST_VAR", "foo")
     with pytest.raises(ValueError):
         assert util.get_envar_as_boolean("TEST_VAR")
+
+
+def test_get_model_type():
+    assert util.get_model_type(asdf.AsdfFile()) is None
+    assert util.get_model_type(asdf.AsdfFile({"meta": {"model_type": "SomeModel"}})) == "SomeModel"
+
+    assert util.get_model_type(fits.HDUList([fits.PrimaryHDU()])) is None
+
+    hdu = fits.PrimaryHDU()
+    hdu.header["DATAMODL"] = "SomeOtherModel"
+    assert util.get_model_type(fits.HDUList([hdu])) == "SomeOtherModel"


### PR DESCRIPTION
We commented this code out originally because jwst model classes aren't available in stdatamodels.  In this PR it's revived, but compares model classes by their string names so that jwst models aren't required.