### PR TITLE
add band to GainModel schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Other
   to scalar values before use to avoid ``DeprecationWarning``s introduced
   in numpy 1.25 [#210]
 
+- Add band to ``GainModel`` schema to account for miri crds file updates
+  [#219]
+
 
 1.8.1 (2023-09-13)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/gain.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/gain.schema.yaml
@@ -5,6 +5,7 @@ id: "http://stsci.edu/schemas/jwst_datamodel/gain.schema"
 allOf:
 - $ref: referencefile.schema
 - $ref: subarray.schema
+- $ref: keyword_band.schema
 - $ref: keyword_gainfact.schema
 - $ref: keyword_filter.schema
 - $ref: bunit.schema


### PR DESCRIPTION
Miri gain files on CRDS now contain the `BAND` keyword.

This PR adds a reference to `keyword_band.schema` to `gain.schema`.

It is not clear to me if at this point the miri gain files should be handled by a more specific schema for the following reasons:
- https://jira.stsci.edu/browse/CRDS-730 mentions a range of possible values, these are a subset but not a match of those defined in`keyword_band.schema` (one example `keyword_band.schema` lists `MEDIUM` which is not listed in the ticket)
- my cursory understanding is that `gain.schema`, used for `GainModel`, is used for all `gain` reference files on crds. There are `gain` files for: `fgs`, `miri`, `nircam`, `niriss` and `nirspec`. Not all of these use the `BAND` keyword and not all of these use the `FILTER` keyword. Although apparently not required by the schema this does mean that adding a `ref` to `keyword_band.schema` means the `GainModel` instances for all of these files will now have a `model.meta.instrument.band` attribute

Regression tests run with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/968/

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
