### PR TITLE
refactor CI and use `tox.ini` with Tox 4 and PEP517 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,121 +14,58 @@ on:
     - cron: '0 9 * * 1'
 
 jobs:
-  style:
-    name: Code style checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: setup.cfg
-      - run: pip install pyproject-flake8
-      - run: pflake8 --count src
-  audit:
-    name: Bandit security audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: setup.cfg
-      - run: pip install bandit
-      - run: bandit -r -ll src
-  test:
-    name: test
-    needs: [ style, audit ]
+  check:
+    name: ${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: [ 3.8, 3.9, '3.10' ]
+        toxenv: [ check-style, check-security, check-build ]
+        python-version: [ '3.11' ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
+      - run: pip install "tox>=4.0"
+      - run: tox -e ${{ matrix.toxenv }}
+  test:
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-xdist ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
+        include:
+          - toxenv: test-xdist-cov
+            os: ubuntu-latest
+            python-version: '3.11'
+          - toxenv: test-jwst-xdist-cov
+            os: ubuntu-latest
+            python-version: '3.11'
     steps:
+      - if: ${{ contains(matrix.toxenv,'docs') }}
+        run: sudo apt-get install graphviz texlive-latex-extra dvipng
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: setup.cfg
-      - run: pip install -e ".[test]" pytest-xdist
-      - run: pip freeze
-      - run: pytest -n auto
-  test_jwst_datamodels:
-    name: test latest version of `jwst.datamodels` with this commit
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    env:
-      CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-      CRDS_PATH: /home/runner/work/stdatamodels/crds_cache
-      CRDS_CLIENT_RETRY_COUNT: 3
-      CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: setup.cfg
-      - run: pip install -e ".[test]" pytest-xdist
-      - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
-      - run: pip freeze
-      - run: echo "crds_context=$(crds list --operational-context)" >> $GITHUB_OUTPUT
-        id: crds_context
-      - run: crds sync --contexts ${{ steps.crds_context.outputs.crds_context }}
-      # Have actions/cache update monthly
-      - run: echo "today=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-        id: cache-date
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: crds-${{ steps.cache-date.outputs.today }}
-      - run: pytest -n auto --pyargs jwst.datamodels --cov-report=xml --cov=src/stdatamodels
-      - run: coverage report -m
-      - uses: codecov/codecov-action@v2
+      - run: pip install "tox>=4.0"
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-  test_with_coverage:
-    name: Coverage
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: setup.cfg
-      - run: pip install -e ".[test]" pytest-xdist pytest-cov
-      - run: pip install "asdf @ git+https://github.com/asdf-format/asdf.git"
-      - run: pip freeze
-      - run: pytest -n auto --cov-report=xml --cov=src/stdatamodels
-      - run: coverage report -m
-      - uses: codecov/codecov-action@v2
-        with:
-          file: ./coverage.xml
-  build-docs:
-    name: Build documentation
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    steps:
-      - run: sudo apt-get install graphviz texlive-latex-extra dvipng
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: setup.cfg
-      - run: pip install -e ".[docs]"
-      - run: sphinx-build -W docs/source build/docs
+          flags: unit
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
   test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      CRDS_PATH: /home/runner/work/stdatamodels/crds_cache
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Changes to API
 Other
 -----
 
+- added environments in ``tox.ini`` to support Tox 4 [#108]
+
 0.4.4 (2022-12-27)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,3 +68,8 @@ addopts = --open-files
 testpaths =
     tests
     src
+norecursedirs =
+    build
+    .tox
+    .eggs
+    venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = stdatamodels
 description = Core support for DataModel classes used in calibration pipelines
 long_description = Core support for DataModel classes used in calibration pipelines
+long_description_content_type = text/x-markdown
 author = STScI
 license = BSD-3-Clause
 url = https://github.com/spacetelescope/stdatamodels

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ text_file_format = rst
 addopts = --open-files
 testpaths =
     tests
-    src
 norecursedirs =
     build
     .tox

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,12 @@ description =
     run tests
     xdist: using parallel processing
     cov: with coverage
+pass_env =
+    jwst: CRDS_*
+set_env =
+    jwst: CRDS_CLIENT_RETRY_COUNT=3
+    jwst: CRDS_CLIENT_RETRY_DELAY_SECONDS=20
+    jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 extras =
     test
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,74 @@
+[tox]
+envlist =
+    check-{style,security,build}
+    test{,-jwst}-xdist{,-cov}
+    build-{docs,dist}
+
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+
+[testenv:check-style]
+description = check code style, e.g. with flake8
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 --count src tests {posargs}
+
+[testenv:check-security]
+description = run bandit to check security compliance
+skip_install = true
+deps =
+    bandit>=1.7
+commands =
+    bandit -r -ll src
+
+[testenv:check-build]
+description = check build sdist/wheel and a strict twine check for metadata
+skip_install = true
+deps =
+    twine>=3.3
+    build
+commands =
+    python -m build .
+    twine check --strict dist/*
+
+[testenv]
+description =
+    run tests
+    xdist: using parallel processing
+    cov: with coverage
+extras =
+    test
+deps =
+    xdist: pytest-xdist
+    cov: pytest-cov
+    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst
+commands_pre =
+    pip freeze
+commands =
+    pytest \
+    xdist: -n auto \
+    cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
+    jwst: --pyargs jwst.datamodels \
+    {posargs}
+
+[testenv:build-docs]
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+commands =
+    sphinx-build -W docs docs/_build
+
+[testenv:build-dist]
+description = build wheel and sdist
+skip_install = true
+deps =
+    build
+commands =
+    python -m build .


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
In an attempt to standardize CI across repos and make it less confusing, this PR reintroduces `tox` and uses the `toxenv` naming scheme from the Romancal repo.

<img width="218" alt="image" src="https://user-images.githubusercontent.com/16024299/211902307-2e75c82b-c1b9-444a-9211-a4e84ee93fcd.png">

Additionally, `toxenvs` in the `check` matrix run concurrently with other tests.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
