### PR TITLE
Don't set level on library loggers

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -26,7 +26,6 @@ from . import validate
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -15,7 +15,6 @@ from . import schema as mschema
 
 import logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 


### PR DESCRIPTION
I can't think of why we'd want logger levels set to DEBUG in a library package, but let me know if there's something I'm overlooking.

https://jira.stsci.edu/browse/AL-473