### PR TITLE
add erfa to devdeps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ git+https://github.com/asdf-format/asdf
 
 # Use weekly astropy dev build
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+--extra-index-url https://pypi.anaconda.org/liberfa/simple erfa --pre
 
 # Use Bi-weekly numpy/scipy dev builds
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
The devdeps jobs are failing on the main branch due to testing against numpy 2.0 with the released version of erfa (which is build against numpy<2.0).

This PR updates the dev requirements to install the erfa pre-release (built against numpy 2.0).

This hit the same drizzle dependency issue as discussed in https://github.com/spacetelescope/jwst/pull/7910