### PR TITLE
Add test for asdf data duplication issue with fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Bug Fixes
 ---------
 
--
+- Increase asdf version to >=2.14.1 to fix hdu data duplication [#105]
 
 Changes to API
 --------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,8 @@ setup_requires =
 install_requires =
     jsonschema>=3.0.2
     # The tests require code that is in asdf master
-    # but not yet released.  The package itself
-    # is compatible with asdf 2.7.
-    asdf>=2.7.1
+    # but not yet released.
+    asdf>=2.14.1
     psutil>=5.7.2
     numpy>=1.16
     astropy>=5.0.4

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -619,3 +619,24 @@ def test_ndarray_validation(tmp_path):
     with pytest.raises(ValidationError, match="Wrong number of dimensions: Expected 2, got 1"):
         with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
             model.validate()
+
+
+@pytest.mark.skip(reason='fix required for asdf')
+def test_resave_duplication_bug(tmp_path):
+    """
+    An issue in asdf (https://github.com/asdf-format/asdf/issues/1232)
+    resulted in duplication of data when a model was read from and then
+    written to a fits file.
+    """
+    fn1 = tmp_path / "test1.fits"
+    fn2 = tmp_path / "test2.fits"
+
+    arr = np.zeros((1000, 100), dtype='f4')
+    m = FitsModel(arr)
+    m.save(fn1)
+
+    m2 = FitsModel.from_fits(fn1)
+    m2.save(fn2)
+
+    with fits.open(fn1) as ff1, fits.open(fn2) as ff2:
+        assert ff1['ASDF'].size == ff2['ASDF'].size

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -621,7 +621,6 @@ def test_ndarray_validation(tmp_path):
             model.validate()
 
 
-@pytest.mark.skip(reason='fix required for asdf')
 def test_resave_duplication_bug(tmp_path):
     """
     An issue in asdf (https://github.com/asdf-format/asdf/issues/1232)


### PR DESCRIPTION
See asdf issue https://github.com/asdf-format/asdf/issues/1232

To summarize the issue, resaving an asdf in fits file breaks the link between hdu
items and arrays within the asdf tree. This results in inclusion of array data as
internal blocks in the asdf tree and a (sometimes substantial) increase in the size
of the tree. The test added here checks that the asdf tree stored in the 'ASDF' hdu
does not change size on a resave.

This test is currently skipped as it will fail with the current asdf version.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
