### PR TITLE
restore column units on cast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Bug Fixes
 - Fix ``rebuild_fits_rec_dtype`` handling of unsigned integer columns
   with shapes [#213]
 
+- Fix unit roundtripping when writing to a datamodel with a table
+  to a FITS file [#242]
+
 Changes to API
 --------------
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_fits.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_fits.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from stdatamodels.jwst import datamodels
-from stdatamodels.jwst.datamodels import ImageModel, JwstDataModel, RampModel
+from stdatamodels.jwst.datamodels import ImageModel, JwstDataModel, RampModel, SpecModel
 
 
 @pytest.fixture
@@ -91,3 +91,18 @@ def test_resave_duplication_bug(tmp_path):
 
     with fits.open(fn1) as ff1, fits.open(fn2) as ff2:
         assert ff1['ASDF'].size == ff2['ASDF'].size
+
+
+def test_units_roundtrip(tmp_path):
+    m = SpecModel()
+    # this next line is required for stdatamodels to cast
+    # spec_table to a FITS_rec (similar to having data assigned
+    # to the attribute)
+    m.spec_table = m.spec_table
+    m.spec_table.columns['WAVELENGTH'].unit = 'nm'
+
+    fn = tmp_path / "test1.fits"
+    m.save(fn)
+
+    m = datamodels.open(fn)
+    assert m.spec_table.columns['WAVELENGTH'].unit == 'nm'

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -83,10 +83,20 @@ def _cast(val, schema):
                     t['shape'] = shape
 
         dtype = ndarray.asdf_datatype_to_numpy_dtype(schema['datatype'])
+
+        # save columns in case this is cast back to a fitsrec
+        if hasattr(val, 'columns'):
+            cols = val.columns
+        else:
+            cols = None
         val = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
 
         if dtype.fields is not None:
             val = _as_fitsrec(val)
+            if cols is not None:
+                for col in cols:
+                    if col.name in val.names and col.unit is not None:
+                        val.columns[col.name].unit = col.unit
 
     if 'ndim' in schema and len(val.shape) != schema['ndim']:
         raise ValueError(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3482](https://jira.stsci.edu/browse/JP-3482)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes [spacetelescope/jwst#8109]

<!-- describe the changes comprising this PR here -->
When a `DataModel` containing a table extension is loaded from a FITS file, stdatamodels currently discards the units defined in the `TUNITS` headers. This is due to a `_cast` from a FITS_rec to a ndarray (to protect against the numerous gotchas in FITS_rec):
https://github.com/spacetelescope/stdatamodels/blob/b7eada9ee768691bafbb9eb6b38b18c3eb50d85b/src/stdatamodels/properties.py#L86
then a conversion back to a FITS_rec to allow jwst code to continue to interact with a FITS_rec:
https://github.com/spacetelescope/stdatamodels/blob/b7eada9ee768691bafbb9eb6b38b18c3eb50d85b/src/stdatamodels/properties.py#L89

This PR is an alternative to #238 and a stop-gap measure until #240 can be resolved.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
