### PR TITLE
fix changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Other
 -----
 
+- Update jwst outlierpars schema to support new IFU outlier detection algorithm. [#164]
+
 - Reduce interpolation vector length in NIRCam backwards transform
   to improve computation times [#165]
 
@@ -24,9 +26,6 @@ Other
   models from required properties of transform schemas. [#161]
 
 - Add wavelength tables for NIRSpec Drizzle cubepars reference file model. [#162]
-
-- Update jwst outlierpars schema to support new IFU outlier detection algorithm. [#164]
-
 
 1.4.0 (2023-04-19)
 ==================


### PR DESCRIPTION
The changelog entry for https://github.com/spacetelescope/stdatamodels/pull/164 was added to the already release 1.5 section as pointed out in: https://github.com/spacetelescope/jwst/pull/7590#issuecomment-1589392129

This PR moves the entry to the unreleased 1.5.1 section.