### PR TITLE
Portion of fix for asdf-transform-schemas develop.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Changed the way NDArrayType wrappers are handled on write. [#89]
+- Bugfix for JWST failing with latest asdf-transform-schemas. [#90]
 
 0.4.0 (2021-11-18)
 ==================

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -191,7 +191,8 @@ def merge_property_trees(schema):
         type = schema.get('type')
         schema = OrderedDict(schema)
         if type == 'object':
-            del schema['properties']
+            if 'properties' in schema:
+                del schema['properties']
         elif type == 'array':
             del schema['items']
         if 'allOf' in schema:


### PR DESCRIPTION
Currently, jwst is failing due to issues with the additions to `transform-1.2.0` in asdf-transform-schemas development. This is due to issues with the `schemas` module in this package.

The PR spacetelescope/jwst#6752 fixes the majority of the this problem by altering how `transform-1.2.0` is used in some of the jwst datamodels; however, this does not completely fix the problem because the schema module still attempts to remove items from the tree which don't exist. This PR fixes that remaining issues. 