### PR TITLE
Raise error when asked to cast FITS binary table with pseudo-unsigned column

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -66,7 +66,7 @@ def test_gentle_asarray_fits_rec_input():
     assert_array_equal(result, inp)
 
 
-def test_gentle_asarray_fits_rec_pseudo_unsigned():
+def test_gentle_asarray_fits_rec_pseudo_unsigned(tmp_path):
     """
     Test gentle_asarray handling of a FITS_rec with a pseudo unsigned
     integer column, which is a special case due to a bug in astropy.
@@ -81,6 +81,25 @@ def test_gentle_asarray_fits_rec_pseudo_unsigned():
     # If not handled, the astropy bug would result in a signed
     # int column dtype:
     assert result["col1"].dtype == np.uint32
+    assert result["col1"][0] == 1
+    assert result["col1"][1] == 2
+    assert result["col1"][2] == 3
+    assert result["col1"][3] == 4
+
+    # This tests the case where a table with a pseudo unsigned integer column
+    # is opened from a FITS file and needs to be cast.  Due to a bug in astropy
+    # this isn't safe so we expect an exception.
+    file_path = tmp_path / "test.fits"
+
+    data = np.array([(0,)], dtype=[("col1", np.uint16)])
+    hdu = fits.BinTableHDU()
+    hdu.data = data
+    hdul = fits.HDUList([fits.PrimaryHDU(), hdu])
+    hdul.writeto(file_path)
+
+    with fits.open(file_path) as hdul:
+        with pytest.raises(ValueError, match="Cannot convert FITS_rec dtype"):
+            util.gentle_asarray(hdul[-1].data, dtype=[("col1", np.uint32)])
 
 
 def test_gentle_asarray_nested_array():


### PR DESCRIPTION
This PR changes the datamodels casting to raise an error when asked to cast a FITS binary table with a pseudo-unsigned integer column.  Due to a bug in astropy `np.asanyarray` causes the TZEROn offset to be applied twice, which makes a mess of the unsigned integer data in the column.

The miri flat references in the current context all have this problem and will need to be fixed and re-submitted to prevent this exception from occurring.