### PR TITLE
Enable tests that have started passing due to FITS hash fix

### DIFF
--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -180,7 +180,6 @@ def _header_to_dict(x):
     return dict((a, b) for (a, b, c) in x)
 
 
-@pytest.mark.skip("requires access to jwst model implementations")
 def test_extra_fits():
     path = os.path.join(ROOT_DIR, "headers.fits")
 
@@ -510,5 +509,3 @@ def test_get_short_doc():
 def test_ensure_ascii():
     for inp in [b"ABCDEFG", "ABCDEFG"]:
         fits_support.ensure_ascii(inp) == "ABCDEFG"
-
-

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -46,7 +46,6 @@ def test_historylist_methods():
     assert len(h1) == 0, "Clear history list"
 
 
-@pytest.mark.skip("requires access to jwst model implementations")
 def test_history_from_model_to_fits(tmpdir):
     tmpfits = str(tmpdir.join('tmp.fits'))
     m = DataModel()
@@ -78,7 +77,6 @@ def test_history_from_model_to_fits(tmpdir):
                                                       "Second entry"]
 
 
-@pytest.mark.skip("requires access to jwst model implementations")
 def test_history_from_fits(tmpdir):
     tmpfits = str(tmpdir.join('tmp.fits'))
     header = fits.Header()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -137,7 +137,7 @@ def test_list2():
             dm.meta.transformations.append({'transformation': 'FOO', 'coeff': 2.0})
 
 
-@pytest.mark.skip("requires access to jwst model implementations")
+@pytest.mark.skip("requires access to datamodels.open")
 def test_invalid_fits():
     hdulist = fits.open(FITS_FILE)
     header = hdulist[0].header
@@ -238,7 +238,6 @@ def test_ad_hoc_json():
         assert dm2.meta.foo == {'a': 42, 'b': ['a', 'b', 'c']}
 
 
-@pytest.mark.skip("requires access to jwst model implementations")
 def test_ad_hoc_fits():
     with DataModel() as dm:
         dm.meta.foo = {'a': 42, 'b': ['a', 'b', 'c']}


### PR DESCRIPTION
@jdavies-st pointed out that the test_history.py tests are passing now.  I checked the other skipped tests and found a few more.