### PR TITLE
Add ABC for ModelContainer inheritance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changes to API
 Other
 -----
 
+- Add abstract base class for datamodel container inheritance [#102]
+
 0.4.3 (2022-06-03)
 ==================
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -8,6 +8,7 @@ import os
 from pathlib import PurePath
 import sys
 import warnings
+import abc
 
 import numpy as np
 
@@ -1125,3 +1126,11 @@ class _FileReference:
         if self._count <= 0:
             self._file.close()
             self._file = None
+
+
+class ModelList(abc.ABC):
+    """Abstract base class to use as a
+    marker to differentiate behavior for
+    datamodels versus datamodel containers.
+    """
+    pass


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds an abstract base class that will exist only as a marker, to check against and alter pipeline behavior for datamodel container input versus datamodel input. Currently, stpipe checks instances against `Sequence`, which has some pitfalls.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
