### PR TITLE
Enable flake8 on the tests directory and resolve issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,7 @@ aws =
 select = F, W, E101, E111, E112, E113, E401, E402, E501, E711, E722
 # We should set max line length to 88 eventually
 max-line-length = 130
-exclude =
-    docs,
+exclude = .git,__pycache__,docs,build,dist,.tox,.eggs
 ignore = E203, W503, W504, W605
 
 [tool:pytest]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,4 +42,3 @@ def patch_env_variables(monkeypatch):
     """
     for var in ["PASS_INVALID_VALUES", "STRICT_VALIDATION", "SKIP_FITS_UPDATE"]:
         monkeypatch.delenv(var, raising=False)
-

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -58,6 +58,3 @@ def test_seekable_file_object():
 def test_non_seekable_object():
     with pytest.raises(ValueError):
         check(object())
-
-
-

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,7 +1,5 @@
 import datetime
 
-import pytest
-
 import numpy as np
 from astropy.io import fits
 from astropy.time import Time

--- a/tests/test_s3_utils.py
+++ b/tests/test_s3_utils.py
@@ -37,4 +37,3 @@ def test_split_uri(s3_text_file):
     assert s3_utils.split_uri("s3://test-s3-data/some/longer/key") == ("test-s3-data", "some/longer/key")
     with pytest.raises(ValueError):
         s3_utils.split_uri("not a URI")
-

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,8 +10,6 @@ from astropy import time
 from stdatamodels.schema import merge_property_trees, build_docstring
 from stdatamodels import DataModel
 
-import asdf
-
 from models import FitsModel, TransformModel, BasicModel, ValidationModel, TableModel
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -78,6 +78,7 @@ def test_required_attribute_assignment():
 
     with pytest.warns(None) as warnings:
         model.meta.required_attribute = "foo"
+    assert len(warnings) == 0
 
     with pytest.warns(ValidationWarning):
         model.meta.required_attribute = None
@@ -176,6 +177,7 @@ def test_validate():
     with pytest.warns(None) as warnings:
         model.meta.string_attribute = "foo"
         model.validate()
+    assert len(warnings) == 0
 
     with pytest.warns(ValidationWarning):
         model.meta.string_attribute = 42
@@ -187,7 +189,6 @@ def test_validate():
 
 @pytest.mark.xfail(reason="validation on init not yet implemented for ASDF files", strict=True)
 def test_validation_on_init(tmp_path):
-    file_path = tmp_path/"test.asdf"
     with asdf.AsdfFile() as af:
         af["meta"] = {"string_attribute": "foo"}
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,8 +1,6 @@
 import pytest
 
 import asdf
-import numpy as np
-from numpy.testing import assert_array_equal
 from jsonschema import ValidationError
 
 from stdatamodels.validate import ValidationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ basepython= python3.8
 deps=
     flake8
 commands=
-    flake8 --count src
+    flake8 --count
 
 [testenv:coverage]
 basepython= python3.8


### PR DESCRIPTION
Now that all the tests are passing or appropriately xfail'ed, we can have flake8 check the tests directory.