### PR TITLE
(JP-3093) Add units to BARTDELT and HELIDELT keywords

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -1434,7 +1434,7 @@ properties:
         type: object
         properties:
           barycentric_correction:
-            title: Barycentric time correction
+            title: "[s] Barycentric correction at exposure start"
             type: number
             fits_keyword: BARTDELT
             blend_table: True
@@ -1454,7 +1454,7 @@ properties:
             fits_keyword: BMIDTIME
             blend_table: True
           heliocentric_correction:
-            title: Heliocentric time correction
+            title: "[s] Heleoentric correction at exposure start"
             type: number
             fits_keyword: HELIDELT
             blend_table: True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3093](https://jira.stsci.edu/browse/JP-3093)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses JIRA ticket JP-3035:Add units to comment fields of BARTDELT and HELIDELT keywords. The comments for these keywords have been modified to match those in the keyword dictionary.
**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ X] added relevant label(s)
