### PR TITLE
Jwst resource warnings from failure to close open files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Other
 - Reduce interpolation vector length in NIRCam backwards transform
   to improve computation times [#165]
 
+- Close for opened files [#169]
+
 1.5.0 (2023-05-16)
 ==================
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -683,13 +683,6 @@ def from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
         Otherwise, the default is `False`
     """
     try:
-        return _from_fits(hdulist, schema, context, skip_fits_update=skip_fits_update, **kwargs)
-    except Exception as exc:
-        hdulist.close()
-        raise exc
-
-def _from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
-    try:
         ff = from_fits_asdf(hdulist, **kwargs)
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -50,10 +50,9 @@ def test_init_from_pathlib(tmp_path):
     path = tmp_path / "pathlib.fits"
     model1 = datamodels.ImageModel((50, 50))
     model1.save(path)
-    model = datamodels.open(path)
-
-    # Test is basically, did we open the model?
-    assert isinstance(model, ImageModel)
+    with datamodels.open(path) as model:
+        # Test is basically, did we open the model?
+        assert isinstance(model, ImageModel)
 
 
 @pytest.mark.parametrize('which_file, skip_fits_update, expected_exp_type',

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -222,7 +222,12 @@ def open(init=None, guess=True, memmap=False, **kwargs):
         log.debug(f'Opening as {new_class}')
 
     # Actually open the model
-    model = new_class(init, **kwargs)
+    try:
+        model = new_class(init, **kwargs)
+    except Exception:
+        if file_to_close is not None:
+            file_to_close.close()
+        raise
 
     # Close the hdulist if we opened it
     if file_to_close is not None:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -232,10 +232,10 @@ class DataModel(properties.ObjectNode):
 
             if file_type == "fits":
                 hdulist = fits.open(init, memmap=memmap)
+                self._file_references.append(_FileReference(hdulist))
                 asdffile = fits_support.from_fits(
                     hdulist, self._schema, self._ctx, **kwargs
                 )
-                self._file_references.append(_FileReference(hdulist))
 
             elif file_type == "asdf":
                 asdffile = self.open_asdf(init=init, **kwargs)
@@ -386,7 +386,6 @@ class DataModel(properties.ObjectNode):
                 target._file_references.append(file_reference)
 
         target._shape = source._shape
-        target._ctx = target
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):


### PR DESCRIPTION
This PR accompanies the jwst PR:
https://github.com/spacetelescope/jwst/pull/7599
see that PR description for more details.

TLDR; address open file issues in downstream jwst CI. Note that a complete fix requires both this PR and the above jwst PR. A test PR (https://github.com/spacetelescope/jwst/pull/7601) was opened against jwst to show the expected final result (showing no `ResourceWarning` and `PytestUnraisableExceptionWarning`.
https://github.com/spacetelescope/jwst/actions/runs/5225497772/jobs/9435044814

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
