### PR TITLE
Initialize documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# setuptools-scm generated module
+src/stdatamodels/_version.py
+
+# auto-generated API docs
+docs/source/api

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+formats:
+  - htmlzip
+  - pdf
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ jobs:
 
     - name: Build documentation and check warnings
       env: TOXENV=build-docs
+      addons:
+        apt:
+          packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
 
     - name: macOS
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ jobs:
     - name: Bandit security audit
       env: TOXENV=bandit
 
+    - name: Build documentation and check warnings
+      env: TOXENV=build-docs
+
     - name: macOS
       env:
         - TOXENV=py38

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,4 @@
+stdatamodels API
+================
+
+.. automodapi:: stdatamodels

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import os
+import sys
+from configparser import ConfigParser
+from datetime import datetime
+import importlib
+
+import stsci_rtd_theme
+
+
+def setup(app):
+    try:
+        app.add_css_file("stsci.css")
+    except AttributeError:
+        app.add_stylesheet("stsci.css")
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Modules that automodapi will document need to be available
+# in the path:
+sys.path.insert(0, str(REPO_ROOT/"src"/"stdatamodels"))
+
+# Read the package's setup.cfg so that we can use relevant
+# values here:
+conf = ConfigParser()
+conf.read(REPO_ROOT/"setup.cfg")
+setup_metadata = dict(conf.items("metadata"))
+
+project = setup_metadata["name"]
+author = setup_metadata["author"]
+copyright = f"{datetime.now().year}, {author}"
+
+package = importlib.import_module(setup_metadata["name"])
+version = package.__version__.split("-", 1)[0]
+release = package.__version__
+
+extensions = [
+    "sphinx_automodapi.automodapi",
+    "numpydoc",
+]
+
+autosummary_generate = True
+numpydoc_show_class_members = False
+autoclass_content = "both"
+
+html_theme = "stsci_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": True
+}
+html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
+html_domain_indices = True
+html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
+html_use_index = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+Welcome to stdatamodels's documentation!
+========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+API
+===
+
+.. toctree::
+   :maxdepth: 1
+
+   api.rst
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,4 @@ requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+write_to = "src/stdatamodels/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,12 @@ test =
     pytest>=4.6.0
     pytest-doctestplus
     pytest-openfiles>=0.5.0
+docs =
+    sphinx
+    sphinx-automodapi
+    numpydoc
+    sphinx-rtd-theme
+    stsci-rtd-theme
 aws =
     stsci-aws-utils>=0.1.2
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-setup(use_scm_version=True)
+setup()

--- a/src/stdatamodels/__init__.py
+++ b/src/stdatamodels/__init__.py
@@ -1,4 +1,8 @@
 from .model_base import DataModel
+from . import _version
 
 
-__all__ = ['DataModel']
+__all__ = ['DataModel', '__version__']
+
+
+__version__ = _version.version

--- a/tox.ini
+++ b/tox.ini
@@ -54,3 +54,9 @@ deps=
     bandit
 commands=
     bandit -r -ll src
+
+[testenv:build-docs]
+basepython= python3.8
+extras= docs
+commands=
+    sphinx-build -W docs/source build/docs


### PR DESCRIPTION
This creates a bare-bones docs directory, currently with nothing but the auto-generated API documentation for `DataModel`.  I looked into migrating documentation over from jwst but what's there is very jwst-specific and I don't have the time to rewrite it right now.