### PR TITLE
JP-3520: Add ngroups to mask schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Changes to API
 Other
 -----
 
--
+- Add ``ngroups`` keyword to ``mask`` schema to match
+  parkeys on crds [#249]
 
 1.9.0 (2023-12-11)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
@@ -8,6 +8,7 @@ allOf:
 - $ref: keyword_exptype.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_preadpatt.schema
+- $ref: keyword_ngroups.schema
 - type: object
   properties:
     dq:

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -239,7 +239,7 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                     # No need to actually load the reference file into the datamodel!
                     with ref_model() as m:
                         for key in parkeys:
-                            assert len(m.search_schema(key.lower())) > 0
+                            assert len(m.search_schema(key.lower())) > 0, f"{f} missing {key} required by {r.basename}"
                     break
         except IrrelevantReferenceTypeError as e:
             log.debug(e)


### PR DESCRIPTION
Addresses [JP-3520](https://jira.stsci.edu/browse/JP-3520)

crds added 'ngroups' as a parkey for mask reference files. This is causing test failures (that check the schema and parkeys).

See the test failure here: https://github.com/asdf-format/asdf/actions/runs/7629799922/job/20784057576?pr=1739#step:10:718

This PR adds 'ngroups' to the mask schema to bring these two projects into alignment.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
