### PR TITLE
reorganize tests, make devdeps testing optional, unpin latest Python testing, and prepare for possibility of data caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: tests
+name: test
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: tests
 
 on:
   push:
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  crds:
+  data:
     name: retrieve current CRDS context
     runs-on: ubuntu-latest
     env:
@@ -26,7 +26,7 @@ jobs:
       CRDS_PATH: /tmp/crds_cache
       CRDS_SERVER_URL: https://jwst-crds.stsci.edu
     steps:
-      - id: context
+      - id: crds_context
         run: >
           echo "pmap=$(
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
@@ -34,56 +34,49 @@ jobs:
           )" >> $GITHUB_OUTPUT
         # Get default CRDS_CONTEXT without installing crds client
         # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
-      - id: path
+      - id: crds_path
         run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
-      - id: server
+      - id: crds_server
         run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
     outputs:
-      context: ${{ steps.context.outputs.pmap }}
-      path: ${{ steps.path.outputs.path }}
-      server: ${{ steps.server.outputs.url }}
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
   check:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
         - linux: check-style
         - linux: check-security
         - linux: build-dist
   test:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-    needs: [ crds ]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ data ]
     with:
       setenv: |
-        CRDS_PATH: ${{ needs.crds.outputs.path }}
-        CRDS_SERVER_URL: ${{ needs.crds.outputs.server }}
+        CRDS_PATH: ${{ needs.data.outputs.crds_path }}
+        CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-      cache-path: ${{ needs.crds.outputs.path }}
-      cache-key: crds-${{ needs.crds.outputs.context }}
+      cache-path: ${{ needs.data.outputs.crds_path }}
+      cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: test-xdist
-          python-version: 3.9
-        - linux: test-xdist
-          python-version: 3.10
-        - linux: test-xdist
-          python-version: 3.11
-        - macos: test-xdist
-          python-version: 3.11
-        - linux: test-xdist-cov
+        - linux: py39-xdist
+        - linux: py310-xdist
+        - linux: py311-xdist
+        - macos: py311-xdist
+        - linux: py3-xdist-cov
           coverage: codecov
-        - linux: test-xdist-devdeps
-          python-version: 3.11
   test_downstream:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-    needs: [ crds ]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ data ]
     with:
       setenv: |
-        CRDS_PATH: ${{ needs.crds.outputs.path }}
-        CRDS_SERVER_URL: ${{ needs.crds.outputs.server }}
+        CRDS_PATH: ${{ needs.data.outputs.crds_path }}
+        CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-      cache-path: ${{ needs.crds.outputs.path }}
-      cache-key: crds-${{ needs.crds.outputs.context }}
+      cache-path: ${{ needs.data.outputs.crds_path }}
+      cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: test-jwst-xdist-cov
-        - linux: test-jwst-xdist-devdeps
+        - linux: py3-jwst-xdist-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         - linux: py310-xdist
         - linux: py311-xdist
         - macos: py311-xdist
-        - linux: py3-xdist-cov
+        - linux: py3-cov-xdist
           coverage: codecov
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
@@ -79,4 +79,4 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py3-jwst-xdist-cov
+        - linux: py3-jwst-cov-xdist

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   data:
+    if: (github.repository == 'spacetelescope/stdatamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
     name: retrieve current CRDS context
     runs-on: ubuntu-latest
     env:
@@ -36,6 +37,7 @@ jobs:
       crds_path: ${{ steps.crds_path.outputs.path }}
       crds_server: ${{ steps.crds_server.outputs.url }}
   test:
+    if: (github.repository == 'spacetelescope/stdatamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     needs: [ data ]
     with:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -38,7 +38,7 @@ jobs:
       crds_server: ${{ steps.crds_server.outputs.url }}
   test:
     if: (github.repository == 'spacetelescope/stdatamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run scheduled tests')))
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     needs: [ data ]
     with:
       setenv: |

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -2,7 +2,7 @@ name: test on schedule
 
 on:
   schedule:
-    # Weekly Monday 6AM build
+    # Weekly Monday midnight build
     - cron: "0 0 * * 1"
   workflow_dispatch:
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,4 +1,4 @@
-name: scheduled tests
+name: test on schedule
 
 on:
   schedule:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   data:
+    if: (github.repository == 'spacetelescope/stdatamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     name: retrieve current CRDS context
     runs-on: ubuntu-latest
     env:
@@ -43,6 +44,7 @@ jobs:
       crds_path: ${{ steps.crds_path.outputs.path }}
       crds_server: ${{ steps.crds_server.outputs.url }}
   test:
+    if: (github.repository == 'spacetelescope/stdatamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run devdeps tests')))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     needs: [ data ]
     with:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -1,4 +1,4 @@
-name: tests with development versions
+name: test with development versions
 
 on:
   push:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -12,6 +12,7 @@ on:
     # Weekly Monday 9AM build
     # * is a special character in YAML so you have to quote this string
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -1,10 +1,17 @@
-name: scheduled tests
+name: tests with development versions
 
 on:
+  push:
+    branches:
+      - master
+      - '*.x'
+    tags:
+      - '*'
+  pull_request:
   schedule:
-    # Weekly Monday 6AM build
-    - cron: "0 0 * * 1"
-  workflow_dispatch:
+    # Weekly Monday 9AM build
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 9 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +43,7 @@ jobs:
       crds_path: ${{ steps.crds_path.outputs.path }}
       crds_server: ${{ steps.crds_server.outputs.url }}
   test:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     needs: [ data ]
     with:
       setenv: |
@@ -47,9 +54,17 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - macos: py39-xdist
-        - windows: py39-xdist
-        - macos: py310-xdist
-        - windows: py310-xdist
-        - windows: py311-xdist
-        - windows: py3-xdist
+        - linux: py3-devdeps-xdist
+  test_downstream:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ data ]
+    with:
+      setenv: |
+        CRDS_PATH: ${{ needs.data.outputs.crds_path }}
+        CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+      cache-path: ${{ needs.data.outputs.crds_path }}
+      cache-key: crds-${{ needs.data.outputs.crds_context }}
+      envs: |
+        - linux: py3-jwst-devdeps-xdist


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-79](https://jira.stsci.edu/browse/SCSB-79)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR reorganizes CI tests and moves devdeps tests to a new optional workflow that can be started with the label `run devdeps tests`

**Checklist**
- [x] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [x] updated relevant tests
- [x] ~updated relevant documentation~
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
