### PR TITLE
Fix CRDS env vars in tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             python-version: 3.8
             toxenv: py38
 
-          - name: jwst.datamodels tests
+          - name: jwst tests
             runs-on: ubuntu-latest
             python-version: 3.8
             toxenv: jwst

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,20 @@ envlist= py38,style,bandit
 
 [testenv]
 usedevelop= true
+
 extras= test
-# astropy will complain if the home directory is missing
-passenv= HOME
+
+passenv =
+    TOXENV
+    CI
+    CODECOV_*
+    HOME
+    CRDS_*
+    STRICT_VALIDATION
+    PASS_INVALID_VALUES
+    VALIDATE_ON_ASSIGNMENT
+    TEST_BIGDATA
+
 deps=
     # The tests require code that is in asdf
     # master but not yet released.  This can
@@ -61,7 +72,7 @@ commands=
 deps=
     jwst[test] @ git+https://github.com/spacetelescope/jwst
 commands=
-    pytest --pyargs jwst.datamodels
+    pytest --pyargs jwst --ignore-glob=timeconversion
 
 [testenv:romancal]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,6 @@ commands=
     coverage run --source=stdatamodels -m pytest
     coverage report -m
     codecov -e TOXENV
-passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY HOME
 
 [testenv:bandit]
 deps=
@@ -69,6 +68,11 @@ commands=
     sphinx-build -W docs/source build/docs
 
 [testenv:jwst]
+setenv=
+    CRDS_SERVER_URL = https://jwst-crds.stsci.edu
+    CRDS_PATH = ~/crds_cache
+    CRDS_CLIENT_RETRY_COUNT = 3
+    CRDS_CLIENT_RETRY_DELAY_SECONDS = 20
 deps=
     jwst[test] @ git+https://github.com/spacetelescope/jwst
 commands=


### PR DESCRIPTION
This fixes the problem seen here

https://github.com/spacetelescope/stdatamodels/runs/2493534318?check_suite_focus=true#step:5:15

where the `jwst` tests use CRDS via the new CRDS_CONTEXT reporter plugin, and therefore need the CRDS env vars set.

This also expands the testing to the whole downstream `jwst` package unit tests, not just those in `jwst.datamodels`.