### PR TITLE
switch schema refs that use tag to uris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Other
 
 - Add ``AmiLgFitModel`` class and schema [#199]
 
+- Switch schema refs from tags to equivalent uris [#201]
+
 
 1.8.0 (2023-08-24)
 ==================

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-0.7.0.yaml
@@ -28,7 +28,7 @@ examples:
           model_type: unitless2directional
 
 allOf:
-  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - object:
     properties:
       model_type:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.0.0.yaml
@@ -28,7 +28,7 @@ examples:
           model_type: unitless2directional
 
 allOf:
-  - $ref:  "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - object:
     properties:
       model_type:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-0.7.0.yaml
@@ -30,7 +30,7 @@ examples:
           output: wavelength
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       groove_density:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-0.7.0.yaml
@@ -11,7 +11,7 @@ description: |
   the slit.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       slits:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-0.7.0.yaml
@@ -16,7 +16,7 @@ examples:
           value: .nan
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       condition:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-0.7.0.yaml
@@ -11,7 +11,7 @@ description: |
   that the coordinate belongs to in detector coordinates.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       beta_zero:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-0.7.0.yaml
@@ -9,7 +9,7 @@ description: |
    - given x,y,wave,order in effective direct image return x,y,wave,order in dispersed
    - given x,y,x0,y0,order in dispersed image returns x,y,wave,order in effective direct
 anyOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       xmodels:
@@ -17,19 +17,19 @@ anyOf:
          NIRCAM row dispersion models
         type: array
         items:
-          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       ymodels:
         description: |
           NIRCAM column dispersion models
         type: array
         items:
-          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       lmodels:
         description: |
           NIRCAM wavelength dispersion models
         type: array
         items:
-          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       orders:
         description: |
           NIRCAM available grism orders, in-sync with the model arrays

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-0.7.0.yaml
@@ -9,7 +9,7 @@ description: |
    - given x,y,wave,order in effective direct image return x,y,wave,order in dispersed
    - given x,y,x0,y0,order in dispersed image returns x,y,wave,order in effective direct
 anyOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       theta:
@@ -23,7 +23,7 @@ anyOf:
         items:
           type: array
           items:
-            $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       ymodels:
         description: |
           NIRISS Grism column dispersion model
@@ -31,13 +31,13 @@ anyOf:
         items:
           type: array
           items:
-            $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       lmodels:
         description: |
           NIRISS wavelength-models for dispersion
         type: array
         items:
-          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
       orders:
         description: |
           NIRISS available grism orders, in-sync with the model arrays

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-0.7.0.yaml
@@ -8,7 +8,7 @@ description: |
   It maps spectral orderto to transform
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       spectral_orders:
@@ -22,5 +22,5 @@ allOf:
           A compound model transferring pixel to worlds coordinates.
         type: array
         items:
-          $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
     required: [spectral_orders, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-0.7.0.yaml
@@ -10,7 +10,7 @@ description: |
   index of refraction.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       prism_angle:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-0.7.0.yaml
@@ -9,7 +9,7 @@ description: |
   A sequence of 3D rotations around different axes.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       angles:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-0.7.0.yaml
@@ -9,7 +9,7 @@ description: |
   It maps a slit to its position in the MSA plane.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       slits:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-0.7.0.yaml
@@ -15,7 +15,7 @@ description: |
   - Applies Snell's law through front surface.
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       prism_angle:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/v23tosky-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/v23tosky-0.7.0.yaml
@@ -20,7 +20,7 @@ examples:
           axes_order: zyxyz
 
 allOf:
-  - $ref: "tag:stsci.edu:asdf/transform/transform-1.1.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
   - type: object
     properties:
       angles:


### PR DESCRIPTION
asdf will soon warn for refs that are not uris. This PR changes the few remaining `$ref`s that contain tags to uris.

The tag `tag:stsci.edu:asdf/transform/transform-1.1.0` resolves to `http://stsci.edu/schemas/asdf/transform/transform-1.1.0`. All uses of this tag were replaced with the corresponding uri.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
