### PR TITLE
Recognize asdf.tags.core.NDArrayType as an array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - Remove automatic management of meta.date attribute and create
   on_init hook. [#44]
 
+- Fix bug where asdf.tags.core.NDArrayType instances remain
+  in flat dict when include_arrays=False. [#58]
+
 0.1.0 (2020-12-04)
 ==================
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -16,6 +16,7 @@ from astropy.time import Time
 from astropy.wcs import WCS
 
 import asdf
+from asdf.tags.core import NDArrayType
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
 
@@ -971,7 +972,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             return dict((key, convert_val(val)) for (key, val) in self.items())
         else:
             return dict((key, convert_val(val)) for (key, val) in self.items()
-                        if not isinstance(val, np.ndarray))
+                        if not isinstance(val, (np.ndarray, NDArrayType)))
 
     @property
     def schema(self):


### PR DESCRIPTION
The `asdf.tags.core.NDArrayType` class does not actually subclass `np.ndarray`, so DataModel wasn't removing them when it should have been.

Resolves #55 