### PR TITLE
remove uses of deprecated asdf.resolver

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -14,7 +14,6 @@ from astropy.io import fits
 from astropy import time
 from astropy.utils.exceptions import AstropyWarning
 import asdf
-from asdf import resolver
 from asdf import schema as asdf_schema
 from asdf.tags.core import NDArrayType
 from asdf.tags.core import ndarray, HistoryEntry
@@ -355,17 +354,6 @@ def _get_validators(hdulist):
     return validators
 
 
-META_SCHEMA_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'metaschema'))
-
-
-FITS_SCHEMA_URL_MAPPING = resolver.Resolver(
-    [
-        ('http://stsci.edu/schemas/fits-schema/',
-         'file://' + META_SCHEMA_PATH + '/{url_suffix}.yaml')
-    ] + resolver.DEFAULT_URL_MAPPING, 'url')
-
-
 def _save_from_schema(hdulist, tree, schema):
     def datetime_callback(node, json_id):
         if isinstance(node, datetime.datetime):
@@ -384,7 +372,7 @@ def _save_from_schema(hdulist, tree, schema):
         kwargs = {}
 
     validator = asdf_schema.get_validator(
-        schema, None, _get_validators(hdulist), FITS_SCHEMA_URL_MAPPING, **kwargs)
+        schema, None, _get_validators(hdulist), **kwargs)
 
     # This actually kicks off the saving
     validator.validate(tree, _schema=schema)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -3,7 +3,6 @@ from functools import partial
 import hashlib
 import inspect
 import io
-import os
 from pkg_resources import parse_version
 import re
 import warnings

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -88,12 +88,10 @@ class MultiExposureModel(JwstDataModel):
         # Get the schemas
         schema = asdf_schema.load_schema(
             self.schema_url,
-            resolver=AsdfFile().resolver,
             resolve_references=True
         )
         core_schema = asdf_schema.load_schema(
             self.core_schema_url,
-            resolver=AsdfFile().resolver,
             resolve_references=True
         )
 

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 from asdf import schema as asdf_schema
-from asdf import treeutil, AsdfFile
+from asdf import treeutil
 
 from .model_base import JwstDataModel
 from .image import ImageModel

--- a/src/stdatamodels/jwst/datamodels/schema_editor.py
+++ b/src/stdatamodels/jwst/datamodels/schema_editor.py
@@ -57,7 +57,6 @@ from asdf import schema as aschema
 from asdf import generic_io
 from asdf import reference
 from asdf import treeutil
-from asdf.extension import get_default_resolver
 
 from . import JwstDataModel
 
@@ -394,8 +393,6 @@ class Keyword_db:
         """
         Resolve urls in the schema
         """
-        resolver = get_default_resolver()
-
         def resolve_refs(node, json_id):
             if json_id is None:
                 json_id = url
@@ -407,11 +404,10 @@ class Keyword_db:
                     suburl_path = suburl[:-(len(fragment) + 1)]
                 else:
                     suburl_path = suburl
-                suburl_path = resolver(suburl_path)
 
                 try:
                     subschema = aschema.load_schema(suburl_path,
-                                                    resolver,
+                                                    None,
                                                     True)
                 except IOError:
                     print("Could not read " + suburl_path)

--- a/src/stdatamodels/jwst/datamodels/schema_editor.py
+++ b/src/stdatamodels/jwst/datamodels/schema_editor.py
@@ -407,8 +407,7 @@ class Keyword_db:
 
                 try:
                     subschema = aschema.load_schema(suburl_path,
-                                                    None,
-                                                    True)
+                                                    resolve_references=True)
                 except IOError:
                     print("Could not read " + suburl_path)
                     subschema = OrderedDict()


### PR DESCRIPTION
asdf.resolver will be deprecated in 2.15: https://github.com/asdf-format/asdf/pull/1362

A few uses were found in stdatamodels

1) fits_support adds a resolver for a non-existent path: https://github.com/spacetelescope/stdatamodels/blob/740477cfc3c5540233de5606e4da23241abc4266/src/stdatamodels/fits_support.py#L362-L366
2) jwst/datamodels/multiexposure provides resolvers that are equivalent to the defaults https://github.com/spacetelescope/stdatamodels/blob/740477cfc3c5540233de5606e4da23241abc4266/src/stdatamodels/jwst/datamodels/multiexposure.py#L89-L98
3) jwst/datamodels/schema_editor uses the default resolver to resolve schema references https://github.com/spacetelescope/stdatamodels/blob/740477cfc3c5540233de5606e4da23241abc4266/src/stdatamodels/jwst/datamodels/schema_editor.py#L397-L415

1 and 2 are unnecessary and this PR removes these uses.

schema_editor duplicates some of the code internal to asdf [see asdf.schema._load_schema_cached](https://github.com/asdf-format/asdf/blob/6b4701277bb25c1d4e8583b88bc2b125be9a36d6/asdf/schema.py#L498-L517). The uses of resolver appear unnecessary as the call to `generic_io.resolve_uri` and `schema.load_schema` appear sufficient to resolve the schema references (as tested with the jwst regression test: https://github.com/spacetelescope/jwst/blob/master/jwst/regtest/test_schema_editor.py).

~A complete run of the jwst regression tests with these changes will be needed.~ EDIT: jwst regression tests passed here: https://github.com/spacetelescope/stdatamodels/pull/128#issuecomment-1447086873

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
