### PR TITLE
add channel to miri apcorr schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changes to API
 Other
 -----
 
--
+- Add ``channel`` keyword to MIRI MRS AP corr schema [#224]
 
 1.8.2 (2023-09-26)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changes to API
 Other
 -----
 
-- Add ``channel`` keyword to MIRI MRS AP corr schema [#224]
+- Add ``channel`` keyword to MIRI MRS Apcorr schema [#224]
 
 1.8.2 (2023-09-26)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/mirmrs_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirmrs_apcorr.schema.yaml
@@ -5,6 +5,7 @@ id: "http://stsci.edu/schemas/jwst_datamodel/mirmrs_apcorr.schema"
 title: MIRI MRS aperture correction data model
 allOf:
 - $ref: referencefile.schema
+- $ref: keyword_channel.schema
 - $ref: keyword_exptype.schema
 - $ref: keyword_pexptype.schema
 - type: object


### PR DESCRIPTION
MIRI MRS AP corr files on CRDS now contain a `META.INSTRUMENT.CHANNEL` parameter. 

https://jwst-crds.stsci.edu/browse/jwst_miri_apcorr_0007.asdf

This PR adds the corresponding keyword to the MIRI MRS AP corr schema to keep things in sync and fix the failing test that compares the crds parameters to the schema.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
