### PR TITLE
added ifu_second_check to outlier detection parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Other
 - Reduce interpolation vector length in NIRCam backwards transform
   to improve computation times [#165]
 
+- Add an parameter to jwst outlierpars schema to support a second level of
+  flagging outliers for JWST MIRI/MRS and NIRSpec IFU data. [#167]
+
 1.5.0 (2023-05-16)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
@@ -61,3 +61,5 @@ allOf:
         datatype: float32
       - name: kernel_size
         datatype: [ascii, 10]
+      - name: ifu_second_check
+        datatype: boolean

--- a/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
@@ -62,4 +62,4 @@ allOf:
       - name: kernel_size
         datatype: [ascii, 10]
       - name: ifu_second_check
-        datatype: boolean
+        type: boolean

--- a/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/outlierpars.schema.yaml
@@ -62,4 +62,4 @@ allOf:
       - name: kernel_size
         datatype: [ascii, 10]
       - name: ifu_second_check
-        type: boolean
+        datatype: bool8


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Supports [JP-3207](https://jira.stsci.edu/browse/JP-3207)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds another parameter to the outlier_detection parameter data model. This parameter 'ifu_second_check' is a boolean and controls if a second level of outlier detection is performed. 

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
