### PR TITLE
allow control of memmapping for asdf files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Changes to API
 - Deprecate ``cast_arrays`` argument to ``from_fits_hdu`` and
   ``cast_fits_arrays`` argument to ``Datamodel.__init__`` [#214]
 
+- Use ``DataModel.__init__`` ``memmap`` argument when opening ASDF
+  files [#232]
+
 Other
 -----
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -94,8 +94,7 @@ class DataModel(properties.ObjectNode):
             will be used.
 
         memmap : bool
-            Turn memmap of FITS file on or off.  (default: False).  Ignored for
-            ASDF files.
+            Turn memmap of FITS/ASDF file on or off.  (default: False).
 
         pass_invalid_values : bool or None
             If `True`, values that do not validate the schema
@@ -244,6 +243,8 @@ class DataModel(properties.ObjectNode):
                 )
 
             elif file_type == "asdf":
+                # use memmap argument of "copy_arrays" was not defined
+                kwargs["copy_arrays"] = kwargs.get("copy_arrays", not memmap)
                 asdffile = self.open_asdf(init=init, **kwargs)
 
             else:
@@ -575,7 +576,8 @@ class DataModel(properties.ObjectNode):
         if isinstance(init, str):
             asdffile = asdf.open(init,
                                  ignore_version_mismatch=ignore_version_mismatch,
-                                 ignore_unrecognized_tag=ignore_unrecognized_tag)
+                                 ignore_unrecognized_tag=ignore_unrecognized_tag,
+                                 **kwargs)
 
         else:
             asdffile = AsdfFile(init,


### PR DESCRIPTION
This PR allows control of memory mapping when opening an asdf file using `DataModel(asdf_filename)`. Control of memory mapping already exists for FITS files (through the `memmap` argument which is reused here).

asdf is making a few changes to memory mapping. This PR will help to prepare stdatamodels for those changes. Specifically, asdf will no longer force closure of memory mapped view of arrays (which can and often results in a segfault when an array access fails during an attempt to access the closed file). Instead, asdf will release all references to the opened memory map and rely on the garbage collector to close the file (see this asdf PR for more details: https://github.com/asdf-format/asdf/pull/1668). This works in most situations but is complicated in a few stdatamodels tests which test for the number of open files without first destroying the model. This PR (by using the default `memmap=False`) allows the effected tests to pass as they no longer use memory mapping.

Regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1025/
show only existing 8 unrelated failures (due to niriss crds file updates).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
