### PR TITLE
test against jwst developement version instead of released version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test]
+    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
 commands_pre =
     pip freeze
 commands =


### PR DESCRIPTION
During migration of datamodels from jwst to this package, testing was switched to a different JWST branch:
https://github.com/spacetelescope/stdatamodels/pull/112
that was compatible with the move.
The switch back after the move finished
https://github.com/spacetelescope/stdatamodels/commit/46e96286d7c23eaf7bed5f1baa1b441f470dacee
changed the CI to test against the released jwst version instead of the development version.
Here is one example of the issue (where jwst 1.9.4 was installed instead of the current git head)
https://github.com/spacetelescope/stdatamodels/actions/runs/4280618786/jobs/7458972540#step:12:59

This PR switches the jwst ci testing to be against the current default git branch.

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
