### PR TITLE
remove use of pkg_resources

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -3,7 +3,6 @@ from functools import partial
 import hashlib
 import inspect
 import io
-from pkg_resources import parse_version
 import re
 import warnings
 import weakref
@@ -37,9 +36,6 @@ __all__ = ['to_fits', 'from_fits', 'fits_hdu_name', 'get_hdu', 'is_builtin_fits_
 _ASDF_EXTENSION_NAME = "ASDF"
 _FITS_SOURCE_PREFIX = "fits:"
 _NDARRAY_TAG = "tag:stsci.edu:asdf/core/ndarray-1.0.0"
-
-_ASDF_GE_2_6 = parse_version(asdf.__version__) >= parse_version('2.6')
-
 
 _builtin_regexes = [
     '', 'NAXIS[0-9]{0,3}', 'BITPIX', 'XTENSION', 'PCOUNT', 'GCOUNT',
@@ -372,10 +368,7 @@ def _save_from_schema(hdulist, tree, schema):
 
     tree = treeutil.walk_and_modify(tree, datetime_callback)
 
-    if _ASDF_GE_2_6:
-        kwargs = {"_visit_repeat_nodes": True}
-    else:
-        kwargs = {}
+    kwargs = {"_visit_repeat_nodes": True}
 
     validators, context = _get_validators(hdulist)
     validator = asdf_schema.get_validator(schema, None, validators, **kwargs)


### PR DESCRIPTION
pkg_resources is deprecated. It's use in stdatamodels is limited to parsing the asdf version to check if it's at least 2.6. The pyproject.toml dependencies set a lower pin on asdf version 2.15.0 making the check in the code unnecessary:
https://github.com/spacetelescope/stdatamodels/blob/27c397415ad2d96a1149f492b7906c49862fc7c2/pyproject.toml#L15

This PR removes the use of pkg_resources.

This is causing issues for 3.12 testing as seen in: https://github.com/spacetelescope/stdatamodels/pull/216

Regression tests passed with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/967/

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
