### PR TITLE
Don't use ASDF ndarray validators for now

### DIFF
--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -46,8 +46,12 @@ def _check_value(value, schema, ctx):
         # regarded as missing in DataModel, and will eventually be stripped out
         # when the model is saved to FITS or ASDF.
     else:
+        # The YAML_VALIDATORS dictionary excludes the ASDF ndarray validators
+        # (datatype, shape, ndim, max_ndim), which we can't use here because
+        # they don't fully support recarray columns whose elements are arrays.
+        # Currently ndarray validation is handled in properties._cast instead.
         value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
-        asdf_schema.validate(value, schema=schema)
+        asdf_schema.validate(value, schema=schema, validators=asdf_schema.YAML_VALIDATORS)
 
 
 def _error_message(path, error):


### PR DESCRIPTION
This PR reverts the change in this repo that enabled the ASDF ndarray validators.  It turns out those aren't compatible with some of the jwst table schemas, which include columns with nested arrays that aren't yet supported by ASDF.

We're just going to keep using the ndarray validation in `properties._cast` for now, and switch to asdf built-in validators once they support all the jwst use cases.