### PR TITLE
deprecate cast_fits_array and cast_arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Bug Fixes
 Changes to API
 --------------
 
--
+- Deprecate ``cast_arrays`` argument to ``from_fits_hdu`` and
+  ``cast_fits_arrays`` argument to ``Datamodel.__init__`` [#214]
 
 Other
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Bug Fixes
 Changes to API
 --------------
 
-- 
+- Deprecate ``cast_arrays`` argument to ``from_fits_hdu`` and
+  ``cast_fits_arrays`` argument to ``Datamodel.__init__`` [#214]
 
 Other
 -----
@@ -31,9 +32,6 @@ Bug Fixes
 
 Changes to API
 --------------
-
-- Deprecate ``cast_arrays`` argument to ``from_fits_hdu`` and
-  ``cast_fits_arrays`` argument to ``Datamodel.__init__`` [#214]
 
 - Sort keyword files used for schema_editor to make output non-arbitrary
   copy schema before merging to avoid schema modification [#227]

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -772,10 +772,14 @@ def _map_hdulist_to_arrays(hdulist, af):
     af._tree = treeutil.walk_and_modify(af.tree, callback)
 
 
-def from_fits_hdu(hdu, schema, cast_arrays=True):
+def from_fits_hdu(hdu, schema, cast_arrays=None):
     """
     Read the data from a fits hdu into a numpy ndarray
     """
+    if cast_arrays is not None:
+        warnings.warn("cast_arrays is deprecated and will be removed")
+    else:
+        cast_arrays = True
     data = hdu.data
 
     if cast_arrays:

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -79,11 +79,6 @@ def open(init=None, guess=True, memmap=False, **kwargs):
 
         - FITS
 
-           cast_fits_arrays : bool
-             If `True`, arrays will be cast to the dtype described by the schema
-             when read from a FITS file.
-             If `False`, arrays will be read without casting.
-
            skip_fits_update :  bool or None
               `True` to skip updating the ASDF tree from the FITS headers, if possible.
               If `None`, value will be taken from the environmental SKIP_FITS_UPDATE.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -63,7 +63,7 @@ class DataModel(properties.ObjectNode):
 
     def __init__(self, init=None, schema=None, memmap=False,
                  pass_invalid_values=None, strict_validation=None,
-                 validate_on_assignment=None, cast_fits_arrays=True,
+                 validate_on_assignment=None, cast_fits_arrays=None,
                  validate_arrays=False, ignore_missing_extensions=True, **kwargs):
         """
         Parameters
@@ -158,7 +158,11 @@ class DataModel(properties.ObjectNode):
         self._strict_validation = strict_validation
         self._ignore_missing_extensions = ignore_missing_extensions
         self._validate_on_assignment = validate_on_assignment
-        self._cast_fits_arrays = cast_fits_arrays
+        if cast_fits_arrays is not None:
+            warnings.warn("cast_fits_array is deprecated and will be removed", DeprecationWarning)
+            self._cast_fits_arrays = cast_fits_arrays
+        else:
+            self._cast_fits_arrays = None
         self._validate_arrays = validate_arrays
 
         kwargs.update({'ignore_missing_extensions': ignore_missing_extensions})

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -592,8 +592,15 @@ def test_ndarray_validation(tmp_path):
 
     # But raise an error when casting is disabled
     with pytest.raises(ValidationError, match="Array datatype 'float64' is not compatible with 'float32'"):
-        with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
-            model.validate()
+        # also warn due to the cast_fits_array deprecation
+        with pytest.warns(DeprecationWarning, match="cast_fits_array"):
+            with FitsModel(
+                file_path,
+                strict_validation=True,
+                cast_fits_arrays=False,
+                validate_arrays=True,
+            ) as model:
+                model.validate()
 
     # Wrong dimensions
     hdu = fits.ImageHDU(data=np.ones((4,), dtype=np.float64), name="SCI")
@@ -607,8 +614,10 @@ def test_ndarray_validation(tmp_path):
 
     # Should also be caught by validation
     with pytest.raises(ValidationError, match="Wrong number of dimensions: Expected 2, got 1"):
-        with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
-            model.validate()
+        # also warn due to the cast_fits_array deprecation
+        with pytest.warns(DeprecationWarning, match="cast_fits_array"):
+            with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
+                model.validate()
 
 
 def test_resave_duplication_bug(tmp_path):


### PR DESCRIPTION
Deprecate `cast_arrays` argument to `from_fits_hdu` and `cast_fits_arrays` argument to `Datamodel.__init__`.

These appear to be unused (outside of the `test_ndarray_validation` test). Deprecating (and eventually removing them) is work towards removing uses of `FITS_rec`.

Regression tests show 2 seemingly unrelated errors and no `DeprecationWarning` with the message introduced in this PR (so no code in the regression tests uses `cast_arrays` or `cast_fits_arrays`): https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/964/

The errors are:
```
[stable-deps] test_nirspec_missing_msa_fail – jwst.regtest.test_nirspec_exceptions3s
[stable-deps] test_nirspec_missing_msa_nofail – jwst.regtest.test_nirspec_exceptions
```
Both with similar failed asserts
```
AssertionError: assert 'Missing MSA meta (MSAMETFL) file' in 'INFO     stpipe.Spec2Pipeline:log_config.py:159 Spec2Pipeline instance created.\nINFO     stpipe.Spec2Pipeline.bkg_su...ng processing for this exposure.\nERROR    stpipe.Spec2Pipeline:log_config.py:159 No output product will be created.\n'

AssertionError: assert 'Missing MSA meta (MSAMETFL) file' in 'INFO     stpipe.Spec2Pipeline:log_config.py:159 Spec2Pipeline instance created.\nINFO     stpipe.Spec2Pipeline.bkg_su...line:log_config.py:159 Ending calwebb_spec2\nINFO     stpipe.Spec2Pipeline:log_config.py:159 Step Spec2Pipeline done\n'
```

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
