### PR TITLE
update warning filters in tests for pytest 8

### DIFF
--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import pytest
 from astropy.io import fits
@@ -592,15 +593,21 @@ def test_ndarray_validation(tmp_path):
 
     # But raise an error when casting is disabled
     with pytest.raises(ValidationError, match="Array datatype 'float64' is not compatible with 'float32'"):
-        # also warn due to the cast_fits_array deprecation
-        with pytest.warns(DeprecationWarning, match="cast_fits_array"):
-            with FitsModel(
-                file_path,
-                strict_validation=True,
-                cast_fits_arrays=False,
-                validate_arrays=True,
-            ) as model:
-                model.validate()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message="cast_arrays is deprecated and will be removed"
+            )
+            # also warn due to the cast_fits_array deprecation
+            with pytest.warns(DeprecationWarning, match="cast_fits_array"):
+                with FitsModel(
+                    file_path,
+                    strict_validation=True,
+                    cast_fits_arrays=False,
+                    validate_arrays=True,
+                ) as model:
+                    model.validate()
 
     # Wrong dimensions
     hdu = fits.ImageHDU(data=np.ones((4,), dtype=np.float64), name="SCI")
@@ -614,10 +621,16 @@ def test_ndarray_validation(tmp_path):
 
     # Should also be caught by validation
     with pytest.raises(ValidationError, match="Wrong number of dimensions: Expected 2, got 1"):
-        # also warn due to the cast_fits_array deprecation
-        with pytest.warns(DeprecationWarning, match="cast_fits_array"):
-            with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
-                model.validate()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message="cast_arrays is deprecated and will be removed"
+            )
+            # also warn due to the cast_fits_array deprecation
+            with pytest.warns(DeprecationWarning, match="cast_fits_array"):
+                with FitsModel(file_path, strict_validation=True, cast_fits_arrays=False, validate_arrays=True) as model:
+                    model.validate()
 
 
 def test_resave_duplication_bug(tmp_path):


### PR DESCRIPTION
pytest 8 includes a change to how "pytest.warns" behaves (it now re-emits non-matched warnings). Running the stdatamodels test suite against pytest 8 (rc1) there is one failing test `test_ndarray_validation` due to this change.

This PR updates the warning filters in `test_ndarray_validation` to work with pytest 8.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
