### PR TITLE
Remove automatic management of meta.date and introduce on_init hook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 0.2.0 (unreleased)
 ==================
 
+- Remove automatic management of meta.date attribute and create
+  on_init hook. [#44]
+
 0.1.0 (2020-12-04)
 ==================
 
-- Create package and import code from jwst.datamodels. [#1]
+- Create package and import code from jwst.datamodels. [#1, #27]
 
 - Remove stdatamodels.open. [#2]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -192,19 +192,18 @@ def test_update_from_dict(tmp_path):
 
 
 def test_object_node_iterator():
-    m = BasicModel()
+    m = BasicModel({"meta": {"foo": "bar"}})
     items = []
     for i in m.meta.items():
         items.append(i[0])
 
-    assert 'date' in items
-    assert 'model_type' in items
+    assert 'foo' in items
 
 
 def test_hasattr():
-    model = DataModel()
-    assert model.meta.hasattr('date')
-    assert not model.meta.hasattr('filename')
+    model = DataModel({"meta": {"foo": "bar"}})
+    assert model.meta.hasattr('foo')
+    assert not model.meta.hasattr('baz')
 
 
 def test_datamodel_raises_filenotfound(tmp_path):
@@ -269,3 +268,27 @@ def test_delete_failed_model():
     model = FailedModel()
     # "Asserting" no error here:
     model.__del__()
+
+
+def test_on_init_hook():
+    class OnInitModel(DataModel):
+        def on_init(self, init):
+            super().on_init(init)
+
+            self.meta.foo = "bar"
+
+    model = OnInitModel()
+    assert model.meta.foo == "bar"
+
+
+def test_on_save_hook(tmp_path):
+    class OnSaveModel(DataModel):
+        def on_save(self, init):
+            super().on_save(init)
+
+            self.meta.foo = "bar"
+
+    model = OnSaveModel()
+    assert model.meta.get("foo") is None
+    model.save(tmp_path/"test.asdf")
+    assert model.meta.foo == "bar"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,24 +1,13 @@
-from datetime import datetime
-
 import pytest
 import numpy as np
 
 import jsonschema
 from astropy.modeling import models
-from astropy import time
 
 from stdatamodels.schema import merge_property_trees, build_docstring
 from stdatamodels import DataModel
 
 from models import FitsModel, TransformModel, BasicModel, ValidationModel, TableModel
-
-
-def test_automatic_date_assignment():
-    with BasicModel(strict_validation=True) as dm:
-        time_obj = time.Time(dm.meta.date)
-        assert isinstance(time_obj, time.Time)
-        date_obj = datetime.strptime(dm.meta.date, '%Y-%m-%dT%H:%M:%S.%f')
-        assert isinstance(date_obj, datetime)
 
 
 @pytest.mark.parametrize("filename", ["test.asdf", "test.fits"])


### PR DESCRIPTION
This removes automatic mangement of the meta.date attribute from this package and introduces an on_init hook that will let us re-implement the feature in jwst and romancal.

Here's what the updates to jwst will look like:

https://github.com/spacetelescope/jwst/compare/master...eslavich:AL-420-implement-meta-date-management

And for romancal:

https://github.com/spacetelescope/romancal/compare/main...eslavich:AL-420-meta-date-management