### PR TITLE
add weekly cron env to tox.ini to fix tox 4.9 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-jwst}-xdist{,-cov}
+    test{,-jwst,-devdeps}-xdist{,-cov}
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)


### PR DESCRIPTION
See: https://github.com/spacetelescope/roman_datamodels/pull/261 for more details

tox 4.9 will no longer run environments that are not either:
- prefixed with a python version: e.g. `py310` for python 3.10
- listed in `tox.ini`

This PR adds the weekly cron env `test-devdeps-xdist` to `tox.ini` so hopefully it will ~fail in a new way~ succeed next week when run with tox 4.9.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
