### PR TITLE
Fix _no_asdf_extension bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.2.3 (unreleased)
 ==================
 
+- Don't allow ASDF hdus to get passed through ``extra_fits``, and don't
+  write out any ASDF extension if ``self._no_asdf_extension=True`` [#71]
+
 0.2.2 (2021-06-09)
 ==================
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -539,23 +539,25 @@ def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
 
     # Add header keywords and data not in schema to extra_fits
     for hdu in hdulist:
-        known = known_keywords.get(hdu, set())
+        # Don't add ASDF hdus to extra_fits for any reason
+        if hdu.name != "ASDF":
+            known = known_keywords.get(hdu, set())
 
-        cards = []
-        for key, val, comment in hdu.header.cards:
-            if not (is_builtin_fits_keyword(key) or
-                    key in known):
-                cards.append([key, val, comment])
+            cards = []
+            for key, val, comment in hdu.header.cards:
+                if not (is_builtin_fits_keyword(key) or
+                        key in known):
+                    cards.append([key, val, comment])
 
-        if len(cards):
-            properties.put_value(
-                ['extra_fits', hdu.name, 'header'], cards, tree)
+            if len(cards):
+                properties.put_value(
+                    ['extra_fits', hdu.name, 'header'], cards, tree)
 
-        if hdu not in known_datas:
-            if hdu.name.lower() != 'asdf':
-                if hdu.data is not None:
-                    properties.put_value(
-                        ['extra_fits', hdu.name, 'data'], hdu.data, tree)
+            if hdu not in known_datas:
+                if hdu.name.lower() != 'asdf':
+                    if hdu.data is not None:
+                        properties.put_value(
+                            ['extra_fits', hdu.name, 'data'], hdu.data, tree)
 
 
 def _load_history(hdulist, tree):

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -554,10 +554,9 @@ def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
                     ['extra_fits', hdu.name, 'header'], cards, tree)
 
             if hdu not in known_datas:
-                if hdu.name.lower() != 'asdf':
-                    if hdu.data is not None:
-                        properties.put_value(
-                            ['extra_fits', hdu.name, 'data'], hdu.data, tree)
+                if hdu.data is not None:
+                    properties.put_value(
+                        ['extra_fits', hdu.name, 'data'], hdu.data, tree)
 
 
 def _load_history(hdulist, tree):

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -408,6 +408,7 @@ def _save_history(hdulist, tree):
 
 
 def to_fits(tree, schema):
+    """Create hdulist and modified ASDF tree"""
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
 
@@ -419,8 +420,7 @@ def to_fits(tree, schema):
     # Store the FITS hash in the tree
     tree[FITS_HASH_KEY] = fits_hash(hdulist)
 
-    asdf = fits_embed.AsdfInFits(hdulist, tree)
-    return asdf
+    return hdulist, tree
 
 
 ##############################################################################

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -628,7 +628,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     # _no_asdf_extension existed, these will have an ASDF
                     # extension, which may get passed along through extra_fits.
                     # Avoid this.
-                    if "ASDF" in [hdu.name for hdu in ff._hdulist]:
+                    if "ASDF" in ff._hdulist:
                         del ff._hdulist["ASDF"]
                     # Use HDUList.writeto instead of AsdfInFits.write_to
                     ff._hdulist.writeto(init, *args, **kwargs)

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -624,6 +624,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='Card is too long')
                 if self._no_asdf_extension:
+                    # For some old files that were written out before the
+                    # _no_asdf_extension existed, these will have an ASDF
+                    # extension, which may get passed along through extra_fits.
+                    # Avoid this.
+                    if "ASDF" in [hdu.name for hdu in ff._hdulist]:
+                        del ff._hdulist["ASDF"]
+                    # Use HDUList.writeto instead of AsdfInFits.write_to
                     ff._hdulist.writeto(init, *args, **kwargs)
                 else:
                     ff.write_to(init, *args, **kwargs)

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -18,6 +18,7 @@ from astropy.wcs import WCS
 import asdf
 from asdf.tags.core import NDArrayType
 from asdf import AsdfFile
+from asdf.fits_embed import AsdfInFits
 from asdf import schema as asdf_schema
 
 from . import ndmodel
@@ -620,20 +621,21 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         self.on_save(init)
 
-        with fits_support.to_fits(self._instance, self._schema) as ff:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', message='Card is too long')
-                if self._no_asdf_extension:
-                    # For some old files that were written out before the
-                    # _no_asdf_extension existed, these will have an ASDF
-                    # extension, which may get passed along through extra_fits.
-                    # Avoid this.
-                    if "ASDF" in ff._hdulist:
-                        del ff._hdulist["ASDF"]
-                    # Use HDUList.writeto instead of AsdfInFits.write_to
-                    ff._hdulist.writeto(init, *args, **kwargs)
-                else:
-                    ff.write_to(init, *args, **kwargs)
+        hdulist, tree = fits_support.to_fits(self._instance, self._schema)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message='Card is too long')
+            if self._no_asdf_extension:
+                # For some old files that were written out before the
+                # _no_asdf_extension existed, these will have an ASDF
+                # extension, which may get passed along through extra_fits.
+                # Avoid this.
+                if "ASDF" in hdulist:
+                    del hdulist["ASDF"]
+                # Use HDUList.writeto instead of AsdfInFits.write_to
+                hdulist.writeto(init, *args, **kwargs)
+            else:
+                ff = AsdfInFits(hdulist, tree)
+                ff.write_to(init, *args, **kwargs)
 
     @property
     def shape(self):
@@ -1024,8 +1026,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             The type will depend on what libraries are installed on
             this system.
         """
-        ff = fits_support.to_fits(self._instance, self._schema)
-        hdu = fits_support.get_hdu(ff._hdulist, hdu_name, index=hdu_ver-1)
+        hdulist, _ = fits_support.to_fits(self._instance, self._schema)
+        hdu = fits_support.get_hdu(hdulist, hdu_name, index=hdu_ver-1)
         header = hdu.header
         return WCS(header, key=key, relax=True, fix=True)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -43,6 +43,13 @@ class FitsModel(DataModel):
     schema_url = "http://example.com/schemas/fits_model"
 
 
+class PureFitsModel(FitsModel):
+
+    def __init__(self, init=None, **kwargs):
+        super().__init__(init=init, **kwargs)
+        self._no_asdf_extension = True
+
+
 class TransformModel(DataModel):
     """
     Model with an astropy.modeling model in one of its attributes.

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -7,7 +7,7 @@ import asdf.schema
 from stdatamodels import DataModel
 from stdatamodels import fits_support
 
-from models import FitsModel
+from models import FitsModel, PureFitsModel
 
 
 def records_equal(a, b):
@@ -546,3 +546,42 @@ def test_data_array(tmp_path):
 ])
 def test_is_builtin_fits_keyword(keyword, result):
     assert fits_support.is_builtin_fits_keyword(keyword) is result
+
+
+def test_no_asdf_extension(tmp_path):
+    """Verify an ASDF extension is not written out"""
+    path = tmp_path / "no_asdf.fits"
+
+    with PureFitsModel((5, 5)) as m:
+        m.save(path)
+
+    with fits.open(path, memmap=False) as hdulist:
+        assert "ASDF" not in [hdu.name for hdu in hdulist]
+
+
+def test_no_asdf_extension_extra_fits(tmp_path):
+    path = tmp_path / "no_asdf.fits"
+
+    extra_fits = {
+        'ASDF': {
+            'header': [
+                ['CHECKSUM', '9kbGAkbF9kbFAkbF', 'HDU checksum updated 2018-03-07T08:48:27'],
+                ['DATASUM', '136453353', 'data unit checksum updated 2018-03-07T08:48:27']
+            ]
+        }
+    }
+
+    with PureFitsModel((5, 5)) as m:
+        m.extra_fits = {}
+        m.extra_fits.instance.update(extra_fits)
+        assert "ASDF" in m.extra_fits.instance
+        assert "CHECKSUM" in m.extra_fits.ASDF.header[0]
+        assert "DATASUM" in m.extra_fits.ASDF.header[1]
+        m.save(path)
+
+    with fits.open(path, memmap=False) as hdulist:
+        assert "ASDF" not in [hdu.name for hdu in hdulist]
+
+    with PureFitsModel(path) as m:
+        with pytest.raises(AttributeError):
+            m.extra_fits

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -556,7 +556,7 @@ def test_no_asdf_extension(tmp_path):
         m.save(path)
 
     with fits.open(path, memmap=False) as hdulist:
-        assert "ASDF" not in [hdu.name for hdu in hdulist]
+        assert "ASDF" not in hdulist
 
 
 def test_no_asdf_extension_extra_fits(tmp_path):
@@ -580,7 +580,7 @@ def test_no_asdf_extension_extra_fits(tmp_path):
         m.save(path)
 
     with fits.open(path, memmap=False) as hdulist:
-        assert "ASDF" not in [hdu.name for hdu in hdulist]
+        assert "ASDF" not in hdulist
 
     with PureFitsModel(path) as m:
         with pytest.raises(AttributeError):


### PR DESCRIPTION
This fixes a bug seen when reading in old CRDS reffiles and trying to write them back out.

Resolves [AL-556](https://jira.stsci.edu/browse/AL-556)
Resolves spacetelescope/jwst#6028 / [JP-2080](https://jira.stsci.edu/browse/JP-2080)

 - Don't allow ASDF hdus to get passed through `extra_fits`, ever
 - Never write out any ASDF extension if `self._no_asdf_extension=True`