### PR TITLE
ci: remove restriction of jwst tests to datamodels

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ commands =
     pytest \
     xdist: -n auto \
     cov: --cov=. --cov-config=setup.cfg --cov-report=term-missing --cov-report=xml \
-    jwst: --pyargs jwst.datamodels \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
There are uses of stdatamodels in jwst outside of jwst.datamodels https://github.com/spacetelescope/jwst/search?q=stdatamodels+-path%3Ajwst%2Fdatamodels that should be included in ci tests

this PR includes all jwst tests include these and hopefully future uses of stdatamodels in jwst

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
