### PR TITLE
fix reference save return value

### DIFF
--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -53,10 +53,11 @@ class ReferenceFileModel(JwstDataModel):
             # uncompressed DQ array.
             dq_orig = self.dq.copy()
             self.dq = dynamic_mask(self, pixel, inv=True)
-            super().save(path, dir_path, *args, **kwargs)
+            output_path = super().save(path, dir_path, *args, **kwargs)
             self.dq = dq_orig
         else:
-            super().save(path, dir_path, *args, **kwargs)
+            output_path = super().save(path, dir_path, *args, **kwargs)
+        return output_path
 
     def print_err(self, message):
         if self._strict_validation:


### PR DESCRIPTION
Changes to `ReferenceFileModel.save` introduced in #132 cause the following jwst doc test to fail:
https://github.com/spacetelescope/jwst/blob/master/docs/jwst/assign_wcs/asdf-howto.rst#create-the-reference-file

The failure can be seen [in this regression test run result](https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-devdeps/644/testReport/junit/docs.jwst.assign_wcs.asdf-howto/rst/_unstable_deps__asdf_howto_rst/)

The doctest expects that `ReferenceFileModel.save` will return the `output_filename` (behavior inherited from `DataModel`):
https://github.com/spacetelescope/stdatamodels/blob/4c177d50096bf4702b021239500937f1db47a488/src/stdatamodels/model_base.py#L536

This PR updates `ReferenceFileModel.save` to return the `output_filename` to fix the failing jwst doc test.