### PR TITLE
Create PR for potential fix to issue #95

### DIFF
--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -139,7 +139,7 @@ def walk_schema(schema, callback, ctx=None):
         if schema.get('type') == 'array':
             items = schema.get('items', {})
             if isinstance(items, list):
-                for i, item in enumerate(items):
+                for item in items:
                     recurse(item, path + ['items'], combiner, ctx)
             elif len(items):
                 recurse(items, path + ['items'], combiner, ctx)


### PR DESCRIPTION
This edits the path extension to allow certain jwst datamodels (e.g. [wavelengthrange](https://github.com/spacetelescope/jwst/blob/master/jwst/datamodels/schemas/wavelengthrange.schema.yaml)) to be traversed using existing methods.