### PR TITLE
remove unsupported RTD system_packages setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,6 @@ conda:
   environment: docs/rtd_environment.yaml
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD no longer supports any system_packages setting:
https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused system_packages setting

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
