### PR TITLE
add docs to test paths, fix failing doctest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Other
   TARGCAT and TARGDESC, which record the target category and description
   as given by the user in the APT. [#179]
 
+- Enable searching docs directory for doctests and fix failing doctest. [#182]
+
 Bug Fixes
 ---------
 

--- a/docs/source/jwst/datamodels/metadata.rst
+++ b/docs/source/jwst/datamodels/metadata.rst
@@ -44,9 +44,13 @@ search is case-insensitive::
     <BLANKLINE>
     meta.target.catalog_name
     <BLANKLINE>
+    meta.target.category
+    <BLANKLINE>
     meta.target.dec
     <BLANKLINE>
     meta.target.dec_uncertainty
+    <BLANKLINE>
+    meta.target.description
     <BLANKLINE>
     meta.target.proper_motion_dec
     <BLANKLINE>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ doctest_rst = true
 text_file_format = "rst"
 addopts = "--color=yes"
 testpaths = [
+    "docs",
     "tests",
     "src/stdatamodels/jwst",
 ]


### PR DESCRIPTION
pyproject.toml test paths did not include the docs directory. This limited the number of doctests run during pytest runs (and the CI in this package). Downstream testing in asdf revealed this limitation and one failing doctest.

This PR adds the docs directory to the test paths and fixes the one failing doctest.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [ ] added relevant label(s)
