### PR TITLE
build docs with python 3.10

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,8 @@
-name: rtd311
+name: rtd310
 channels:
  - conda-forge
  - defaults
 dependencies:
- - python=3.11
+ - python=3.10
  - pip
  - graphviz


### PR DESCRIPTION
sphinx-asdf 0.2.0 fails for some uses in python 3.11 (see: https://github.com/asdf-format/sphinx-asdf/pull/72).

This PR temporarily switches the docs to build in 3.10 until an update can be released for sphinx-asdf.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
