### PR TITLE
add warning filter for known issue with fgs distortion file on crds

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -1,9 +1,12 @@
 import os
 import logging
 from collections.abc import Iterable
-from stdatamodels.jwst import datamodels as dm
-import pytest
 import warnings
+
+import asdf
+import pytest
+
+from stdatamodels.jwst import datamodels as dm
 
 os.environ["CRDS_SERVER_URL"] = "https://jwst-crds.stsci.edu"
 
@@ -207,6 +210,11 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                         with warnings.catch_warnings():
                             warnings.simplefilter('ignore', dm.util.NoTypeWarning)
                             refs = cache_references(context, {reftype: f})
+                            if os.path.basename(refs[reftype]) == 'jwst_fgs_distortion_0003.asdf':
+                                # jwst_fgs_distortion_0003.asdf contains an invalid set of ASDF
+                                # tags and will load with a warning for asdf >= 3.0. This is a known
+                                # issue and doesn't affect the use of the file in this test.
+                                warnings.simplefilter('ignore', asdf.exceptions.AsdfConversionWarning)
                             with dm.open(refs[reftype]) as model:
                                 try:
                                     ref_exptype = model.meta.exposure.type


### PR DESCRIPTION
The fgs distortion reference file on crds: https://jwst-crds.stsci.edu/browse/jwst_fgs_distortion_0003.asdf
contains an invalid set of ASDF tags. Looking at the first few lines of the file...
```
#ASDF 1.0.0
#ASDF_STANDARD 1.2.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.0.0
```
The file reports to be ASDF standard version 1.2.0, yet uses the `core/asdf-1.0.0` tag (which [does not exist in 1.2.0 which uses `core/asdf-1.1.0` instead](https://github.com/asdf-format/asdf-standard/blob/4e461f3a61e722bad8b4302d9bc52b6503aacbbd/src/asdf_standard/resources/schemas/stsci.edu/asdf/version_map-1.2.0.yaml#L6)). For asdf 3.0 (currently in development and soon to be released), this will result in a warning and the data associated with this tag will be loaded as a `TaggedDict` instead of an `AsdfObject`. Both of these classes act like dictionaries and the use of this file is otherwise unaffected.

This PR adds a filter to ignore the warning which if not ignored can cause the test suite to fail with asdf 3.0 (as warnings are turned into errors) as seen here: https://github.com/asdf-format/asdf/actions/runs/5891427574/job/16013125322#step:10:929

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
