### PR TITLE
JP-2506: Updating How the ZEROFRAME Array gets Allocated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Other
 -----
 
+- Update the allocation of the ZEROFRAME array for the RampModel. [#176]
+
 - Added two new header keywords to the JWST core schema exposure section: PRIMECRS and
   EXTNCRS, which are used to record the rate of primary cosmic rays and extended cosmic
   rays (Snowballs and Showers). [#173]

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from .model_base import JwstDataModel
 from stdatamodels.jwst.library.basic_utils import deprecate_class
 

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -44,16 +44,6 @@ class RampModel(JwstDataModel):
         self.groupdq = self.groupdq
         self.err = self.err
 
-        if isinstance(init, tuple) or self.meta.exposure.zero_frame is True:
-            try:
-                self.getarray_noinit("zeroframe")
-            except AttributeError:
-                # If "zeroframe" is not in the instance, create a zero array with
-                # the correct dimensions.
-                nints, ngroups, nrows, ncols = self.data.shape
-                dims = (nints, nrows, ncols)
-                self.zeroframe = np.zeros(dims, dtype=self.data.dtype)
-
 
 @deprecate_class(RampModel)
 class MIRIRampModel:

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -177,7 +177,13 @@ def _make_default_array(attr, schema, ctx):
                 if ndim is None:
                     shape = primary_array.shape
                 else:
-                    shape = primary_array.shape[-ndim:]
+                    if attr == "zeroframe":
+                        dims = primary_array.shape
+                        if len(dims) != 4:
+                            raise IndexError(f"To allocate ZEROFRAME, the primary array must have 4 dimensions, but has only {len(dims)}")
+                        shape = (dims[0], dims[2], dims[3])
+                    else:
+                        shape = primary_array.shape[-ndim:]
             elif ndim is None:
                 shape = (0,)
             else:
@@ -314,6 +320,7 @@ class ObjectNode(Node):
         return node, parts[-1]
 
     def __getattr__(self, attr):
+
         if attr.startswith('_'):
             raise AttributeError('No attribute {0}'.format(attr))
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -180,7 +180,9 @@ def _make_default_array(attr, schema, ctx):
                     if attr == "zeroframe":
                         dims = primary_array.shape
                         if len(dims) != 4:
-                            raise IndexError(f"To allocate ZEROFRAME, the primary array must have 4 dimensions, but has only {len(dims)}")
+                            error_msg = "To allocate ZEROFRAME, the primary array must "
+                            error_msg += f"have 4 dimensions, but has {len(dims)}."
+                            raise IndexError(error_msg)
                         shape = (dims[0], dims[2], dims[3])
                     else:
                         shape = primary_array.shape[-ndim:]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2506](https://jira.stsci.edu/browse/JP-2506)

<!-- describe the changes comprising this PR here -->
This PR addresses the ZEROFRAME array for the RampModel getting incorrectly allocated with dimensions (ngroups, nrows, ncols), when it should have dimensions (nints, nrows, ncols).  This RampModel array gets automatically allocated when referenced.  The dimensions for all arrays of dimension `ndim` is that it should have the dimensions `dims[-ndims:]` where `dims` is the dimensions of the primary array.  This assumption is incorrect.  There is now a special handler for the ZEROFRAME array to ensure it gets allocated with the proper dimensions.

This changed doesn't cause any CI failures in `STCAL`, `JWST`, nor `stdatamodels`.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
