### PR TITLE
fix rebuild_fits_rec_dtype for shaped columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Bug Fixes
 
 - Fixed ``ValidationError`` during ``AmiOIModel.update`` [#234]
 
+- Fix ``rebuild_fits_rec_dtype`` handling of unsigned integer columns
+  with shapes [#213]
+
 Changes to API
 --------------
 

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -333,11 +333,14 @@ def rebuild_fits_rec_dtype(fits_rec):
     new_dtype = []
     for field_name in dtype.fields:
         table_dtype = dtype[field_name]
+        shape = table_dtype.shape
+        if shape:
+            table_dtype = table_dtype.base
         field_dtype = fits_rec.field(field_name).dtype
         if np.issubdtype(table_dtype, np.signedinteger) and np.issubdtype(field_dtype, np.unsignedinteger):
-            new_dtype.append((field_name, field_dtype))
+            new_dtype.append((field_name, field_dtype, shape))
         else:
-            new_dtype.append((field_name, table_dtype))
+            new_dtype.append((field_name, table_dtype, shape))
     return np.dtype((np.record, new_dtype))
 
 


### PR DESCRIPTION
`stdatamodels.util.rebuild_fits_rec_dtype` appears to incorrectly handle unsigned integer columns with shapes. This PR updates `rebuild_fits_rec_dtype` and adds tests for this error.

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/stdatamodels/issues/206

Regression tests run with no errors: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/963/pipeline

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
