### PR TITLE
Handle multiple calls to DataModel.close gracefully

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -357,6 +357,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if hasattr(self, "_file_references"):
             for file_reference in self._file_references:
                 file_reference.decrement()
+            # Discard the list in case close is called a second time.
+            self._file_references = []
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):


### PR DESCRIPTION
A bug revealed by tests in jwst...