### PR TITLE
Improve management of open files among shallow DataModel copies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 - Fix bug where asdf.tags.core.NDArrayType instances remain
   in flat dict when include_arrays=False. [#58]
 
+- Improve handling of open files among shallow copies
+  of a DataModel. [#59]
+
 0.1.0 (2020-12-04)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ where = src
 
 [options.extras_require]
 test =
+    psutil
     pytest>=4.6.0
     pytest-doctestplus
     pytest-openfiles>=0.5.0

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,145 @@
+"""Test model resource management"""
+import gc
+
+import pytest
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+import psutil
+
+from models import FitsModel
+
+
+@pytest.mark.parametrize("extension", ["asdf", "fits"])
+def test_context_management(extension, tmp_path):
+    """Ensure working across context management"""
+    original_path = tmp_path / f"original.{extension}"
+    new_path = tmp_path / f"new.{extension}"
+
+    process = psutil.Process()
+    base_count = len(process.open_files())
+
+    array = np.random.uniform(size=(1024, 1024))
+
+    with FitsModel() as model:
+        model.data = array
+        model.save(original_path)
+
+    # No files left open by creating and saving a model:
+    assert len(process.open_files()) == base_count
+
+    with FitsModel(original_path) as model:
+        # Count should be higher due to opening the file:
+        model_count = len(process.open_files())
+        assert model_count > base_count
+
+        new_model = FitsModel(model)
+
+    # No files should be closed yet because new_model still
+    # needs the resources:
+    assert len(process.open_files()) == model_count
+
+    new_model.save(new_path)
+    new_model.close()
+
+    # Back to the original state:
+    assert len(process.open_files()) == base_count
+
+    # Confirm that the array was written accurately:
+    with FitsModel(new_path) as model:
+        assert_array_almost_equal(model.data, array)
+
+
+@pytest.mark.parametrize("extension", ["asdf", "fits"])
+def test_close(extension, tmp_path):
+    """Ensure file resources exist after re-instantiation
+    After re-instantiating a model that has been constructed
+    from a file, the original model should be closeable
+    without affecting the underlying file resources for the new
+    model.
+    """
+    original_path = tmp_path / f"original.{extension}"
+    new_path = tmp_path / f"new.{extension}"
+
+    process = psutil.Process()
+    base_count = len(process.open_files())
+
+    array = np.random.uniform(size=(1024, 1024))
+
+    model = FitsModel()
+    model.data = array
+    model.save(original_path)
+    model.close()
+
+    # No files left open by creating and saving a model:
+    assert len(process.open_files()) == base_count
+
+    model = FitsModel(original_path)
+    # Count should be higher due to opening the file:
+    model_count = len(process.open_files())
+    assert model_count > base_count
+
+    new_model = FitsModel(model)
+    model.close()
+
+    # No files should be closed yet because new_model still
+    # needs the resources:
+    assert len(process.open_files()) == model_count
+
+    new_model.save(new_path)
+    new_model.close()
+
+    # Back to the original state:
+    assert len(process.open_files()) == base_count
+
+    # Confirm that the array was written accurately:
+    model = FitsModel(new_path)
+    assert_array_almost_equal(model.data, array)
+    model.close()
+
+
+@pytest.mark.parametrize("extension", ["asdf", "fits"])
+def test_delete(extension, tmp_path):
+    """Deleting the model should also not close files
+    until the last model has been deleted."""
+    original_path = tmp_path / f"original.{extension}"
+    new_path = tmp_path / f"new.{extension}"
+
+    process = psutil.Process()
+    base_count = len(process.open_files())
+
+    array = np.random.uniform(size=(1024, 1024))
+
+    model = FitsModel()
+    model.data = array
+    model.save(original_path)
+    del model
+    gc.collect()
+
+    # No files left open by creating and saving a model:
+    assert len(process.open_files()) == base_count
+
+    model = FitsModel(original_path)
+    # Count should be higher due to opening the file:
+    model_count = len(process.open_files())
+    assert model_count > base_count
+
+    new_model = FitsModel(model)
+    del model
+    gc.collect()
+
+    # No files should be closed yet because new_model still
+    # needs the resources:
+    assert len(process.open_files()) == model_count
+
+    new_model.save(new_path)
+    del new_model
+    gc.collect()
+
+    # Back to the original state:
+    assert len(process.open_files()) == base_count
+
+    # Confirm that the array was written accurately:
+    model = FitsModel(new_path)
+    assert_array_almost_equal(model.data, array)
+    del model
+    gc.collect()


### PR DESCRIPTION
This is a riff on https://github.com/spacetelescope/stdatamodels/pull/54 that I think will give us a little more flexibility in the future.  I also added parameterized the tests to cover models opened from ASDF files.