### PR TITLE
JP-3235: Add step status keyword for NSClean

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ Changes to API
 Other
 -----
 
-- 
+- Updated JWST core datamodel schema to include the new step status keyword
+  "S_NSCLEN" for the new "nsclean" calibration step. [#237]
+
 
 1.8.4 (2023-12-04)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2420,6 +2420,10 @@ properties:
             type: string
             fits_keyword: S_MSAFLG
             blend_table: True
+          nsclean:
+            title: NIRSpec 1/f Noise Correction
+            type: string
+            fits_keyword: S_NSCLEN
           outlier_detection:
             title: Outlier Detection
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3235](https://jira.stsci.edu/browse/JP-3235)

<!-- describe the changes comprising this PR here -->
This PR adds a new step status keyword to the JWST datamodels for the new "nsclean" step being added in B10.1.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
