### PR TITLE
JP-3482: Load units from FITS default header keywords directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 Bug Fixes
 ---------
 
-- 
+- Pull unit strings from FITS ``TUNIT`` header keywords
+  to populate ``MultiSpecModel`` table units. [#238]
 
 Changes to API
 --------------

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -1,5 +1,6 @@
 from .model_base import JwstDataModel
 from .spec import SpecModel
+from astropy.io import fits
 
 
 __all__ = ['MultiSpecModel']
@@ -57,3 +58,13 @@ class MultiSpecModel(JwstDataModel):
             return
 
         super(MultiSpecModel, self).__init__(init=init, **kwargs)
+
+        try:
+            if init[1].name == 'EXTRACT1D':
+                for key in init[1].header.keys():
+                    if 'TUNIT' in key:
+                        col = int(key.split('TUNIT')[1]) - 1
+                        for spec in self.spec:
+                            spec.spec_table.columns[col].unit = init[1].header[key]
+        except (AttributeError, IndexError) as e:
+            pass

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -1,7 +1,9 @@
 from .model_base import JwstDataModel
 from .spec import SpecModel
-from astropy.io import fits
 
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 __all__ = ['MultiSpecModel']
 
@@ -67,4 +69,5 @@ class MultiSpecModel(JwstDataModel):
                         for spec in self.spec:
                             spec.spec_table.columns[col].unit = init[1].header[key]
         except (AttributeError, IndexError) as e:
+            log.info(f"Failed to load units from FITS header: {e}")
             pass

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -1,5 +1,6 @@
 from .model_base import JwstDataModel
 from .spec import SpecModel
+from astropy.io import fits
 
 import logging
 log = logging.getLogger(__name__)
@@ -62,12 +63,15 @@ class MultiSpecModel(JwstDataModel):
         super(MultiSpecModel, self).__init__(init=init, **kwargs)
 
         try:
-            if init[1].name == 'EXTRACT1D':
-                for key in init[1].header.keys():
-                    if 'TUNIT' in key:
-                        col = int(key.split('TUNIT')[1]) - 1
-                        for spec in self.spec:
-                            spec.spec_table.columns[col].unit = init[1].header[key]
-        except (AttributeError, IndexError) as e:
+            if isinstance(init, fits.hdu.hdulist.HDUList):
+                for entry in init:
+                    if entry.name == 'EXTRACT1D':
+                        for key in entry.header.keys():
+                            if 'TUNIT' in key:
+                                col = int(key.split('TUNIT')[1]) - 1
+                                for spec in self.spec:
+                                    spec.spec_table.columns[col].unit = init[1].header[key]
+                        break
+        except (KeyError, IndexError) as e:
             log.info(f"Failed to load units from FITS header: {e}")
             pass


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3482](https://jira.stsci.edu/browse/JP-3482)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes [spacetelescope/jwst#8109]

<!-- describe the changes comprising this PR here -->
This PR addresses a lack of specified units in the spec/spectable jwst schemas, resulting in metadata not propagating through a save/load cycle. Additionally, loading a spectrum into a datamodel will not have any unit strings accessible. This feels like hacky workaround, but does generate unit strings in the spec_table. Looking forward to expert review 🙂 

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] updated relevant milestone(s)
- [x] added relevant label(s)
