### PR TITLE
fix pull request triggers for optional workflows

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     # Weekly Monday midnight build
     - cron: "0 0 * * 1"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -8,6 +8,12 @@ on:
     tags:
       - '*'
   pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
   schedule:
     # Weekly Monday 9AM build
     # * is a special character in YAML so you have to quote this string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses an issue where labeling a pull request does not trigger the `devdeps` workflow (see #210).

**Checklist**
- [x] ~added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)~
- [x] ~updated relevant tests~
- [x] ~updated relevant documentation~
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
