### PR TITLE
map JWST to OIFITS keywords prior to validate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Bug Fixes
 ---------
 
--
+- Fixed ``ValidationError`` during ``AmiOIModel.update`` [#234]
 
 Changes to API
 --------------
@@ -14,7 +14,7 @@ Changes to API
 Other
 -----
 
-- Add mrsptcorr ref_file to core.schema [#228] 
+- Add mrsptcorr ref_file to core.schema [#228]
 
 1.8.3 (2023-10-02)
 ==================

--- a/src/stdatamodels/jwst/datamodels/amioi.py
+++ b/src/stdatamodels/jwst/datamodels/amioi.py
@@ -17,9 +17,7 @@ class AmiOIModel(JwstDataModel):
         # for the example file OI_T3 is the largest array
         return 't3'
 
-    def on_save(self, path=None):
-        super().on_save(path)
-
+    def _map_oifits_keywords(self):
         # OIFITS requires specific keyword names for some data that already
         # exist in JWST files under different keywords. For existing
         # (and defined) metadata, copy the data to the OIFITS compatible
@@ -73,3 +71,12 @@ class AmiOIModel(JwstDataModel):
             self.meta.oifits.derived.array.y = 0.0
         if self.meta.oifits.derived.array.z is None:
             self.meta.oifits.derived.array.z = 0.0
+
+    def on_save(self, path=None):
+        super().on_save(path)
+        self._map_oifits_keywords()
+
+    def validate(self):
+        # map the JWST to OIFITS keywords prior to validate
+        self._map_oifits_keywords()
+        super().validate()

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -434,6 +434,14 @@ def oifits_ami_model():
     return m
 
 
+def test_amioi_model_oifits_validate(oifits_ami_model):
+    oifits_ami_model.validate()
+
+
+def test_amioi_model_oifits_update(oifits_ami_model):
+    oifits_ami_model.update({})
+
+
 def test_amioi_model_oifits_compliance(tmp_path, oifits_ami_model):
     """
     This test cannot fully test oifits compliance but the schema for the model


### PR DESCRIPTION
As reported by @rcooper295 using `AmiOIModel.update` results in a `ValidationError`. This is due to the mapping of JWST to OIFITS keywords only during `AmiOIModel.on_save` (which is not called during `update`).

This PR updates `AmiOIModel` to map JWST to OIFITS keywords before calling `validate` (which is called during `update` and also fixes an issue that without this PR `AmiOIModel.validate` would also similarly fail).

Unit tests were added to verify that `AmiOIModel.update` and `AmiOIModel.validate` run successfully for an OIFITS compliant model.

Regression tests run with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1047/

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
