### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,11 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ steps.cache-date.outputs.today }}
-      - run: pytest -n auto --pyargs jwst.datamodels
+      - run: pytest -n auto --pyargs jwst.datamodels --cov-report=xml --cov=src/stdatamodels
+      - run: coverage report -m
+      - uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.xml
   test_with_coverage:
     name: Coverage
     needs: [ style, audit ]
@@ -124,4 +128,3 @@ jobs:
           cache-dependency-path: setup.cfg
       - run: pip install -e ".[docs]"
       - run: sphinx-build -W docs/source build/docs
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,20 @@ jobs:
     name: Code style checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          python-version: '3.10'
       - run: pip install pyproject-flake8
       - run: pflake8 --count src
   audit:
     name: Bandit security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: audit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          python-version: '3.10'
       - run: pip install bandit
       - run: bandit -r -ll src
   test:
@@ -52,14 +44,14 @@ jobs:
         python: [ 3.8, 3.9, '3.10' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip freeze
       - run: pytest -n auto
@@ -73,38 +65,41 @@ jobs:
       CRDS_CLIENT_RETRY_COUNT: 3
       CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
         with:
-          python-version: 3.8
-      - uses: actions/cache@v3
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install -e ".[test]" pytest-xdist
       - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
-      - run: echo "::set-output name=crds_context::$(crds list --operational-context)"
+      - run: pip freeze
+      - run: echo "crds_context=$(crds list --operational-context)" >> $GITHUB_OUTPUT
         id: crds_context
+      - run: crds sync --contexts ${{ steps.crds_context.outputs.crds_context }}
+      # Have actions/cache update monthly
+      - run: echo "today=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+        id: cache-date
       - uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-jwst-datamodels-${{ steps.crds_context.outputs.crds_context }}
-      - run: crds sync --contexts ${{ steps.crds_context.outputs.crds_context }}
-      - run: pip freeze
+          key: crds-${{ steps.cache-date.outputs.today }}
       - run: pytest -n auto --pyargs jwst.datamodels
   test_with_coverage:
     name: Coverage
-    needs: [ test ]
+    needs: [ style, audit ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
         with:
-          python-version: 3.8
-      - uses: actions/cache@v3
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install -e ".[test]" pytest-xdist pytest-cov
       - run: pip install "asdf @ git+https://github.com/asdf-format/asdf.git"
       - run: pip freeze
@@ -115,18 +110,18 @@ jobs:
           file: ./coverage.xml
   build-docs:
     name: Build documentation
-    needs: [ test ]
+    needs: [ style, audit ]
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install graphviz texlive-latex-extra dvipng
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
         with:
-          python-version: 3.8
-      - uses: actions/cache@v3
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: build-docs-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install -e ".[docs]"
       - run: sphinx-build -W docs/source build/docs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install pyproject-flake8
       - run: pflake8 --count src
   audit:
@@ -32,6 +34,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - run: pip install bandit
       - run: bandit -r -ll src
   test:


### PR DESCRIPTION
This PR fixes the currently broken CI.

The main issue was outdated versions of the github `action/setup-python`.  `action/checkout` was also updated, which allowed the use of the pip wheel caching as well, removing the need to use a separate `action/cache` call to do so.

Other updates:

- after style and security checks, run all the other jobs in parallel.
- report coverage from running `jwst.datamodels` tests.  Coverage increases here by a few percent.  All good!
- change cache restore key for CRDS_CACHE for the `jwst.datamodels` job so that the cache is renewed monthly, given the episodic dev cycle for this package.