### PR TITLE
JP-3520: Add ngroups to mask datamodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Changes to API
 Other
 -----
 
--
+- Added ``ngroups`` keyword to JWST mask reference file
+  datamodel. [#251]
 
 1.9.0 (2023-12-11)
 ==================

--- a/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
@@ -8,6 +8,7 @@ allOf:
 - $ref: keyword_exptype.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_preadpatt.schema
+- $ref: keyword_ngroups.schema
 - type: object
   properties:
     dq:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3520](https://jira.stsci.edu/browse/JP-3520)

<!-- describe the changes comprising this PR here -->
This PR addresses an issue found in tests for JP-3519 - recent updates to the CRDS selection criteria for MIRI MRS bad pixel masks caused test failures due to the lack of these updates being applied to the datamodel.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
