### PR TITLE
JP-3244: Add dither pointing RA/Dec to schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Other
 
 - Add ``AmiLgFitModel`` class and schema [#199]
 
+- Add ``DITH_RA`` and ``DITH_DEC`` to JWST core schema metadata,
+  to be used in spectral extraction window centering. [#203]
+
 
 1.8.0 (2023-08-24)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -1330,8 +1330,7 @@ properties:
             fits_keyword: MRSPRCHN
           dithered_ra:
             title: RA of dithered pointing location
-            type: float
-            default: 0.0
+            type: number
             fits_keyword: DITH_RA
           dithered_dec:
             title: Dec of dithered pointing location

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -1328,6 +1328,16 @@ properties:
             type: string
             enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4]
             fits_keyword: MRSPRCHN
+          dithered_ra:
+            title: RA of dithered pointing location
+            type: float
+            default: 0.0
+            fits_keyword: DITH_RA
+          dithered_dec:
+            title: Dec of dithered pointing location
+            type: float
+            default: 0.0
+            fits_keyword: DITH_DEC
       ephemeris:
         title: JWST ephemeris information
         type: object

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -1335,8 +1335,7 @@ properties:
             fits_keyword: DITH_RA
           dithered_dec:
             title: Dec of dithered pointing location
-            type: float
-            default: 0.0
+            type: number
             fits_keyword: DITH_DEC
       ephemeris:
         title: JWST ephemeris information


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3244](https://jira.stsci.edu/browse/JP-3244)

<!-- describe the changes comprising this PR here -->
This PR addresses issues in extraction window centering for MIRI LRS fixed slit observations. Target RA/Dec information is not necessarily accurate, and an alternative was desired. The dither offset from slit center is a known and fixed quantity - we can use this with the transforms and wcsinfo metadata to store the RA/Dec of the dither offset position for extraction centering. It must be stored rather than calculated on the fly because the WCS frames necessary for calculation from existing metadata no longer exist after the product is resampled, prior to extraction.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
