### PR TITLE
Support casting of FITS_rec with unsigned integer column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Add schema feature to forward deprecated model attributes to
   a new location. [#86]
 
+- Support casting of FITS_rec tables with unsigned integer columns. [#87]
+
 0.3.0 (2021-09-03)
 ==================
 

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -91,10 +91,13 @@ def gentle_asarray(a, dtype):
 def _safe_asanyarray(a, dtype):
     if isinstance(a, fits.fitsrec.FITS_rec):
         if any(c.bzero is not None for c in a.columns):
-            # Due to an issue in astropy, it's not safe to convert
+            # Due to an issue in astropy, it's not safe to directly cast
             # a FITS_rec with a pseudo-unsigned column.
             # See https://github.com/astropy/astropy/issues/12112
-            raise ValueError("Cannot convert FITS_rec dtype")
+            result = np.zeros(a.shape, dtype=dtype)
+            for old_col, new_col in zip(a.dtype.names, result.dtype.names):
+                result[new_col] = a[old_col]
+            return result
 
     return np.asanyarray(a, dtype=dtype)
 


### PR DESCRIPTION
Previously we raised an exception when asked to cast a FITS_rec with an unsigned integer column, since that hits a bug in astropy that garbles the data in the column by applying the bzero shift twice.  This PR adds special handling for such arrays so that we no longer need to raise the exception.