### PR TITLE
Remove nested None values before validating

### DIFF
--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -7,6 +7,14 @@ import os
 import numpy as np
 from astropy.io import fits
 import asdf
+from asdf import treeutil
+
+try:
+    from asdf.treeutil import RemoveNode
+except ImportError:
+    # Prior to asdf 2.8, None was used to indicate
+    # that a node should be removed.
+    RemoveNode = None
 
 import logging
 log = logging.getLogger(__name__)
@@ -189,3 +197,28 @@ def get_model_type(init):
         return init[0].header.get("DATAMODL")
     else:
         raise TypeError(f"Unhandled init type: {init.__class__.__name__}")
+
+
+def remove_none_from_tree(tree):
+    """
+    Remove None values from a tree.  Both dictionary keys
+    and list indices with None values will be removed.
+
+    Parameters
+    ----------
+    tree : object
+        The root node of the tree.
+
+    Returns
+    -------
+    object
+        Modified tree.
+    """
+
+    def _remove_none(node):
+        if node is None:
+            return RemoveNode
+        else:
+            return node
+
+    return treeutil.walk_and_modify(tree, _remove_none)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,11 +70,10 @@ def test_list_attribute_ssignment():
     assert len(model.meta.list_attribute) == 0
 
 
-@pytest.mark.xfail(reason="correct handling of nested null values not yet implemented", strict=True)
 def test_object_assignment_with_nested_null():
     model = ValidationModel()
 
-    with pytest.warns(ValidationWarning) as warnings:
+    with pytest.warns(None) as warnings:
         model.meta.object_attribute = {"string_attribute": None}
     assert len(warnings) == 0
 


### PR DESCRIPTION
This fixes validation behavior when an object with nested None values is assigned to a DataModel.

Resolves spacetelescope/jwst#5491