### PR TITLE
Resolves JP-2798 improves memory usage of datamodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Bug Fixes
 ---------
 
+- improve datamodels memory usage [#109]
+
 Changes to API
 --------------
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -176,7 +176,6 @@ class DataModel(properties.ObjectNode):
         self._schema = mschema.merge_property_trees(schema)
 
         # Provide the object as context to other classes and functions
-        self._ctx = self
         self._parent = None
 
         # Initialize with an empty AsdfFile instance as this is needed for
@@ -300,6 +299,15 @@ class DataModel(properties.ObjectNode):
 
         # Call hook that sets model properties
         self.on_init(init)
+
+    @property
+    def _ctx(self):
+        # self._ctx is a property to avoid reference cycle that would be
+        # created if we set self._ctx = self
+        # a reference cycle would make DataModel difficult to garbage
+        # collect and could reopen the memory leak issues fixed in
+        # https://github.com/spacetelescope/stdatamodels/pull/109
+        return self
 
     @property
     def crds_observatory(self):


### PR DESCRIPTION
Remove the self-reference (`self._ctx = self`) and other difficult to garbage collect patterns to help python clean up when a process allocates and saves several models.

DataModel contains a self reference that makes it difficult to collect. ~~This PR clears that reference on __del__.~~ This PR changes _ctx to a property.

The use of `validate` to generate the hdulist suffers from leakage as validators are cached resulting in references to the hdulist remaining after a model deleted. This PR changes the hdulist ref to a weakref in FitsContext to work around the caching.

walk_schema defines a recursive function (recurse) that can capture references to data when called from _load_from_schema. This PR adds an explicit del of the recurse function to help it clean up after use.

~~These are only partial fixes as creating a DataModel instance appears to immediately put the instance in generation 2 for garbage collection (so python will very lazily clean these up).~~ EDIT: converting _ctx to a property allowed DataModel to stay in generation 0.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
