### PR TITLE
clean up some test warnings and turn warnings into errors in ci

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,12 +133,11 @@ testpaths = [
     "src/stdatamodels/jwst",
 ]
 filterwarnings = [
-    # This error replaces pytest-openfiles
-    "error::ResourceWarning",
-    # Sometimes turning ResourceWarnings into errors creates an unraisable exception
-    #   e.g. when pyest catches another exception, this will block the turning of
-    #        ResourceWarnings into errors
-    "error::pytest.PytestUnraisableExceptionWarning",
+    # turn all warnings into errors, this includes ResourceWarning which
+    # allows catching files left open by tests
+    "error",
+    # astropy table issues this warning on import so we ignore it here
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
 ]
 asdf_schema_tests_enabled = true
 asdf_schema_validate_default = false

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,16 +33,17 @@ def test_set_shape():
 
 def test_broadcast():
     with BasicModel((50, 50)) as dm:
-        data = np.empty((50,))
+        data = np.zeros((50,))
         dm.dq = data
+        assert dm.dq.dtype == np.uint32
 
 
 def test_broadcast2():
     with BasicModel() as dm:
-        data = np.empty((52, 50))
+        data = np.zeros((52, 50))
         dm.data = data
 
-        dq = np.empty((50,))
+        dq = np.zeros((50,))
         dm.dq = dq
 
 
@@ -87,14 +88,14 @@ def test_stringify(tmp_path):
 
 
 def test_init_with_array():
-    array = np.empty((50, 50))
+    array = np.zeros((50, 50))
     with BasicModel(array) as dm:
         assert dm.data.shape == (50, 50)
 
 
 def test_init_with_array2():
     with pytest.raises(ValueError):
-        array = np.empty((50,))
+        array = np.zeros((50,))
         with BasicModel(array) as dm:
             dm.data
 
@@ -102,13 +103,13 @@ def test_init_with_array2():
 def test_set_array():
     with pytest.raises(ValueError):
         with BasicModel() as dm:
-            data = np.empty((50,))
+            data = np.zeros((50,))
             dm.data = data
 
 
 def test_set_array2():
     with BasicModel() as dm:
-        data = np.empty((50, 50))
+        data = np.zeros((50, 50))
         dm.data = data
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ commands =
     xdist: -n auto \
     cov: --cov=src --cov-report=term-missing --cov-report=xml \
     jwst: --pyargs jwst --ignore-glob=*/scripts/* \
+    jwst: -o filterwarnings="[]" \
     # TODO: fix bug with `.finalize()` in `jwst.associations`
     jwst: --ignore-glob=*/associations/tests/test_dms.py \
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ pass_env =
     CRDS_*
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    cov: COVERAGE_RC_FILE=pyproject.toml
 extras =
     test
 deps =
@@ -54,7 +55,7 @@ commands_pre =
 commands =
     pytest \
     xdist: -n auto \
-    cov: --cov=src --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    cov: --cov=src --cov-report=term-missing --cov-report=xml \
     jwst: --pyargs jwst --ignore-glob=*/scripts/* \
     # TODO: fix bug with `.finalize()` in `jwst.associations`
     jwst: --ignore-glob=*/associations/tests/test_dms.py \


### PR DESCRIPTION
This PR cleans up the warnings in the test suite (these were almost all from use of `np.empty` which often produced values that fell outside of the range of the destination datatype when the empty arrays were assigned to a datamodel).

This PR also turns all warnings into errors in the test suite (with 1 exception where `RuntimeWarning` with a message `numpy.ndarray size changed` is ignored as it's produced by importing astropy code).

If there's any objection to turning all warnings into errors I'm happy to remove that part of this PR.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
