### PR TITLE
fix numpy scalar handling in RefractionIndexFromPrism

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ Changes to API
 Other
 -----
 
-- 
+- Update ``RefractionIndexFromPrism`` converting single element ndarrays
+  to scalar values before use to avoid ``DeprecationWarning``s introduced
+  in numpy 1.25 [#210]
+
 
 1.8.1 (2023-09-13)
 ==================

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -229,8 +229,10 @@ class RefractionIndexFromPrism(Model):
         self.outputs = ("n",)
 
     def evaluate(self, alpha_in, beta_in, alpha_out, prism_angle):
-        sangle = (math.sin(prism_angle))
-        cangle = (math.cos(prism_angle))
+        if isinstance(prism_angle, np.ndarray) and prism_angle.ndim == 1 and prism_angle.size == 1:
+            prism_angle = prism_angle[0]
+        sangle = np.sin(prism_angle)
+        cangle = np.cos(prism_angle)
         nsq = ((alpha_out + alpha_in * (1 - 2 * sangle ** 2)) / (2 * sangle * cangle)) ** 2 + \
             alpha_in ** 2 + beta_in ** 2
         return np.sqrt(nsq)

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -229,10 +229,9 @@ class RefractionIndexFromPrism(Model):
         self.outputs = ("n",)
 
     def evaluate(self, alpha_in, beta_in, alpha_out, prism_angle):
-        if isinstance(prism_angle, np.ndarray) and prism_angle.ndim == 1 and prism_angle.size == 1:
-            prism_angle = prism_angle[0]
-        sangle = np.sin(prism_angle)
-        cangle = np.cos(prism_angle)
+        # prism_angle is always a 1 element numpy array
+        sangle = math.sin(prism_angle.item())
+        cangle = math.cos(prism_angle.item())
         nsq = ((alpha_out + alpha_in * (1 - 2 * sangle ** 2)) / (2 * sangle * cangle)) ** 2 + \
             alpha_in ** 2 + beta_in ** 2
         return np.sqrt(nsq)


### PR DESCRIPTION
As shown in jwst tests fixing numpy 2.0 deprecations there are a few deprecations from numpy 1.25 that are not yet addressed:
https://github.com/spacetelescope/jwst/actions/runs/6198454984/job/16828931603#step:10:459

A few of these are from code in stdatamodels file `RefractionIndexFromPrism`. ~These warnings are not seen in the stdatamodels CI as not all jwst tests are currently run.~ These warnings can also be seen in our `test_downstream` runs:
https://github.com/spacetelescope/stdatamodels/actions/runs/6175840080/job/16763536280#step:10:1995

This PR updates `RefractionIndexFromPrism` to convert single element ndarrays to scalars before computing sin cos to avoid deprecation warning:

DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)


**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
