### PR TITLE
Bugfix for `test_history` times.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Bug Fixes
 
 - Increase asdf version to >=2.14.1 to fix hdu data duplication [#105]
 - Remove use of deprecated override__dir__ [#103]
+- Add requirement of asdf-astropy >= 0.3.0 to prevent future issues with using deprecated
+  astropy serialization methods [#104]
 
 Changes to API
 --------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     # The tests require code that is in asdf master
     # but not yet released.
     asdf>=2.14.1
+    asdf-astropy>=0.3.0
     psutil>=5.7.2
     numpy>=1.16
     astropy>=5.0.4

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -49,10 +49,10 @@ def test_history_from_model_to_fits(tmpdir):
     m = DataModel()
     m.history = [HistoryEntry({
         'description': 'First entry',
-        'time': Time(datetime.datetime.now())})]
+        'time': Time(datetime.datetime.now().isoformat())})]
     m.history.append(HistoryEntry({
         'description': 'Second entry',
-        'time': Time(datetime.datetime.now())
+        'time': Time(datetime.datetime.now().isoformat())
     }))
     m.save(tmpfits)
 


### PR DESCRIPTION
test_history fails if asdf-astropy is installed.

The root cause is that asdf-astropy serializes astropy.time.Time objects in a way that is incompatible with the schema for history entries in some cases (the way that it is currently being handled). If asdf-astropy is not installed, astropy.time.Time serialization will fall back to a legacy extension in astropy.io.misc.asdf which was allowing the test to pass.

In asdf-astropy 0.3.0+ the time serialization was adjusted to be history compatible but only for a limited subset of astropy.time.Time formats. This PR adjust the astropy.time.Time object so that it explicitly uses one of those formats. Moreover, it adds asdf-astropy as an explicit dependency so that stdatamodels does not accidentally fall back on the legacy astropy.io.misc.asdf serialization which is important because that support will be removed with astropy 6 in October 2023 (note the main downstream user of stdatamodels, jwst, explicitly requires asdf-astropy meaning stdatamodels really should be requiring its use too).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
