### PR TITLE
replace utcnow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Other
 
 - Add mrsptcorr ref_file to core.schema [#228]
 
+- Replace uses of ``utcnow`` (deprecated in python 3.12) [#231] 
+
 - Updated JWST MIRI imager photom model to include time-dependent correction
   coeffs. [#235]
 

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -227,9 +227,10 @@ def create_history_entry(description, software=None):
     elif software is not None:
         software = Software(software)
 
+    dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     entry = HistoryEntry({
         'description': description,
-        'time': datetime.datetime.utcnow()
+        'time': dt
     })
 
     if software is not None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -259,7 +259,8 @@ def test_create_history_entry():
     assert isinstance(entry, HistoryEntry)
     assert entry["description"] == "Once upon a time..."
     assert entry.get("software") is None
-    assert (datetime.utcnow() - entry["time"]) < timedelta(seconds=10)
+    dt = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert (dt - entry["time"]) < timedelta(seconds=10)
 
     software = {"name": "PolarBearSoft", "version": "1.2.3"}
     entry = util.create_history_entry("There was a tie-dyed polar bear...", software)


### PR DESCRIPTION
updates use of `utcnow` (deprecated in python 3.12) with an equivalent call that returns a non-timezone aware utc timestamp

Regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1023/

Showed the expected niriss failures due to crds file updates and also showed 2 failures:
- test_nirspec_missing_msa_fail
- test_nirspec_missing_msa_nofail

As these tests appear to sometimes fail (possibly due to test ordering or io buffering) they were re-run in another test run:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1026/pipeline/199
where they both passed.

This PR removes one of the python 3.12 failures:
```
FAILED tests/test_util.py::test_create_history_entry - DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled ...
```
see in a CI run on main:
https://github.com/spacetelescope/stdatamodels/actions/runs/6669314479/job/18126824996
but not seen in the CI run for this PR:
https://github.com/spacetelescope/stdatamodels/actions/runs/6669380674/job/18127057458?pr=231

The remaining failures are due to crds use of `ast.Str`: https://github.com/spacetelescope/crds/issues/1000
The crds issues are addressed in: https://github.com/spacetelescope/crds/pull/1007
and a test PR with the changes in this PR and crds shows passing python 3.12 unit tests in stdatamodels: https://github.com/spacetelescope/stdatamodels/pull/233

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
