### PR TITLE
TEST: remove uses of FITS_rec in memory

### DIFF
--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -44,6 +44,9 @@ def _cast(val, schema):
         if isinstance(val, ndarray.NDArrayType):
             val = val._make_array()
 
+        if isinstance(val, fits.FITS_rec):
+            val = val.view(np.ndarray)
+
         allow_extra_columns = False
         if (_is_struct_array_schema(schema) and len(val) and
             (_is_struct_array_precursor(val) or _is_struct_array(val))):
@@ -85,8 +88,8 @@ def _cast(val, schema):
         dtype = ndarray.asdf_datatype_to_numpy_dtype(schema['datatype'])
         val = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
 
-        if dtype.fields is not None:
-            val = _as_fitsrec(val)
+        #if dtype.fields is not None:
+        #    val = _as_fitsrec(val)
 
     if 'ndim' in schema and len(val.shape) != schema['ndim']:
         raise ValueError(

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -329,3 +329,14 @@ def rebuild_fits_rec_dtype(fits_rec):
         else:
             new_dtype.append((field_name, table_dtype))
     return np.dtype((np.record, new_dtype))
+
+
+def _fits_rec_to_array(fits_rec):
+    new_dtype = rebuild_fits_rec_dtype(fits_rec)
+    if new_dtype == fits_rec.dtype:
+        return fits_rec.view(np.ndarray)
+    arr = np.asarray(fits_rec, new_dtype)
+    for name in fits_rec.dtype.fields:
+        if new_dtype != fits_rec.dtype[name]:
+            arr[name] = fits_rec[name]
+    return arr

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -146,6 +146,7 @@ def _check_value(value, schema, ctx):
         value = remove_none_from_tree(value)
         value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
 
+
         if ctx._validate_arrays:
             validators = _VALIDATORS
         else:

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -322,12 +322,12 @@ def test_table_with_unsigned_int(tmp_path):
         test_table = np.array(list(zip(float64_arr, uint32_arr)), dtype=dm.test_table.dtype)
 
         def assert_table_correct(model):
-            for idx, (col_name, col_data) in enumerate([('float64_col', float64_arr), ('uint32_col', uint32_arr)]):
+            for idx, (col_name, col_data) in enumerate([('FLOAT64_COL', float64_arr), ('UINT32_COL', uint32_arr)]):
                 # The table dtype and field dtype are stored separately, and may not
                 # necessarily agree.
                 assert np.can_cast(model.test_table.dtype[idx], col_data.dtype, 'equiv')
-                assert np.can_cast(model.test_table.field(col_name).dtype, col_data.dtype, 'equiv')
-                assert np.array_equal(model.test_table.field(col_name), col_data)
+                assert np.can_cast(model.test_table[col_name].dtype, col_data.dtype, 'equiv')
+                assert np.array_equal(model.test_table[col_name], col_data)
 
         # The datamodel casts our array to FITS_rec on assignment, so here we're
         # checking that the data survived the casting.
@@ -657,9 +657,9 @@ def test_table_linking(tmp_path):
     with DataModel(schema=schema) as dm:
         test_array = np.array([(1, 2), (3, 4)], dtype=[('A_COL', 'i1'), ('B_COL', 'i1')])
 
-        # assigning to the model will convert the array to a FITS_rec
+        # assigning to the model should not convert the array to a FITS_rec
         dm.test_table = test_array
-        assert isinstance(dm.test_table, fits.FITS_rec)
+        assert not isinstance(dm.test_table, fits.FITS_rec)
 
         # save the model (with the table)
         dm.save(file_path)


### PR DESCRIPTION
This is a test PR. The modifications haphazardly remove use of FITS_rec in memory. The eventual goal is to remove it's usage which will almost certainly require updates to jwst. So far, this test PR aims to hack out FITS_rec to run jwst tests and regtests to find what code relies on FITS_rec.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
