### PR TITLE
remove redundant check in rebuild_fits_rec_dtype

### DIFF
--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -333,7 +333,7 @@ def rebuild_fits_rec_dtype(fits_rec):
     for field_name in dtype.fields:
         table_dtype = dtype[field_name]
         field_dtype = fits_rec.field(field_name).dtype
-        if np.issubdtype(table_dtype, np.signedinteger) and np.issubdtype(field_dtype, np.unsignedinteger):
+        if np.issubdtype(field_dtype, np.unsignedinteger):
             new_dtype.append((field_name, field_dtype))
         else:
             new_dtype.append((field_name, table_dtype))


### PR DESCRIPTION
unsigned integers are unsupported by FITS and will be saved as signed integers with an offset (by astropy) so there is no need to check that the stored type is signed if the dtype presented to the user is unsigned.

Fixes #206 

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
