### PR TITLE
remove unused V23ToSkyConverter from jwst.transforms extension 1.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 Other
 -----
 
--
+- Remove ignored V23ToSkyConverter from jwst.transforms version 1.0.0
+  asdf extension [#184]
 
 1.7.1 (2023-07-11)
 ==================

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -8,35 +8,44 @@ from .converters.jwst_models import (Gwa2SlitConverter, Slit2MsaConverter, Logic
                                      CoordsConverter, V23ToSkyConverter)
 
 
-JWST_TRANSFORM_CONVERTERS = [
-    CoordsConverter(),
-    Gwa2SlitConverter(),
-    Slit2MsaConverter(),
-    LogicalConverter(),
-    NirissSOSSConverter(),
-    RefractionIndexConverter(),
-    Rotation3DToGWAConverter(),
-    MIRI_AB2SliceConverter(),
-    NIRCAMGrismDispersionConverter(),
-    NIRISSGrismDispersionConverter(),
-    GratingEquationConverter(),
-    SnellConverter(),
-    V23ToSkyConverter(),
-]
-
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.
-TRANSFORM_MANIFEST_URIS = [
-    "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.0.0",
-    "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-0.7.0"
-]
-
-
 TRANSFORM_EXTENSIONS = [
     ManifestExtension.from_uri(
-        uri,
+        "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.0.0",
         legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
-        converters=JWST_TRANSFORM_CONVERTERS,
+        converters=[
+            CoordsConverter(),
+            Gwa2SlitConverter(),
+            Slit2MsaConverter(),
+            LogicalConverter(),
+            NirissSOSSConverter(),
+            RefractionIndexConverter(),
+            Rotation3DToGWAConverter(),
+            MIRI_AB2SliceConverter(),
+            NIRCAMGrismDispersionConverter(),
+            NIRISSGrismDispersionConverter(),
+            GratingEquationConverter(),
+            SnellConverter(),
+        ],
+    ),
+    ManifestExtension.from_uri(
+        "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-0.7.0",
+        legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
+        converters=[
+            CoordsConverter(),
+            Gwa2SlitConverter(),
+            Slit2MsaConverter(),
+            LogicalConverter(),
+            NirissSOSSConverter(),
+            RefractionIndexConverter(),
+            Rotation3DToGWAConverter(),
+            MIRI_AB2SliceConverter(),
+            NIRCAMGrismDispersionConverter(),
+            NIRISSGrismDispersionConverter(),
+            GratingEquationConverter(),
+            SnellConverter(),
+            V23ToSkyConverter(),
+        ],
     )
-    for uri in TRANSFORM_MANIFEST_URIS
 ]


### PR DESCRIPTION
V23ToSkyConverter is supported in the jwst.transforms asdf extension version 0.7.0 (see [0.7.0 manifest](https://github.com/spacetelescope/stdatamodels/blob/fbd97cc7ab5a675d36e42db25218f8bffec8f494/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-0.7.0.yaml#L88)) but is not currently supported in 1.0.0 (see [1.0.0 manifest](https://github.com/spacetelescope/stdatamodels/blob/master/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.0.0.yaml))

This removes V23ToSkyConverter from the 1.0.0 extension (which already does not support the tag) and in all prior versions of asdf this converter was ignored.

Previously asdf ignored any Converter that lists tags that are not in the manifest. This behavior is undocumented and may conflict with future asdf changes. asdf is changing Converter.select_tag to allow Converter deferral (see https://github.com/asdf-format/asdf/pull/1561) where a converter can support no tags but still support types (where the converter will convert the object being serialized to a new type which is handled by a different converter).

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
