### PR TITLE
fix sphinx link for asdf in fits documentation

### DIFF
--- a/docs/source/asdf_in_fits.rst
+++ b/docs/source/asdf_in_fits.rst
@@ -1,4 +1,4 @@
-.. _asdf_in_fits
+.. _asdf_in_fits:
 
 ==========
 AsdfInFits


### PR DESCRIPTION
The missing colon made it not appear as a std:label and made creating a sphinx link difficult in https://github.com/asdf-format/asdf/pull/1337

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
