### PR TITLE
Safely convert fitsrec in tree before serializing with asdf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Other
 - Change format of the MirMrsPtCorrModel to use a 1d reference table
   instead of 2d FITS image extensions [#196]
 
+- Convert ``FITS_rec`` instances to arrays before serializing or
+  validating with asdf [#205]
+
 
 1.8.0 (2023-08-24)
 ==================

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -775,7 +775,8 @@ def _map_hdulist_to_arrays(hdulist, af):
             data = hdulist[pair].data
             return data
         return node
-    af.tree = treeutil.walk_and_modify(af.tree, callback)
+    # don't assign to af.tree to avoid an extra validation
+    af._tree = treeutil.walk_and_modify(af.tree, callback)
 
 
 def from_fits_hdu(hdu, schema, cast_arrays=True):

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -11,7 +11,7 @@ from asdf.schema import YAML_VALIDATORS
 from asdf.util import HashableDict
 import numpy as np
 
-from .util import remove_none_from_tree
+from .util import convert_fitsrec_to_array_in_tree, remove_none_from_tree
 
 
 class ValidationWarning(Warning):
@@ -144,6 +144,7 @@ def _check_value(value, schema, ctx):
         # converting to tagged tree, so that we don't have to descend unnecessarily
         # into nodes for custom types.
         value = remove_none_from_tree(value)
+        value = convert_fitsrec_to_array_in_tree(value)
         value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
 
         if ctx._validate_arrays:


### PR DESCRIPTION
Prior to asdf 3.0, `FITS_rec` (a subclass of ndarray) was serialized like an ndarray. In asdf 3.0, this will result in a warning:
```
asdf.exceptions.AsdfConversionWarning: A ndarray subclass (<class 'astropy.io.fits.fitsrec.FITS_rec'>) was converted as a ndarray. This behavior will be removed from a future version of ASDF. See https://asdf.readthedocs.io/en/latest/asdf/config.html#convert-unknown-ndarray-subclasses
```
This is done out of abundance of caution for oddities that can occur when treating `FITS_rec` like an `ndarray`. See below for an example.

There are many places where stdatamodels passes a `FITS_rec`to asdf in a way that is unaware of these oddities (see this run log for a full list of warnings that will appear when asdf 3.0 is released or if testing stdatamodels against current asdf main: https://github.com/asdf-format/asdf/actions/runs/6088051343/job/16588221134)

This PR converts all `FITS_rec` instances to `ndarray` instances prior to asdf serialization/validation. The conversion is done using a new method `_fits_rec_to_array` which corrects columns containing unsigned integers.

Example of where treating `FITS_rec` like a `ndarray` can be problematic
------
```python
from astropy.io import fits
import numpy as np

arr = np.zeros([6], dtype=[('a', 'uint32')])
arr['a'] = np.arange(6)

h = fits.HDUList()
h.append(fits.PrimaryHDU())
h.append(fits.BinTableHDU())
h[-1].data = arr
h.writeto('foo.fits', overwrite=True)

with fits.open('foo.fits') as ff:
    print(ff[-1].data)
    print(ff[-1].data.view(np.ndarray))
```
Produces invalid data in the view created from the `FITS_rec`.
```
[(          0,) (          1,) (          2,) (          3,)
 (          4,) (          5,)]
[(-2147483648,) (-2147483647,) (-2147483646,) (-2147483645,)
 (-2147483644,) (-2147483643,)]
```

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
