### PR TITLE
JP-3349: add keyword_filter ref to gain.schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Other
 
 - Use binary masks for dq calculations in dynamicdq [#185]
 
+- Add keyword_filter.schema reference to gain schema to accomodate
+  changes to CRDS files to support meta.instrument.filter [#197]
+
+
 1.7.2 (2023-08-14)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/schemas/gain.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/gain.schema.yaml
@@ -6,6 +6,7 @@ allOf:
 - $ref: referencefile.schema
 - $ref: subarray.schema
 - $ref: keyword_gainfact.schema
+- $ref: keyword_filter.schema
 - $ref: bunit.schema
 - type: object
   properties:


### PR DESCRIPTION
Resolves [JP-3349](https://jira.stsci.edu/browse/JP-3349)

Closes spacetelescope/jwst#7832

Add `$ref` to `keyword_filter` schema to `gain` schema to support the `meta.instrument.filter` parameter added to the corresponding miri gain crds file.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
