### PR TITLE
Remove deprecated @override__dir__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Bug Fixes
 
 - Increase asdf version to >=2.14.1 to fix hdu data duplication [#105]
 
+- Remove deprecated @override__dir__ [#106]
+
 Changes to API
 --------------
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -1,20 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import copy
-import warnings
-import numpy as np
 from collections.abc import Mapping
+import copy
+import logging
+import warnings
+
 from astropy.io import fits
-
-from astropy.utils.compat.misc import override__dir__
-
 from asdf.tags.core import ndarray
+import numpy as np
 
 from . import util
 from . import validate
 from . import schema as mschema
 
-import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -267,9 +265,9 @@ class Node():
         return self._instance
 
 class ObjectNode(Node):
-    @override__dir__
     def __dir__(self):
-        return list(self._schema.get('properties', {}).keys())
+        added = set(self._schema.get('properties', {}).keys())
+        return sorted(set(super().__dir__()) | added)
 
     def __eq__(self, other):
         if isinstance(other, ObjectNode):


### PR DESCRIPTION
This PR fixes a deprecation warning now being emitted by `astropy`.

```python
stdatamodels/properties.py:270: AstropyDeprecationWarning: http://bugs.python.org/issue12166 is resolved. See docstring for alternatives.
  @override__dir__
```

This is no longer needed for a very long time now in Python, i.e.:

https://github.com/astropy/astropy/blob/d31499bb3d4d4cf02981c9b7fdd35bc37c62ad54/astropy/utils/compat/misc.py#L46-L54

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
