### PR TITLE
JP-2113: Update NIRCam WFSS transforms for field dependence (v6)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Other
 -----
 
--
+- Provide second-order polynomial transforms for NIRCam WFSS grisms. [#124]
 
 1.4.0 (2023-04-19)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
@@ -15,37 +15,49 @@ allOf:
           Nircam Grism wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     dispx:
         description: |
           Nircam Grism row dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     dispy:
         description: |
           Nircam Grism column dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     invdispl:
         description: |
           Nircam Grism inverse wavelength dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     invdispx:
         description: |
           Nircam Grism inverse row dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     invdispy:
         description: |
           Nircam Grism inverse column dispersion model, instance of astropy.modeling.Model
         type: array
         items:
-          type: object
+          type: array
+          items:
+            type: object
     orders:
         description: |
           NIRCAM Grism orders, matched to the array locations of the dispersion models

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -20,7 +20,7 @@ class NIRCAMGrismDispersionConverter(TransformConverterBase):
     def from_yaml_tree_transform(self, node, tag, ctx):
         from stdatamodels.jwst.transforms import models
 
-        _fname = getattr(models, node["class_name"])
+        _fname = getattr(models, node["model_type"])
         return _fname(list(node['orders']),
                       list(node['lmodels']),
                       list(node['xmodels']),
@@ -28,11 +28,14 @@ class NIRCAMGrismDispersionConverter(TransformConverterBase):
                       )
 
     def to_yaml_tree_transform(self, model, tag, ctx):
+        xll = [list(m) for m in model.xmodels]
+        yll = [list(m) for m in model.ymodels]
+        lll = [list(m) for m in model.lmodels]
         node = {'orders': list(model.orders),
-                'lmodels': list(model.lmodels),
-                'xmodels': list(model.xmodels),
-                'ymodels': list(model.ymodels),
-                'class_name': type(model).name
+                'xmodels': xll,
+                'ymodels': yll,
+                'lmodels': lll,
+                'model_type': type(model).name
                 }
         return node
 

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -25,16 +25,25 @@ class NIRCAMGrismDispersionConverter(TransformConverterBase):
                       list(node['lmodels']),
                       list(node['xmodels']),
                       list(node['ymodels']),
+                      list(node['inv_lmodels']),
+                      list(node['inv_xmodels']),
+                      list(node['inv_ymodels']),
                       )
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         xll = [list(m) for m in model.xmodels]
         yll = [list(m) for m in model.ymodels]
         lll = [list(m) for m in model.lmodels]
+        inv_xll = [list(m) for m in model.inv_xmodels]
+        inv_yll = [list(m) for m in model.inv_ymodels]
+        inv_lll = [list(m) for m in model.inv_lmodels]
         node = {'orders': list(model.orders),
                 'xmodels': xll,
                 'ymodels': yll,
                 'lmodels': lll,
+                'inv_xmodels': inv_xll,
+                'inv_ymodels': inv_yll,
+                'inv_lmodels': inv_lll,
                 'model_type': type(model).name
                 }
         return node

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -664,9 +664,12 @@ class NIRCAMForwardRowGrismDispersion(Model):
         def apply_poly(coeff_model, inputs, t):
             # Determine order of polynomial in t
             ord_t = len(coeff_model)
-            sumval = 0.
-            for i in range(ord_t):
-                sumval += t ** i * coeff_model[i](*inputs[:coeff_model[i].n_inputs])
+            if ord_t == 1:
+                sumval = coeff_model[0](t)
+            else:
+                sumval = 0.
+                for i in range(ord_t):
+                    sumval += t ** i * coeff_model[i](*inputs[:coeff_model[i].n_inputs])
             return sumval
 
         l_poly = apply_poly(lmodel, (x0, y0), t)
@@ -780,9 +783,12 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         def apply_poly(coeff_model, inputs, t):
             # Determine order of polynomial in t
             ord_t = len(coeff_model)
-            sumval = 0.
-            for i in range(ord_t):
-                sumval += t ** i * coeff_model[i](*inputs[2-coeff_model[i].n_inputs:])
+            if ord_t == 1:
+                sumval = coeff_model[0](t)
+            else:
+                sumval = 0.
+                for i in range(ord_t):
+                    sumval += t ** i * coeff_model[i](*inputs[2-coeff_model[i].n_inputs:])
             return sumval
 
         try:
@@ -950,10 +956,10 @@ class NIRCAMBackwardGrismDispersion(Model):
             xr = (np.ones_like(t_re) * model[0](x0, y0)) + (t_re * model[1](x0, y0)) + \
                  (t_re ** 2 * model[2](x0, y0))
         elif len(model.instance[0].inputs) == 1:
-            xr = model[0](t_re)
+            xr = model[0](t0)
             f = np.zeros_like(wavelength)
             for i, w in enumerate(wavelength):
-                f[i] = np.interp(w, xr[:,0], t0)
+                f[i] = np.interp(w, xr, t0)
             return f
         else:
             raise Exception

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -814,8 +814,8 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         elif len(model[order]) == 3:
             xr = model[order][0](x0, y0) + t0 * model[order][1](x0, y0) + \
                  t0 ** 2 * model[order][2](x0, y0)
-        elif len(model[order].instance[0].inputs) == 1:
-            xr = (dy - model[order].instance[0].c0.value) / model[order].instance[0].c1.value
+        elif len(model[order][0].inputs) == 1:
+            xr = (dy - model[order][0].c0.value) / model[order][0].c1.value
             return xr
         else:
             raise Exception
@@ -914,8 +914,8 @@ class NIRCAMBackwardGrismDispersion(Model):
             t = self.invdisp_interp(self.inv_lmodels[iorder], x, y, wavelength)
         else:
             t = self.lmodels[iorder](wavelength)
-        xmodel = self.inv_xmodels[iorder].instance
-        ymodel = self.inv_ymodels[iorder].instance
+        xmodel = self.inv_xmodels[iorder]
+        ymodel = self.inv_ymodels[iorder]
 
         if len(xmodel[0].inputs) == 2:
             dx = xmodel[0](x, y) + t * xmodel[1](x, y) + t**2 * xmodel[2](x, y)

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -243,7 +243,7 @@ class Gwa2Slit(Model):
     ----------
     slits : list
         A list of open slits.
-        A slit is a namedtuple of type `~jwst.transforms.models.Slit`
+        A slit is a namedtuple of type `~stdatamodels.jwst.transforms.models.Slit`
         Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
         "quadrant", "source_id", "shutter_state", "source_name",
         "source_alias", "stellarity", "source_xpos", "source_ypos",
@@ -296,7 +296,7 @@ class Slit2Msa(Model):
     ----------
     slits : list
         A list of open slits.
-        A slit is a namedtuple, `~jwst.transforms.models.Slit`
+        A slit is a namedtuple, `~stdatamodels.jwst.transforms.models.Slit`
         Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
         "quadrant", "source_id", "shutter_state", "source_name",
         "source_alias", "stellarity", "source_xpos", "source_ypos",
@@ -562,7 +562,7 @@ def _toindex(value):
 
     Examples
     --------
-    >>> from jwst.transforms.models import _toindex
+    >>> from stdatamodels.jwst.transforms.models import _toindex
     >>> _toindex(np.array([-0.5, 0.49999]))
     array([0, 0])
     >>> _toindex(np.array([0.5, 1.49999]))

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -916,13 +916,13 @@ class NIRCAMBackwardGrismDispersion(Model):
         else:
             raise ValueError("xmodel has incorrect number of inputs required.")
 
-        if len(ymodel[0].inputs) ==2:
-            dy = ymodel[0](x, y) + t * ymodel[1](x, y) + t ** 2 * ymodel[2](x, y)
+        if len(ymodel[0].inputs) == 2:
+            dy = ymodel[0](x, y) + t * ymodel[1](x, y) + t**2 * ymodel[2](x, y)
         elif len(ymodel[0].inputs) == 1:
             if len(ymodel) == 1:
-                dy = ymodel[0](x)
+                dy = ymodel[0](y)
             elif len(ymodel) == 2:
-                dy = ymodel[0](x) + t * ymodel[1](x)
+                dy = ymodel[0](y) + t * ymodel[1](y)
         else:
             raise ValueError("ymodel has incorrect number of inputs required.")
 

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.0.0.yaml
@@ -17,19 +17,28 @@ allOf:
          NIRCAM row dispersion models
         type: array
         items:
-          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       ymodels:
         description: |
           NIRCAM column dispersion models
         type: array
         items:
-          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       lmodels:
         description: |
           NIRCAM wavelength dispersion models
         type: array
         items:
-          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       orders:
         description: |
           NIRCAM available grism orders, in-sync with the model arrays

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.0.0.yaml
@@ -39,6 +39,33 @@ allOf:
           items:
             type: object
             $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+      inv_xmodels:
+        description: |
+         NIRCAM inverse row dispersion models
+        type: array
+        items:
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+      inv_ymodels:
+        description: |
+          NIRCAM inverse column dispersion models
+        type: array
+        items:
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+      inv_lmodels:
+        description: |
+          NIRCAM inverse wavelength dispersion models
+        type: array
+        items:
+          type: array
+          items:
+            type: object
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
       orders:
         description: |
           NIRCAM available grism orders, in-sync with the model arrays
@@ -52,4 +79,4 @@ allOf:
         items:
           minItems: 1
           maxItems: 1
-    required: [lmodels, xmodels, ymodels, orders]
+    required: [lmodels, xmodels, ymodels, inv_lmodels, inv_xmodels, inv_ymodels, orders]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2113](https://jira.stsci.edu/browse/JP-2113)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR provides higher-order polynomial transform models for the NIRCam WFSS grisms. It has a coupled PR in jwst (https://github.com/spacetelescope/jwst/pull/7018).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
