### PR TITLE
Fix open file handles which were not being caught by `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.3.2 (unreleased)
 ==================
 
+Other
+-----
+
 - Add pixel replacement step keyword to jwst.datamodels core schema, and change
   DQ bit 28 from ``UNRELIABLE_RESET`` to ``FLUX_ESTIMATED``. [#149]
   
@@ -10,6 +13,12 @@
 
 - Remove the defunct ``s3_utils`` module, so that ``stpipe`` no longer needs to depend 
   on this package. This also removes the ``aws`` install option as this is no longer need. [#154]
+  
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning``s. [#152]
+
+- Fix open file handles, which were previously ignored by ``pytest-openfiles``, but which raise
+  blocked ``ResourceWarning`` errors. [#153]
 
 1.3.1 (2023-03-31)
 ==================
@@ -18,10 +27,6 @@ Other
 -----
 
 - Add units to BARTDELT and HELIDELT jwst keywords in datamodels schema. [#147]
-
-- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
-  catching ``ResourceWarning``s. [#152]
-
 
 1.3.0 (2023-03-13)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,12 @@ testpaths = [
     "src/stdatamodels/jwst",
 ]
 filterwarnings = [
+    # This error replaces pytest-openfiles
     "error::ResourceWarning",
+    # Sometimes turning ResourceWarnings into errors creates an unraisable exception
+    #   e.g. when pyest catches another exception, this will block the turning of
+    #        ResourceWarnings into errors
+    "error::pytest.PytestUnraisableExceptionWarning",
 ]
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -683,6 +683,13 @@ def from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
         Otherwise, the default is `False`
     """
     try:
+        return _from_fits(hdulist, schema, context, skip_fits_update=skip_fits_update, **kwargs)
+    except Exception as exc:
+        hdulist.close()
+        raise exc
+
+def _from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
+    try:
         ff = from_fits_asdf(hdulist, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -77,23 +77,23 @@ def test_skip_fits_update(jail_environ,
     """Test skip_fits_update setting"""
     # Setup the FITS file, modifying a header value
     path = make_models[which_file]
-    hduls = fits.open(path)
-    hduls[0].header['exp_type'] = 'FGS_DARK'
+    with fits.open(path) as hduls:
+        hduls[0].header['exp_type'] = 'FGS_DARK'
 
-    # Decide how to skip. If using the environmental,
-    # set that and pass None to the open function.
-    try:
-        del os.environ['SKIP_FITS_UPDATE']
-    except KeyError:
-        # No need to worry, environmental doesn't exist anyways
-        pass
-    if use_env:
-        if skip_fits_update is not None:
-            os.environ['SKIP_FITS_UPDATE'] = str(skip_fits_update)
-            skip_fits_update = None
+        # Decide how to skip. If using the environmental,
+        # set that and pass None to the open function.
+        try:
+            del os.environ['SKIP_FITS_UPDATE']
+        except KeyError:
+            # No need to worry, environmental doesn't exist anyways
+            pass
+        if use_env:
+            if skip_fits_update is not None:
+                os.environ['SKIP_FITS_UPDATE'] = str(skip_fits_update)
+                skip_fits_update = None
 
-    with datamodels.open(hduls, skip_fits_update=skip_fits_update) as model:
-        assert model.meta.exposure.type == expected_exp_type
+        with datamodels.open(hduls, skip_fits_update=skip_fits_update) as model:
+            assert model.meta.exposure.type == expected_exp_type
 
 
 def test_asnmodel_table_size_zero():

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -195,6 +195,8 @@ def open(init=None, guess=True, memmap=False, **kwargs):
     new_class = _class_from_model_type(hdulist)
     has_model_type = new_class is not None
     if not guess and not has_model_type:
+        if file_to_close is not None:
+            file_to_close.close()
         raise TypeError('Model type is not specifically defined and guessing has been disabled.')
 
     # Special handling for ramp files for backwards compatibility


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
`pytest-openfiles` was not catching all the open file-handles left during the tests. These handles were often blocked by
other exception handling. The removal of `pytest-openfiles` and replacement with `ResourceWarning` catching pointed this issue out in the form of `PytestUnraisableExceptionWarning`s, because other exceptions were being caught `pytest` could not raise the `ResourceWarning` as an exception.

This PR fixes all the new file handles being caught and turns `PytestUnraisableExceptionWarning`s into errors to prevent this issue in the future.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
