### PR TITLE
Updates nirspec cubepar reference to use driz wavelength table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Other
 
 - Provide second-order polynomial transforms for NIRCam WFSS grisms. [#124]
 
+- Add wavelength tables for NIRSpec Drizzle cubepars reference file [#157]
+
 1.4.0 (2023-04-19)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/ifucubepars.py
+++ b/src/stdatamodels/jwst/datamodels/ifucubepars.py
@@ -36,13 +36,13 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
 
-    ifucubepars_prism_driz_wavetable : numpy table
+    ifucubepars_prism_driz_wavetable : numpy float32 array
          default IFU cube prism drizzle wavetable
 
-    ifucubepars_med_driz_wavetable : numpy table
+    ifucubepars_med_driz_wavetable : numpy float32 array
          default IFU cube med resolution drizzle wavetable
 
-    ifucubepars_high_driz_wavetable : numpy table
+    ifucubepars_high_driz_wavetable : numpy float32 array
          default IFU cube high resolution drizzle wavetable
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
@@ -69,7 +69,7 @@ class MiriIFUCubeParsModel(ReferenceFileModel):
     ifucubepars_multichannel_emsm_wavetable : numpy table
          default IFU cube emsm wavetable
 
-    ifucubepars_multichannel_driz_wavetable : numpy table
+    ifucubepars_multichannel_driz_wavetable : numpy float32 array
          default IFU cube driz wavetable
 
     """

--- a/src/stdatamodels/jwst/datamodels/ifucubepars.py
+++ b/src/stdatamodels/jwst/datamodels/ifucubepars.py
@@ -35,6 +35,15 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
 
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
+
+    ifucubepars_prism_driz_wavetable : numpy table
+         default IFU cube prism drizzle wavetable
+
+    ifucubepars_med_driz_wavetable : numpy table
+         default IFU cube med resolution drizzle wavetable
+
+    ifucubepars_high_driz_wavetable : numpy table
+         default IFU cube high resolution drizzle wavetable
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
 

--- a/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
@@ -132,3 +132,21 @@ allOf:
         datatype: float32
       - name: scalerad
         datatype: float32
+    ifucubepars_prism_driz_wavetable:
+      title: default IFU cube drizzle prism wavetable
+      fits_hdu: MULTICHAN_PRISM_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32
+    ifucubepars_med_driz_wavetable:
+      title: default IFU cube drizzle med resolution wavetable
+      fits_hdu: MULTICHAN_MED_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32
+    ifucubepars_high_driz_wavetable:
+      title: default IFU cube drizzle high resolution wavetable
+      fits_hdu: MULTICHAN_HIGH_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3047](https://jira.stsci.edu/browse/JP-3047)


<!-- describe the changes comprising this PR here -->
This PR updates the jwst cubepars reference file data model to include wavelength arrays for the drizzle weighting method.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
