### PR TITLE
fix coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,3 +148,8 @@ norecursedirs = [
 
 [tool.setuptools_scm]
 write_to = "src/stdatamodels/_version.py"
+
+[tool.coverage.run]
+omit = [
+    '*/tests/*',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ minversion = "4.6"
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"
-addopts = "--open-files"
+addopts = "--open-files --color=yes"
 testpaths = [
     "tests",
     "src/stdatamodels/jwst",

--- a/tox.ini
+++ b/tox.ini
@@ -52,12 +52,14 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
+use_develop=
+    cov: true
 commands_pre =
     pip freeze
 commands =
     pytest \
     xdist: -n auto \
-    cov: --cov=. --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    cov: --cov=src --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
     jwst: --pyargs jwst --ignore-glob=*/scripts/* \
     # TODO: fix bug with `.finalize()` in `jwst.associations`
     jwst: --ignore-glob=*/associations/tests/test_dms.py \

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,9 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
-use_develop=
-    cov: true
+package=
+    cov: editable
+    !cov: wheel
 commands_pre =
     pip freeze
 commands =


### PR DESCRIPTION
The coverage measurement does not appear to be working correctly.

For example, this function:
https://github.com/spacetelescope/stdatamodels/blob/dc0da6d55da8e6251ef04b55551d14246c488a48/src/stdatamodels/asdf_in_fits.py#L13

is covered by this test:
https://github.com/spacetelescope/stdatamodels/blob/dc0da6d55da8e6251ef04b55551d14246c488a48/tests/test_asdf_in_fits.py#L35

The test does appear to be running (confirmed locally) and coverage reports run locally outside tox (with a development install of the package) show increased coverage.

However this function does not appear to have coverage in the CI.
https://app.codecov.io/gh/spacetelescope/stdatamodels/blob/master/src/stdatamodels/asdf_in_fits.py

I tested a few of the solutions mentioned here, which describe how pytest will test the installed package yet coverage is measured against the current directory (for our current configuration):
https://stackoverflow.com/questions/58696476/tox-0-coverage

and the 'usedevelop' option appears to improve the coverage measurement.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
