### PR TITLE
Improve backwards transform speed for NRC_WFSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ Other
 
 - Provide second-order polynomial transforms for NIRCam WFSS grisms. [#124]
 
-
 - Deprecate ``stdatamodels.jwst.datamodels.DataModel`` in favor of
   ``stdatamodels.jwst.datamodels.JwstDataModel``. [#160]
 
@@ -15,6 +14,8 @@ Other
 
 - Add wavelength tables for NIRSpec Drizzle cubepars reference file model. [#162]
 
+- Reduce interpolation vector length in NIRCam backwards transform
+  to improve computation times [#165]
 
 1.4.0 (2023-04-19)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.5.1 (unreleased)
+==================
+
+Other
+-----
+
+- Reduce interpolation vector length in NIRCam backwards transform
+  to improve computation times [#165]
+
 1.5.0 (2023-05-16)
 ==================
 
@@ -13,9 +22,6 @@ Other
   models from required properties of transform schemas. [#161]
 
 - Add wavelength tables for NIRSpec Drizzle cubepars reference file model. [#162]
-
-- Reduce interpolation vector length in NIRCam backwards transform
-  to improve computation times [#165]
 
 1.4.0 (2023-04-19)
 ==================

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -945,7 +945,7 @@ class NIRCAMBackwardGrismDispersion(Model):
 
     def invdisp_interp(self, model, x0, y0, wavelength):
 
-        t0 = np.linspace(0., 1., 1000)
+        t0 = np.linspace(0., 1., 40)
         t_re = np.reshape(t0, [len(t0), *map(int, np.ones_like(np.shape(x0)))])
 
         if len(model) == 2:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Related to [JP-2113](https://jira.stsci.edu/browse/JP-2113)

<!-- describe the changes comprising this PR here -->
This PR addresses speed issues caused in part by an over-long vector used for interpolation - reducing length from 1000 -> 40 appears to improve speeds in a linear fashion wrt. vector length.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
