### PR TITLE
Prevent deprecation issue from importing from tests

### DIFF
--- a/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
@@ -4,8 +4,13 @@ import numpy as np
 import os
 import warnings
 from astropy.modeling.models import Shift, Rotation2D, Const1D
-from asdf_astropy.converters.transform.tests.test_transform import (
-    assert_model_roundtrip)
+
+from astropy.utils import minversion
+
+if minversion("asdf_astropy", "0.3.0", False):
+    from asdf_astropy.testing.helpers import assert_model_roundtrip
+else:
+    from asdf_astropy.converters.transform.tests.test_transform import assert_model_roundtrip
 
 from stdatamodels.jwst.transforms.models import (
     NirissSOSSModel, Rotation3DToGWA, Gwa2Slit, Logical, Slit,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Importing from another package's tests is strictly frowned upon as the tests are considered part of the private interface of the package. `asdf-astropy` is moving some stuff in its tests in astropy/asdf-astropy#170, which `stdatamodels` is importing in its tests. To be nice `asdf-astropy` is including a deprecation warning, which still causes one of the `stdatamodels` tests to fail see: https://github.com/astropy/asdf-astropy/actions/runs/4265199400/jobs/7424250651. This PR fixes that issue before it can arise.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
