### PR TITLE
JP-3329: Add GSC_VER to JWST core schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Other
 
 - Use binary masks for dq calculations in dynamicdq [#185]
 
+- Added the new keyword "GSC_VER" to the JWST core datamodels schema. [#190]
+
 
 1.7.1 (2023-07-11)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -33,22 +33,27 @@ properties:
         fits_keyword: FILENAME
         blend_table: True
       data_processing_software_version:
-        title: Data processing software version number
+        title: Data processing (DP) Software Version
         type: string
         fits_keyword: SDP_VER
         blend_table: True
       prd_software_version:
-        title: S&OC PRD version number used in data processing
+        title: S&OC Project Reference Database (PRD) Version
         type: string
         fits_keyword: PRD_VER
         blend_table: True
       oss_software_version:
-        title: Observatory Scheduling Software (OSS) version number
+        title: Observatory Scheduling Software (OSS) Version
         type: string
         fits_keyword: OSS_VER
         blend_table: True
+      guide_star_catalog_version:
+        title: Guide Star Catalog (GSC) Version
+        type: string
+        fits_keyword: GSC_VER
+        blend_table: True
       calibration_software_version:
-        title: Calibration software version number
+        title: Calibration Software Version
         type: string
         fits_keyword: CAL_VER
         blend_table: True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3329](https://jira.stsci.edu/browse/JP-3329)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/jwst#7791

<!-- describe the changes comprising this PR here -->
This PR adds the new "GSC_VER" keyword to the JWST core schema, to keep in synch with the changes made to the keyword dictionary in [JWSTKD-534](https://jira.stsci.edu/browse/JWSTKD-524). In addition to adding the definition of GSC_VER, it also makes minor updates to the comment/title field of several other xxx_VER keywords, again in keeping with changes made in the dictionary.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
