### PR TITLE
Fix search in docs by adding jquery to docs conf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Bug Fixes
 ---------
 
-- 
+- Fix search in documentation [#241] 
 
 Changes to API
 --------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ release = package.__version__
 
 extensions = [
     "sphinx_automodapi.automodapi",
+    "sphinxcontrib.jquery",
     "numpydoc",
     'sphinx_asdf',
 ]


### PR DESCRIPTION
Applies the same fix as in: https://github.com/spacetelescope/jwst/pull/7524

Fix search in docs by including jquery in the docs conf file.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
