### PR TITLE
Make close() resistant to partially initialized models

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -359,14 +359,20 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         _drop_array(self._instance)
 
     def close(self):
-        if not self._iscopy:
-            if self._asdf is not None:
+        # This method is called by __del__, which may be invoked
+        # even when the model failed to initialize.  Consequently,
+        # we can't assume that any attributes have been set.
+        if hasattr(self, "_iscopy") and not self._iscopy:
+            if hasattr(self, "_asdf") and self._asdf is not None:
                 self._asdf.close()
+
+            if hasattr(self, "_instance"):
                 self._drop_arrays()
 
-            for fd in self._files_to_close:
-                if fd is not None:
-                    fd.close()
+            if hasattr(self, "_files_to_close"):
+                for fd in self._files_to_close:
+                    if fd is not None:
+                        fd.close()
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -259,3 +259,19 @@ def test_skip_serializing_null(tmp_path, filename):
         # Make sure that 'telescope' is not in the tree
         with pytest.raises(KeyError):
             assert model.meta["telescope"] is None
+
+
+def test_delete_failed_model():
+    """
+    Test that a model that failed to initialize does not
+    error when deleted.
+    """
+    class FailedModel(DataModel):
+        def __init__(self, *args, **kwargs):
+            # Simulate a failed init by not invoking the
+            # superclass __init__.
+            pass
+
+    model = FailedModel()
+    # "Asserting" no error here:
+    model.__del__()


### PR DESCRIPTION
I don't know if we'll keep `DataModel.__del__` long term, but this will make it safer in the meantime.