### PR TITLE
Add support for deprecated properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.4.0 (unreleased)
+==================
+
+- Add schema feature to forward deprecated model attributes to
+  a new location. [#85]
+
 0.3.0 (2021-09-03)
 ==================
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -62,3 +62,12 @@ class TableModel(DataModel):
     Model that includes a recarray-style table.
     """
     schema_url = "http://example.com/schemas/table_model"
+
+
+class DeprecatedModel(DataModel):
+    """
+    Model with a top-level "old_origin" property that has
+    moved to "meta.origin", and a "meta.old_data" property that has
+    moved to "data".
+    """
+    schema_url = "http://example.com/schemas/deprecated_model"

--- a/tests/schemas/deprecated_model.yaml
+++ b/tests/schemas/deprecated_model.yaml
@@ -1,0 +1,32 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/deprecated_model
+title: Basic model with deprecated properties.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          origin:
+            type: string
+          telescope:
+            type: string
+        deprecated_properties:
+          old_data: ../data
+      data:
+        ndim: 2
+        datatype: float32
+        default: 0.0
+      dq:
+        ndim: 1
+        datatype: uint32
+        default: 0
+      area:
+        ndim: 2
+        datatype: float32
+        default: 0.0
+    deprecated_properties:
+      old_origin: meta/origin
+...

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from stdatamodels import DataModel
 
-from models import BasicModel, AnyOfModel
+from models import BasicModel, AnyOfModel, DeprecatedModel
 
 
 def test_init_from_pathlib(tmp_path):
@@ -291,3 +291,26 @@ def test_on_save_hook(tmp_path):
     assert "foo" not in model.meta._instance
     model.save(tmp_path/"test.asdf")
     assert model.meta.foo == "bar"
+
+
+def test_deprecated_properties():
+    model = DeprecatedModel()
+
+    model.meta.origin = "somewhere"
+
+    with pytest.warns(DeprecationWarning, match="Attribute 'old_origin' has been deprecated"):
+        assert model.old_origin == "somewhere"
+
+    with pytest.warns(DeprecationWarning, match="Attribute 'old_origin' has been deprecated"):
+        model.old_origin = "somewhere else"
+    assert model.meta.origin == "somewhere else"
+
+    data = np.arange(100, dtype=np.float32).reshape(10, 10)
+    model.data = data
+    with pytest.warns(DeprecationWarning, match="Attribute 'old_data' has been deprecated"):
+        assert model.meta.old_data is data
+
+    data = np.arange(80, dtype=np.float32).reshape(8, 10)
+    with pytest.warns(DeprecationWarning, match="Attribute 'old_data' has been deprecated"):
+        model.meta.old_data = data
+    assert model.data is data


### PR DESCRIPTION
This adds a new schema feature, deprecated_properties, that describes a list of properties that when accessed are redirected to a new property with a warning. This is intended to be used for Multi* model deprecations.