### PR TITLE
enable devdeps testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           python-version: 3.11
         - linux: test-xdist-cov
           coverage: codecov
+        - linux: test-xdist-devdeps
+          python-version: 3.11
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ crds ]
@@ -84,3 +86,4 @@ jobs:
       cache-key: crds-${{ needs.crds.outputs.context }}
       envs: |
         - linux: test-jwst-xdist-cov
+        - linux: test-jwst-xdist-devdeps

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+git+https://github.com/astropy/asdf-astropy
+git+https://github.com/asdf-format/asdf
+
+# Use weekly astropy dev build
+--extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+
+# Use Bi-weekly numpy/scipy dev builds
+--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+numpy>=0.0.dev0
+# even though we don't need scipy some deps might and it's version is tightly linked to numpy
+scipy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-jwst,-devdeps}-xdist{,-cov}
+    test{,-jwst}{,-devdeps}-xdist{,-cov}
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)
@@ -37,7 +37,6 @@ description =
 pass_env =
     CRDS_*
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     cov: COVERAGE_RC_FILE=pyproject.toml
 extras =
     test
@@ -50,7 +49,7 @@ package=
     cov: editable
     !cov: wheel
 commands_pre =
-    devdeps: pip install numpy>=0.0.dev0 git+https://github.com/astropy/astropy -U --upgrade-strategy eager
+    devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
     pip freeze
 commands =
     pytest \


### PR DESCRIPTION
This PR enables devdeps testing in github actions allowing us to run tests against numpy 2.0 and other development versions of some key dependencies.

`requirements-dev.txt` is added, listing several key dependencies (asdf, astropy, asdf-astropy numpy) and configuring pip to install development versions (either from git or from available built development versions). scipy is not a direct dependency of stdatmodels but is installed in `requirements-dev.txt` as it's unlikely the development version of numpy will work with the released scipy.

`tox.ini` required minor updates to use the new `requirements-dev.txt` (an existing `devdeps` environment was already configured).

`ci.yml` was updated to run the `devdeps` tox environment which appears as `test-devdeps-xdist`. See a run triggered by this PR: https://github.com/spacetelescope/stdatamodels/actions/runs/6150774039/job/16689450474?pr=208

`test-jwst-devdeps-xdist` is also run (jwst tests are run in the CI and contribute to stdatamodels coverage due to a large part of stdatamodels.jwst coming directly from jwst). However these tests are more likely to fail due to extra dependencies included for jwst.


**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
