### PR TITLE
Add tests for dynamic_mask and remove usage of `numpy.where`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Other
   directly, remove jsonschema as a direct dependency, increase asdf minimum
   version to 2.15.0.  [#177]
 
+- Use binary masks for dq calculations in dynamicdq [#185]
+
 
 1.7.1 (2023-07-11)
 ==================

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -53,14 +53,10 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
 
             if not inv:
                 # Decompress the DQ array using 'dq_def'.
-                just_this_bit = np.bitwise_and(input_model.dq, bitplane)
-                pixels = np.where(just_this_bit != 0)
-                dqmask[pixels] = np.bitwise_or(dqmask[pixels], standard_bitvalue)
+                dqmask[np.bitwise_and(input_model.dq, bitplane) != 0] |= standard_bitvalue
             else:
                 # Compress the DQ array using 'dq_def'.
-                just_this_bit = np.bitwise_and(input_model.dq, standard_bitvalue)
-                pixels = np.where(just_this_bit != 0)
-                dqmask[pixels] = np.bitwise_or(dqmask[pixels], bitplane)
+                dqmask[np.bitwise_and(input_model.dq, standard_bitvalue) != 0] |= bitplane
 
     else:
         dqmask = input_model.dq

--- a/tests/test_dynamicdq.py
+++ b/tests/test_dynamicdq.py
@@ -1,0 +1,65 @@
+import numpy
+import pytest
+
+from stdatamodels.dynamicdq import dynamic_mask
+
+
+def _dq(init):
+    return numpy.array(init, dtype='u4')
+
+
+def _dq_def(init):
+    return numpy.array(init, dtype=[('VALUE', 'u4'), ('NAME', 'S40')])
+
+
+class FakeModel:
+    def __init__(self, dq, dq_def):
+        # len == 0 -> copy dq
+        self.dq = dq
+
+        # recarray with dtype [('VALUE', 'u32'), ('NAME', [ascii, 40])]
+        # None -> copy dq
+        # scalar -> copy dq
+        # len == 0 -> copy dq
+        self.dq_def = dq_def
+
+
+@pytest.mark.parametrize('dq', [[], [1, 2, 3]])
+@pytest.mark.parametrize('dq_def', [None, 1, _dq_def([])])
+@pytest.mark.parametrize('mmap', [{}, {'a': 1}])
+@pytest.mark.parametrize('inv', [True, False])
+def test_copy_dq(dq, dq_def, mmap, inv):
+    dq = _dq(dq)
+    model = FakeModel(dq, dq_def)
+    dqmask = dynamic_mask(model, mmap, inv)
+    assert dq is dqmask
+
+
+@pytest.mark.parametrize('inv', [True, False])
+def test_mmap(inv):
+    dq = _dq([0, 1, 2, 4])
+    dq_def = _dq_def([(1, 'FOO'), (2, 'BAR'), (4, 'BAM')])
+    model = FakeModel(dq, dq_def)
+    mmap = {
+        b'FOO': 4,
+        b'BAR': 1,
+        b'BAM': 2,
+    }
+    dqmask = dynamic_mask(model, mmap, inv)
+    if inv:
+        numpy.testing.assert_equal(dqmask, [0, 2, 4, 1])
+    else:
+        numpy.testing.assert_equal(dqmask, [0, 4, 1, 2])
+
+
+@pytest.mark.parametrize('inv', [True, False])
+def test_missing_map_key(caplog, inv):
+    dq = _dq([0, 1])
+    dq_def = _dq_def([(1, 'FOO')])
+    model = FakeModel(dq, dq_def)
+    mmap = {
+        b'BAR': 2,
+    }
+    dqmask = dynamic_mask(model, mmap, inv)
+    numpy.testing.assert_equal(dqmask, [0, 0])
+    assert 'does not correspond to an existing DQ' in caplog.text

--- a/tests/test_dynamicdq.py
+++ b/tests/test_dynamicdq.py
@@ -14,13 +14,7 @@ def _dq_def(init):
 
 class FakeModel:
     def __init__(self, dq, dq_def):
-        # len == 0 -> copy dq
         self.dq = dq
-
-        # recarray with dtype [('VALUE', 'u32'), ('NAME', [ascii, 40])]
-        # None -> copy dq
-        # scalar -> copy dq
-        # len == 0 -> copy dq
         self.dq_def = dq_def
 
 


### PR DESCRIPTION
This PR adds some basic unit tests for `dynamic_mask` and improves performance by removing use of `np.where` calls on binary masks and instead uses the masks directly (local testing shows the new code takes ~30% the time).

Regtest run with these changes show no errors:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/812/pipeline/123

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
