### PR TITLE
update CI for python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,10 @@ jobs:
       envs: |
         - linux: py39-xdist
         - linux: py310-xdist
-        - linux: py311-xdist
         - macos: py311-xdist
-        - linux: py3-cov-xdist
+        - linux: py311-cov-xdist
           coverage: codecov
+        - linux: py312-xdist
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     needs: [ data ]
@@ -78,4 +78,4 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py3-jwst-cov-xdist
+        - linux: py311-jwst-cov-xdist

--- a/.github/workflows/test_devdeps.yml
+++ b/.github/workflows/test_devdeps.yml
@@ -76,4 +76,4 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py3-jwst-devdeps-xdist
+        - linux: py311-jwst-devdeps-xdist


### PR DESCRIPTION
`3.x` is now using python 3.12 (instead of python 3.11). This PR updates the CI to use python 3.11 for coverage and jwst jobs

As this PR changes require CI jobs the branch protection rules will need to be updated.

As this PR only changes CI configuration regression tests were not run.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
