### PR TITLE
remove use of deprecated override__dir__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Bug Fixes
 ---------
 
 - Increase asdf version to >=2.14.1 to fix hdu data duplication [#105]
+- Remove use of deprecated override__dir__ [#103]
 
 Changes to API
 --------------

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -6,8 +6,6 @@ import numpy as np
 from collections.abc import Mapping
 from astropy.io import fits
 
-from astropy.utils.compat.misc import override__dir__
-
 from asdf.tags.core import ndarray
 
 from . import util
@@ -267,9 +265,9 @@ class Node():
         return self._instance
 
 class ObjectNode(Node):
-    @override__dir__
     def __dir__(self):
-        return list(self._schema.get('properties', {}).keys())
+        added = set(self._schema.get('properties', {}).keys())
+        return sorted(set(super().__dir__()) | added)
 
     def __eq__(self, other):
         if isinstance(other, ObjectNode):


### PR DESCRIPTION
astropy 5.2 will deprecate override__dir__
The deprecation notes suggest an alternative (used here) which should work for all versions of python >=3.3

Deprecation: https://github.com/astropy/astropy/blob/0944607116f373e64e94ce3e5535c49509897c87/astropy/utils/compat/misc.py#L19
Root python issue: https://bugs.python.org/issue12166
Fixed in 3.3: https://docs.python.org/3.3/whatsnew/changelog.html

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
