### PR TITLE
Add jwst and romancal jobs to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 os: linux
 dist: xenial
 language: python
-python: 3.8
+python: 3.8.5
 
 jobs:
   include:
+    - name: Python 3.9
+      python: 3.9.0
+      env: TOXENV=py39
+
     - name: Python 3.8
       env: TOXENV=py38
 
@@ -40,6 +44,21 @@ jobs:
       install:
         - pip3 install tox
 
-install: pip install tox
+    - name: jwst
+      env: TOXENV=jwst
 
-script: tox
+    - name: romancal
+      env: TOXENV=romancal
+
+  allow_failures:
+    - name: jwst
+      env: TOXENV=jwst
+
+    - name: romancal
+      env: TOXENV=romancal
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: xenial
 language: python
-python: 3.8.5
+python: 3.8.6
 
 jobs:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -60,3 +60,17 @@ basepython= python3.8
 extras= docs
 commands=
     sphinx-build -W docs/source build/docs
+
+[testenv:jwst]
+basepython= python3.8
+deps=
+    jwst[test] @ git+https://github.com/spacetelescope/jwst
+commands=
+    pytest --pyargs jwst.datamodels
+
+[testenv:romancal]
+basepython= python3.8
+deps=
+    romancal[test] @ git+https://github.com/spacetelescope/romancal
+commands=
+    pytest --pyargs romancal.datamodels


### PR DESCRIPTION
This adds 2 new `allow_failures` jobs to the Travis matrix that run the `jwst.datamodels` and `romancal.datamodels` tests.  This will give us a heads-up if anything in an `stdatamodels` PRs breaks something in the dev versions of those 2 packages.

Only running the `.datamodels` tests now for each package for efficiency.  And running on the installed versions of the packages.

Also added a Python 3.9 job.

Resolves #34 