### PR TITLE
Remove `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Other
 
 - Add units to BARTDELT and HELIDELT jwst keywords in datamodels schema. [#147]
 
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning``s. [#152]
+
 1.3.0 (2023-03-13)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
     "psutil",
     "pytest>=4.6.0",
     "pytest-doctestplus",
-    "pytest-openfiles>=0.5.0",
     "crds>=11.16.14",
     "scipy>=1.5",
 ]
@@ -131,10 +130,13 @@ minversion = "4.6"
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"
-addopts = "--open-files --color=yes"
+addopts = "--color=yes"
 testpaths = [
     "tests",
     "src/stdatamodels/jwst",
+]
+filterwarnings = [
+    "error::ResourceWarning",
 ]
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false


### PR DESCRIPTION
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
