### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
             python-version: 3.9
             toxenv: py39
 
-          - name: Python 3.8
-            runs-on: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38
-
           - name: Coverage
             runs-on: ubuntu-latest
             python-version: 3.8
@@ -60,7 +55,17 @@ jobs:
             runs-on: ubuntu-latest
             python-version: 3.8
             toxenv: romancal
+
+          - name: Build documentation
+            runs-on: ubuntu-latest
+            python-version: 3.8
+            toxenv: build-docs
+
     steps:
+      - name: Install extra system packages
+        if: ${{ contains(matrix.toxenv,'docs') }}
+        run: |
+          sudo apt-get install graphviz texlive-latex-extra dvipng
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -74,26 +79,3 @@ jobs:
           pip install tox
       - name: Run tox
         run: tox -e ${{ matrix.toxenv }}
-
-  # Kept in a separate job because it needs extra system dependencies
-  # that can't be installed by tox.
-  build-docs:
-    name: Build documentation and check warnings
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install system packages
-        run: |
-          sudo apt-get install graphviz texlive-latex-extra dvipng
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install tox
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox
-      - name: Run tox
-        run: tox -e build-docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - '*.x'
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
- Run CI workflow on release branches named `a.b.x`
- Streamline doc build steps in CI workflow
- Do only one of `py38` and `py38 w/coverage`