### PR TITLE
fix crds context in workflow to follow operational context of server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip freeze
       - run: pytest -n auto
-  test_jwst:
-    name: jwst.datamodels tests
+  test_jwst_datamodels:
+    name: test latest version of `jwst.datamodels` with this commit
     needs: [ style, audit ]
     runs-on: ubuntu-latest
     env:
@@ -83,17 +83,18 @@ jobs:
           key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
-      - run: export CRDS_VERSION=$(crds list --contexts jwst_0865.pmap --version)
+      - run: echo "::set-output name=crds_version::$(crds list --version)"
+        id: crds_version
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-jwst-datamodels-${{ env.CRDS_VERSION }}
-      - run: crds sync --contexts jwst_0865.pmap
+          key: crds-jwst-datamodels-${{ steps.crds_version.outputs.crds_version }}
+      - run: crds sync --contexts jwst_0881.pmap jwst_0865.pmap
       - run: pip freeze
       - run: pytest -n auto --pyargs jwst.datamodels
   test_with_coverage:
     name: Coverage
-    needs: [ test, test_jwst ]
+    needs: [ test, test_jwst_datamodels ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -114,7 +115,7 @@ jobs:
           file: ./coverage.xml
   build-docs:
     name: Build documentation
-    needs: [ test, test_jwst ]
+    needs: [ test, test_jwst_datamodels ]
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install graphviz texlive-latex-extra dvipng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - run: pytest -n auto --pyargs jwst.datamodels
   test_with_coverage:
     name: Coverage
-    needs: [ test, test_jwst_datamodels ]
+    needs: [ test ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
           file: ./coverage.xml
   build-docs:
     name: Build documentation
-    needs: [ test, test_jwst_datamodels ]
+    needs: [ test ]
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install graphviz texlive-latex-extra dvipng

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,13 @@ jobs:
           key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
-      - run: echo "::set-output name=crds_version::$(crds list --version)"
-        id: crds_version
+      - run: echo "::set-output name=crds_context::$(crds list --operational-context)"
+        id: crds_context
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-jwst-datamodels-${{ steps.crds_version.outputs.crds_version }}
-      - run: crds sync --contexts jwst_0881.pmap jwst_0865.pmap
+          key: crds-jwst-datamodels-${{ steps.crds_context.outputs.crds_context }}
+      - run: crds sync --contexts ${{ steps.crds_context.outputs.crds_context }}
       - run: pip freeze
       - run: pytest -n auto --pyargs jwst.datamodels
   test_with_coverage:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Currently, [the GitHub Actions workflow job testing `jwst.datamodels`](https://github.com/spacetelescope/stdatamodels/runs/7069458676?check_suite_focus=true) fails because the requested and sync'ed CRDS context is different from the operational context on the server. This change ensures that the correct context is sync'ed on every workflow run, and caches and re-uses the current context until it changes.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
