### PR TITLE
JP-2227: Making changes to properly create HDU from an ndarray.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4.1 (unreleased)
+==================
+
+- Changed the way NDArrayType wrappers are handled on write. [#89]
+
 0.4.0 (2021-11-18)
 ==================
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -156,6 +156,9 @@ def get_hdu(hdulist, hdu_name, index=None):
 
 
 def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
+    if isinstance(value, NDArrayType):
+        value = np.asarray(value)
+
     if hdu_type is None:
         hdu_type = _get_hdu_type(hdu_name, value=value)
         if hdu_type is None:
@@ -164,8 +167,6 @@ def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
     if hdu_type == fits.PrimaryHDU:
         hdu = hdu_type(value)
     else:
-        if isinstance(value, NDArrayType):
-            value = np.asarray(value)
         hdu = hdu_type(value, name=hdu_name)
     if index is not None:
         hdu.ver = index + 1

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -13,6 +13,7 @@ import asdf
 from asdf import fits_embed
 from asdf import resolver
 from asdf import schema as asdf_schema
+from asdf.tags.core import NDArrayType
 from asdf.tags.core import ndarray, HistoryEntry
 from asdf import treeutil
 from asdf.util import HashableDict
@@ -163,6 +164,9 @@ def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
     if hdu_type == fits.PrimaryHDU:
         hdu = hdu_type(value)
     else:
+        # XXX This is where the problem is occurring.
+        if isinstance(value, NDArrayType):
+            value = np.asarray(value)
         hdu = hdu_type(value, name=hdu_name)
     if index is not None:
         hdu.ver = index + 1

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -164,7 +164,6 @@ def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
     if hdu_type == fits.PrimaryHDU:
         hdu = hdu_type(value)
     else:
-        # XXX This is where the problem is occurring.
         if isinstance(value, NDArrayType):
             value = np.asarray(value)
         hdu = hdu_type(value, name=hdu_name)


### PR DESCRIPTION
Resolves JP-2227
Closes issue: https://github.com/spacetelescope/jwst/issues/6271

To support lazy loading in JWST data models a wrapper is used to wrap Numpy `ndarrays` called NDArrayType.  At the lower levels in the class hierarchy this causes problems during write.  When a data model is written an HDU needs to be created for the HDU list to be written out.  This can only be done properly if the `ndarray.dtype` is known.

For lazy loading this may not be known because the needed information is not in the NDArrayType wrapper, so an extra step must be taken to check if the type is NDArrayType, then ensure the `ndarray` gets loaded.  When this is done all the needed information for type checking on write is there and the round trip will succeed.