### PR TITLE
catch expected NoTypeWarnings in tests

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -2,6 +2,7 @@
 Test datamodel.open
 """
 
+import contextlib
 import os
 import os.path
 from pathlib import Path, PurePath
@@ -254,8 +255,10 @@ def test_open_asdf_no_datamodel_class(tmp_path, suffix):
 
     # Note: only the fits open emits a "model_type not found" warning.  Both
     # fits and asdf should behave the same
-    with datamodels.open(path) as m:
-        assert isinstance(m, DataModel)
+    ctx = pytest.warns(util.NoTypeWarning) if suffix == 'fits' else contextlib.nullcontext()
+    with ctx:
+        with datamodels.open(path) as m:
+            assert isinstance(m, DataModel)
 
 
 def test_open_asdf(tmp_path):
@@ -264,8 +267,9 @@ def test_open_asdf(tmp_path):
     with asdf.AsdfFile(tree) as af:
         af.write_to(path)
 
-    with datamodels.open(path) as m:
-        assert isinstance(m, DataModel)
+    with pytest.warns(util.NoTypeWarning):
+        with datamodels.open(path) as m:
+            assert isinstance(m, DataModel)
 
 
 def test_open_kwargs_asdf(tmp_path):

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from stdatamodels.jwst import datamodels as dm
 import pytest
 import warnings
-from ..util import NoTypeWarning
 
 os.environ["CRDS_SERVER_URL"] = "https://jwst-crds.stsci.edu"
 
@@ -206,7 +205,7 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                     if reftype in ref_to_multiples_dict.keys():
                         model_map = ref_to_multiples_dict[reftype]
                         with warnings.catch_warnings():
-                            warnings.simplefilter('ignore', NoTypeWarning)
+                            warnings.simplefilter('ignore', dm.util.NoTypeWarning)
                             refs = cache_references(context, {reftype: f})
                             with dm.open(refs[reftype]) as model:
                                 try:


### PR DESCRIPTION
I noticed a few expected `NoTypeWarning` messages in the test logs. This PR uses `pytest.warns` to catch (and check for) these warnings and modifies the import of `NoTypeWarning` in `test_schema_against_crds.py` to make sure that the issued `NoTypeWarning` class in the warning filter matches the one issued by the code (this can differ if the tests are run from the repository by the code being tested is installed).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
