### PR TITLE
Fix typo in ifu-outlier metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Other
 - Add option to ``allow_extra_columns`` in datamodel schema that defines
   structured arrays (tables) and allow extra columns in tables [#189]
 
+- Fix typo in ``outlierifuoutput`` schema for ``kernel_ysize`` [#191]
 
 1.7.2 (2023-08-14)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/outlierifuoutput.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/outlierifuoutput.schema.yaml
@@ -17,7 +17,7 @@ allOf:
         kernel_ysize:
           title: outlier detection kernel y size
           type: integer
-          fits_keyword: KERNXSY
+          fits_keyword: KERNYSZ
         threshold_percent:
           title: outlier detection threshold percent
           type: number


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR addresses what looks like a typo, found in the outlierifuoutput schema during a comparison to the keyword dictionary (which does not have any version of this metadata yet). @jemorrison Does this look like a fix or was it the intended name?

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
