### PR TITLE
import `tomli` as `tomllib` for `docs` builds before Python 3.11

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,10 @@ from datetime import datetime
 import importlib
 
 import stsci_rtd_theme
-import tomli
-
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 def setup(app):
     try:
@@ -23,7 +25,7 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT/"src"/"stdatamodels"))
 
 with open(REPO_ROOT / "pyproject.toml", 'rb') as configuration_file:
-    setup_metadata = tomli.load(configuration_file)['project']
+    setup_metadata = tomllib.load(configuration_file)['project']
 
 project = setup_metadata["name"]
 author = setup_metadata["authors"][0]["name"]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
`tomli` is implemented read-only as `tomllib` in Python 3.11

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
