### PR TITLE
use asdf instead of jsonschema directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Other
 - Remove ignored V23ToSkyConverter from jwst.transforms version 1.0.0
   asdf extension [#184]
 
+- Use ValidationError and type validator from asdf instead of from jsonschema
+  directly, remove jsonschema as a direct dependency [#177]
+
+
 1.7.1 (2023-07-11)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Other
   asdf extension [#184]
 
 - Use ValidationError and type validator from asdf instead of from jsonschema
-  directly, remove jsonschema as a direct dependency [#177]
+  directly, remove jsonschema as a direct dependency, increase asdf minimum
+  version to 2.15.0.  [#177]
 
 
 1.7.1 (2023-07-11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf>=2.14.1",
+    "asdf>=2.15.0",
     "asdf-astropy>=0.3.0",
     "psutil>=5.7.2",
     "numpy>=1.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jsonschema>=3.0.2",
     "asdf>=2.14.1",
     "asdf-astropy>=0.3.0",
     "psutil>=5.7.2",

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -20,7 +20,6 @@ from asdf import treeutil
 from asdf.util import HashableDict
 from asdf import tagged
 from asdf import generic_io
-from jsonschema import validators
 
 from . import properties
 from . import schema as mschema
@@ -329,7 +328,8 @@ def _fits_item_recurse(fits_context, validator, items, instance, schema):
 def _fits_type(fits_context, validator, items, instance, schema):
     if instance in ('N/A', '#TODO', '', None):
         return
-    return validators.Draft4Validator.VALIDATORS["type"](validator, items, instance, schema)
+
+    return asdf_schema.YAML_VALIDATORS["type"](validator, items, instance, schema)
 
 
 class FitsContext:

--- a/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
@@ -1,6 +1,6 @@
 from astropy.io import fits
 from astropy.time import Time
-import jsonschema
+from asdf.exceptions import ValidationError
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -50,7 +50,7 @@ def test_multislit_move_from_fits(tmp_path):
 
 
 def test_multislit_append_string():
-    with pytest.raises(jsonschema.ValidationError):
+    with pytest.raises(ValidationError):
         m = MultiSlitModel(strict_validation=True)
         m.slits.append('junk')
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_validation.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_validation.py
@@ -1,6 +1,6 @@
 from astropy import time
 from datetime import datetime
-import jsonschema
+from asdf.exceptions import ValidationError
 import pytest
 
 from stdatamodels.jwst.datamodels import JwstDataModel
@@ -9,14 +9,14 @@ from stdatamodels.jwst.datamodels import JwstDataModel
 def test_strict_validation_enum():
     with JwstDataModel(strict_validation=True) as dm:
         assert dm.meta.instrument.name is None
-        with pytest.raises(jsonschema.ValidationError):
+        with pytest.raises(ValidationError):
             # FOO is not in the allowed enumerated values
             dm.meta.instrument.name = 'FOO'
 
 
 def test_strict_validation_type():
     with JwstDataModel(strict_validation=True) as dm:
-        with pytest.raises(jsonschema.ValidationError):
+        with pytest.raises(ValidationError):
             # Schema requires a float
             dm.meta.target.ra = "FOO"
 

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -3,11 +3,11 @@ Functions that support validation of model changes
 """
 
 import warnings
-import jsonschema
 from asdf import schema as asdf_schema
 from asdf import yamlutil
+from asdf.exceptions import ValidationError
 from asdf.tags.core import ndarray
-from asdf.schema import ValidationError, YAML_VALIDATORS
+from asdf.schema import YAML_VALIDATORS
 from asdf.util import HashableDict
 import numpy as np
 
@@ -27,13 +27,13 @@ def value_change(path, value, schema, ctx):
         _check_value(value, schema, ctx)
         update = True
 
-    except jsonschema.ValidationError as error:
+    except ValidationError as error:
         update = False
         errmsg = _error_message(path, error)
         if ctx._pass_invalid_values:
             update = True
         if ctx._strict_validation:
-            raise jsonschema.ValidationError(errmsg)
+            raise ValidationError(errmsg)
         else:
             warnings.warn(errmsg, ValidationWarning)
     return update

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -4,8 +4,8 @@ import pytest
 from astropy.io import fits
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
+from asdf.exceptions import ValidationError
 import asdf.schema
-from jsonschema import ValidationError
 
 from stdatamodels import DataModel
 from stdatamodels import fits_support

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,8 +3,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import asdf
+from asdf.exceptions import ValidationError
 from asdf.tags.core import NDArrayType
-import jsonschema
 from astropy.modeling import models
 
 from stdatamodels.schema import merge_property_trees, build_docstring
@@ -46,7 +46,7 @@ def test_dictionary_like():
         x.meta.string_attribute = 'FOO'
         assert x['meta.string_attribute'] == 'FOO'
 
-        with pytest.raises(jsonschema.ValidationError):
+        with pytest.raises(ValidationError):
             x['meta.string_attribute'] = 12
 
         with pytest.raises(KeyError):
@@ -153,7 +153,7 @@ def test_add_schema_entry():
         dm.meta.foo.bar = 'bar'
         try:
             dm.meta.foo.bar = 'what?'
-        except jsonschema.ValidationError:
+        except ValidationError:
             pass
         else:
             assert False

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ import warnings
 
 import pytest
 import asdf
-from jsonschema import ValidationError
+from asdf.exceptions import ValidationError
 import numpy as np
 
 from stdatamodels.validate import ValidationWarning


### PR DESCRIPTION
get ValidationError from asdf.exceptions
get 'type' validator from asdf.schema.YAML_VALIDATORS

Regression tests running at: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/790/

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
