### PR TITLE
JP-3015: Updates to support new JWST undersampling_correction step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ Other
 
 - Add helper functions to aid in migration of ASDF-in-FITS
   uses from asdf to this package [#114]
-- Move JP-3015 ``jwst.datamodels`` updates from the ``jwst`` package into this
-  package. [#127]
+- Add UNDERSAMP flag to dqflags and undersample correction metadata to core schema
+  in stdatamodels.jwst.datamodels [#127]
   
 1.0.0 (2023-02-14)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Other
 
 - Add helper functions to aid in migration of ASDF-in-FITS
   uses from asdf to this package [#114]
-
+- Move JP-3015 ``jwst.datamodels`` updates from the ``jwst`` package into this
+  package. [#127]
+  
 1.0.0 (2023-02-14)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -31,7 +31,7 @@ pixel = {'GOOD':             0,      # No bits set, all is good
          'OUTLIER':          2**4,   # Flagged by outlier detection (was RESERVED_1)
          'PERSISTENCE':      2**5,   # High persistence (was RESERVED_2)
          'AD_FLOOR':         2**6,   # Below A/D floor (0 DN, was RESERVED_3)
-         'RESERVED_4':       2**7,   #
+         'UNDERSAMP':        2**7,   # Undersampling correction (was RESERVED_4)
          'UNRELIABLE_ERROR': 2**8,   # Uncertainty exceeds quoted error
          'NON_SCIENCE':      2**9,   # Pixel not on science portion of detector
          'DEAD':             2**10,  # Dead pixel
@@ -67,6 +67,7 @@ group = {'GOOD':       pixel['GOOD'],
          'JUMP_DET':   pixel['JUMP_DET'],
          'DROPOUT':    pixel['DROPOUT'],
          'AD_FLOOR':   pixel['AD_FLOOR'],
+         'UNDERSAMP':  pixel['UNDERSAMP'],
          }
 
 __all__ = ["ap_interpret_bit_flags", "interpret_bit_flags", "dqflags_to_mnemonics",

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2182,6 +2182,11 @@ properties:
                 type: string
                 fits_keyword: R_V2V3
                 blend_table: True
+          undersampling_correction:
+            title: Undersampling Correction
+            type: string
+            fits_keyword: S_UNDSMP 
+            blend_table: True
           wavecorr:
             title: Zero point wavelength correction for Nirspec MOS and FS mode
             type: object


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3015](https://jira.stsci.edu/browse/JP-3015)

<!-- describe the changes comprising this PR here -->
Updated the jwst dqflags definitions and core schema to support the new jwst undersampling_correction step. This includes a new DQ flag definition and a step status keyword.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
