### PR TITLE
Make arrays C-contiguous on save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.2.2 (unreleased)
+==================
+
+- Make arrays contiguous on save to prevent issue with duplicate
+  array data between ASDF and FITS. [#70]
+
 0.2.1 (2021-03-08)
 ==================
 


### PR DESCRIPTION
This is a fix for https://github.com/spacetelescope/jwst/issues/6104.

I think I understand the full story now --  asdf is trying to write the groupdq array into a block because of this change (released in asdf 2.7.4):

https://github.com/asdf-format/asdf/pull/949

Since RefPixStep is assigning groupdq to a view of itself:

https://github.com/spacetelescope/jwst/blob/1.2.2/jwst/refpix/irs2_subtract_reference.py#L251

it ends up with a base array with a wacky strides value that asdf doesn't know how to compute a view against, so it's forced to make a copy.  Before 2.7.4 asdf did not make a copy but that left the door open to other problems.

In the end I think the sanest thing we can do here is make the arrays C-contiguous before saving to an ASDF-in-FITS file, since that is how astropy.io.fits will write them anyway.


