### PR TITLE
Update the NIRSpec Cubepar reference file to read in drizzle wavelength arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,12 @@ Other
 
 - Provide second-order polynomial transforms for NIRCam WFSS grisms. [#124]
 
+
 - Deprecate ``stdatamodels.jwst.datamodels.DataModel`` in favor of
   ``stdatamodels.jwst.datamodels.JwstDataModel``. [#160]
+
+- Add wavelength tables for NIRSpec Drizzle cubepars reference file [#157]
+
 
 1.4.0 (2023-04-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Other
 - Deprecate ``stdatamodels.jwst.datamodels.DataModel`` in favor of
   ``stdatamodels.jwst.datamodels.JwstDataModel``. [#160]
 
-- Add wavelength tables for NIRSpec Drizzle cubepars reference file [#157]
+- Add wavelength tables for NIRSpec Drizzle cubepars reference file [#162]
 
 
 1.4.0 (2023-04-19)

--- a/src/stdatamodels/jwst/datamodels/ifucubepars.py
+++ b/src/stdatamodels/jwst/datamodels/ifucubepars.py
@@ -36,13 +36,13 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
 
-    ifucubepars_prism_driz_wavetable : numpy table
+    ifucubepars_prism_driz_wavetable : numpy float32 array
          default IFU cube prism drizzle wavetable
 
-    ifucubepars_med_driz_wavetable : numpy table
+    ifucubepars_med_driz_wavetable : numpy float32 array
          default IFU cube med resolution drizzle wavetable
 
-    ifucubepars_high_driz_wavetable : numpy table
+    ifucubepars_high_driz_wavetable : numpy float32 array
          default IFU cube high resolution drizzle wavetable
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
@@ -69,7 +69,7 @@ class MiriIFUCubeParsModel(ReferenceFileModel):
     ifucubepars_multichannel_emsm_wavetable : numpy table
          default IFU cube emsm wavetable
 
-    ifucubepars_multichannel_driz_wavetable : numpy table
+    ifucubepars_multichannel_driz_wavetable : numpy float32 array
          default IFU cube driz wavetable
 
     """

--- a/src/stdatamodels/jwst/datamodels/ifucubepars.py
+++ b/src/stdatamodels/jwst/datamodels/ifucubepars.py
@@ -35,6 +35,15 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
 
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
+
+    ifucubepars_prism_driz_wavetable : numpy table
+         default IFU cube prism drizzle wavetable
+
+    ifucubepars_med_driz_wavetable : numpy table
+         default IFU cube med resolution drizzle wavetable
+
+    ifucubepars_high_driz_wavetable : numpy table
+         default IFU cube high resolution drizzle wavetable
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nirspec_ifucubepars.schema"
 

--- a/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
@@ -134,19 +134,19 @@ allOf:
         datatype: float32
     ifucubepars_prism_driz_wavetable:
       title: default IFU cube drizzle prism wavetable
-      fits_hdu: MULTICHAN_PRISM_DRIZ
+      fits_hdu: MULTICHAN_PRISM_DRIZZLE
       datatype:
       - name: wavelength
         datatype: float32
     ifucubepars_med_driz_wavetable:
       title: default IFU cube drizzle med resolution wavetable
-      fits_hdu: MULTICHAN_MED_DRIZ
+      fits_hdu: MULTICHAN_MED_DRIZZLE
       datatype:
       - name: wavelength
         datatype: float32
     ifucubepars_high_driz_wavetable:
       title: default IFU cube drizzle high resolution wavetable
-      fits_hdu: MULTICHAN_HIGH_DRIZ
+      fits_hdu: MULTICHAN_HIGH_DRIZZLE
       datatype:
       - name: wavelength
         datatype: float32

--- a/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nirspec_ifucubepars.schema.yaml
@@ -132,3 +132,21 @@ allOf:
         datatype: float32
       - name: scalerad
         datatype: float32
+    ifucubepars_prism_driz_wavetable:
+      title: default IFU cube drizzle prism wavetable
+      fits_hdu: MULTICHAN_PRISM_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32
+    ifucubepars_med_driz_wavetable:
+      title: default IFU cube drizzle med resolution wavetable
+      fits_hdu: MULTICHAN_MED_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32
+    ifucubepars_high_driz_wavetable:
+      title: default IFU cube drizzle high resolution wavetable
+      fits_hdu: MULTICHAN_HIGH_DRIZ
+      datatype:
+      - name: wavelength
+        datatype: float32


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Is used to resolve [JP-3047](https://jira.stsci.edu/browse/JP-3047)

<!-- describe the changes comprising this PR here -->
This PR makes updates to the NIRSpec cubepar reference file data model to read in 3 new extensions. These extensions have names of MULTICHAN_PRISM_DRIZZLE, MULTICHAN_MED_DRIZZLE, and  MULTICHAN_HIGH_DRIZZLE.
These extensions are used to build ifu cubes when weighting='drizzle'. In particular these arrays are used when the grating/filters in the association are not the same and the wavelength range will then be non-linear. For NIRSpec all the gratings need to be either all  prism, all  medium, or all high resolution (i.e no mixture of medium and high resolution gratings are allowed). 
According to the type of grating (prism, medium, or high) the wavelength array is read in from the new extensions and used when creating an IFU cube. 

The changes to the jwst pipeline that support these updates to the cubepars reference file are in JWST pipeline #7559

We need to  merge this PR before the JWST PR #7559. I have tested that if the cubepar reference file does not have these wavelength arrays the code will still work. The arrays are just not read in. But we need to coordinate getting the new reference file in the CRDS and merging the JWST code.  

**Checklist**
- [X] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
