### PR TITLE
drop use of json_id in walk_and_modify callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Bug Fixes
 Changes to API
 --------------
 
--
+- Remove ``json_id`` argument use for callbacks passed
+  to ``asdf.treeutil.walk_and_modify`` [#244]
 
 Other
 -----

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -357,7 +357,7 @@ def _get_validators(hdulist):
 
 
 def _save_from_schema(hdulist, tree, schema):
-    def datetime_callback(node, json_id):
+    def datetime_callback(node):
         if isinstance(node, datetime.datetime):
             node = time.Time(node)
 
@@ -378,7 +378,7 @@ def _save_from_schema(hdulist, tree, schema):
 
     # Now link extensions to items in the tree
 
-    def callback(node, json_id):
+    def callback(node):
         if id(node) in context.extension_array_links:
             hdu = context.extension_array_links[id(node)]()
             return _create_tagged_dict_for_fits_array(hdu, hdulist.index(hdu))
@@ -432,7 +432,7 @@ def _normalize_arrays(tree):
     don't want the asdf library to notice the change in memory
     layout and duplicate the array in the embedded ASDF.
     """
-    def normalize_array(node, json_id):
+    def normalize_array(node):
         if isinstance(node, np.ndarray):
             # We can't use np.ascontiguousarray because it converts FITS_rec
             # to vanilla np.ndarray, which results in misinterpretation of
@@ -746,7 +746,7 @@ def from_fits_asdf(hdulist,
 
 
 def _map_hdulist_to_arrays(hdulist, af):
-    def callback(node, json_id):
+    def callback(node):
         if (
                 isinstance(node, NDArrayType) and
                 isinstance(node._source, str) and

--- a/src/stdatamodels/jwst/datamodels/schema_editor.py
+++ b/src/stdatamodels/jwst/datamodels/schema_editor.py
@@ -394,9 +394,8 @@ class Keyword_db:
         """
         Resolve urls in the schema
         """
-        def resolve_refs(node, json_id):
-            if json_id is None:
-                json_id = url
+        def resolve_refs(node):
+            json_id = url
             if isinstance(node, dict) and '$ref' in node:
                 suburl = generic_io.resolve_uri(json_id, node['$ref'])
                 parts = urlparse(suburl)


### PR DESCRIPTION
This PR removes uses of the optional `json_id` argument for callbacks passed to `asdf.treeutil.walk_and_modify`.

In `fits_support` this argument was unused and removal has no effect.

In `schema_editor` it is likely better to not use this argument (it's use might lead to bugs like in https://github.com/asdf-format/asdf/pull/1716).

For some extra context, `json_id` contains the string value under the key "id" of the most closely nested dictionary for the contained object processed in the callback. This is useful for draft 4 jsonschema so any reference fragments can be resolved using the uri stored in the "id" (see [this schema for an example id](https://github.com/spacetelescope/stdatamodels/blob/44a5691d56e001f5f1a9c54167481fb73be14813/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml#L4)). Keyword files do not follow draft 4 and do not contain an "id" with a uri. Within the schema_editor code, the top level keyword files are combined:
https://github.com/spacetelescope/stdatamodels/blob/44a5691d56e001f5f1a9c54167481fb73be14813/src/stdatamodels/jwst/datamodels/schema_editor.py#L231-L242
before calling 'resolve_references' to resolve references to other keyword files:
https://github.com/spacetelescope/stdatamodels/blob/44a5691d56e001f5f1a9c54167481fb73be14813/src/stdatamodels/jwst/datamodels/schema_editor.py#L244
using the directory as the 'uri' for resolving these references:
https://github.com/spacetelescope/stdatamodels/blob/44a5691d56e001f5f1a9c54167481fb73be14813/src/stdatamodels/jwst/datamodels/schema_editor.py#L393-L399
so that references can be found relative to the directory containing the keyword json files. The presence of an "id" key would break this resolution if it did not contain the directory that contains the keyword json files.

Locally the `test_schema_editor` jwst regression tests pass. Regression test run:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1117/
shows only unrelated errors (due to new emicorr reference file and engdb failure, both of which are occurring on jwst main and the random "missing_msa_fail/nofail").

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
