### PR TITLE
JP-3455: Changes to the MIRI imager PHOTOM datamodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Other
 
 - Add mrsptcorr ref_file to core.schema [#228]
 
-- Modified MIRI-Imager photom scheme [#8064, spacetelescope/stdatamodels#235]
+- Updated JWST MIRI imager photom model to include time-dependent correction
+  coeffs. [#235]
 
   
 1.8.3 (2023-10-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Other
 
 - Add mrsptcorr ref_file to core.schema [#228]
 
+- Modified MIRI-Imager photom scheme [#8064, spacetelescope/stdatamodels#235]
+
+  
 1.8.3 (2023-10-02)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -45,7 +45,7 @@ class MirImgPhotomModel(ReferenceFileModel):
        - photmjsr: float32
        - uncertainty: float32
 
-    correction_table : numpy table
+    timecoeff : numpy table
         Table with the coefficients for the time-dependent correction.
 
        - amplitude: float32

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -45,8 +45,18 @@ class MirImgPhotomModel(ReferenceFileModel):
        - photmjsr: float32
        - uncertainty: float32
 
+    correction_table : numpy table
+        Table with the coefficients for the time-dependent correction.
+
+       - amplitude: float32
+       - tau: float32
+       - t0: float32
+
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_photom.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(MirImgPhotomModel, self).__init__(init=init, **kwargs)
 
 
 class MirLrsPhotomModel(ReferenceFileModel):

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -23,3 +23,15 @@ allOf:
         datatype: float32
       - name: uncertainty
         datatype: float32
+- type: object
+  properties:
+    correction_table:
+      title: Temporal correction to the PHOTOM value
+      fits_hdu: TIMECORR
+      datatype:
+      - name: amplitude
+        datatype: float32
+      - name: tau
+        datatype: float32
+      - name: t0
+        datatype: float32

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -25,9 +25,9 @@ allOf:
         datatype: float32
 - type: object
   properties:
-    correction_table:
+    timecoeff:
       title: Temporal correction to the PHOTOM value
-      fits_hdu: TIMECORR
+      fits_hdu: TIMECOEFF
       datatype:
       - name: amplitude
         datatype: float32


### PR DESCRIPTION
Related to [JP-3455](https://jira.stsci.edu/browse/JP-3455)

This PR is related to proposed changes to the PHOTOM step for the MIRI Imager (and coronographs). We add a time-dependent correction to the PHOTOM value. A new datamodel is needed for the PHOTOM reference file.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
