### PR TITLE
fixes to run tests outside of CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,16 @@
 [![codecov](https://codecov.io/gh/spacetelescope/stdatamodels/branch/master/graph/badge.svg?token=TrmUKaTP2t)](https://codecov.io/gh/spacetelescope/stdatamodels)
 
 
-Provides `DataModel`, which is the base class for data models implemented in the JWST and Roman calibration software.
+Provides `DataModel`, which is the base class for data models implemented in the JWST calibration software.
+
+
+## Unit Tests
+
+A few unit tests require downloading (~500MB) data from CRDS. CRDS must be configured for these tests to pass
+(see the [CRDS User Guide](https://jwst-crds.stsci.edu/static/users_guide/index.html)
+for more information). Minimally (if not on the stsci vpn where the default path of
+`/grp/crds/cache` is available) you will need to set `CRDS_PATH`.
+
+```bash
+export CRDS_PATH=/tmp/crds_cache/jwst_ops
+```

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -6,6 +6,15 @@ import pytest
 import warnings
 from ..util import NoTypeWarning
 
+os.environ["CRDS_SERVER_URL"] = "https://jwst-crds.stsci.edu"
+
+# the CRDS_SERVER_URL environment variable must be set before
+# crds is imported
+import crds  # noqa: E402
+from crds.client.api import cache_references, dump_files  # noqa: E402
+from crds.core.exceptions import IrrelevantReferenceTypeError  # noqa: E402
+
+
 log = logging.getLogger(__name__)
 
 
@@ -164,16 +173,11 @@ ref_to_datamodel_dict = {
 
 @pytest.mark.parametrize('instrument', ['fgs', 'miri', 'nircam', 'niriss', 'nirspec'])
 def test_crds_selectors_vs_datamodel(jail_environ, instrument):
-
-    os.environ["CRDS_SERVER_URL"] = 'https://jwst-crds.stsci.edu'
-
-    log.info(f"CRDS_PATH: {os.environ['CRDS_PATH']}")
-
-    import crds
-    from crds.client.api import cache_references
-    from crds.core.exceptions import IrrelevantReferenceTypeError
+    log.info(f"crds_path: {crds.config.get_crds_path()}")
+    log.info(f"crds_server: {crds.config.get_server_url('jwst')}")
 
     context = crds.get_context_name('jwst')
+    dump_files(context)
     pmap = crds.get_cached_mapping(context)
 
     imap = pmap.get_imap(instrument)


### PR DESCRIPTION
~~#112 introduced a few tests to access CRDS. These expect a CRDS_PATH environment variable and can take considerable time to download data.~~

~~This PR modifies the log line accessing CRDS_PATH (to fall back to a value of None if CRDS_PATH is not defined) and adds a pytest mark (off by default) that controls running of the crds tests. The tox tests are modified to enable this new crds mark.~~

~~Edited: This PR adds a no_crds pytest option to disable tests that require downloading 500MB of files and~~ addresses a few failures related to local testing that resulted in test failures when:
- not run on the vpn (or on the vpn but without a defined CRDS_PATH environment variable)
- not run on a machine with a pre-existing cached CRDS context

~~A description of the mark is added to the readme.~~

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
