### PR TITLE
Add xfail'ed test for nested null values

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,15 @@ def test_list_attribute_ssignment():
     assert len(model.meta.list_attribute) == 0
 
 
+@pytest.mark.xfail(reason="correct handling of nested null values not yet implemented", strict=True)
+def test_object_assignment_with_nested_null():
+    model = ValidationModel()
+
+    with pytest.warns(ValidationWarning) as warnings:
+        model.meta.object_attribute = {"string_attribute": None}
+    assert len(warnings) == 0
+
+
 @pytest.mark.xfail(reason="validation of a required attribute not yet implemented", strict=True)
 def test_required_attribute_assignment():
     model = RequiredModel()


### PR DESCRIPTION
I was daydreaming about DataModel validation (doesn't everybody?) and thought of this case.  If we wanted to fix it I think we'd need to override jsonschema's `properties`, `patternProperties`, `required`, and `additionalProperties` validators to all treat `None` as absent.  We can do that, but it's a bit of a hassle so I think we ought to wait and see if we give up on validating on assignment entirely.