### PR TITLE
add schema and model for nrm reference file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Bug Fixes
 Changes to API
 --------------
 
--
+- Add ``NRMModel`` for new NIRISS NRM reference file [#253]
 
 Other
 -----

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -46,6 +46,7 @@ from .multiprod import MultiProductModel
 from .multislit import MultiSlitModel
 from .multispec import MultiSpecModel
 from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
+from .nrm import NRMModel
 from .outlierpars import OutlierParsModel
 from .outlierifuoutput import OutlierIFUOutputModel
 from .pathloss import PathlossModel, MirLrsPathlossModel
@@ -98,6 +99,7 @@ __all__ = [
     'AmiLgModel',
     'AmiLgFitModel',
     'AmiOIModel',
+    'NRMModel',
     'FgsImgApcorrModel', 'MirImgApcorrModel', 'NrcImgApcorrModel', 'NisImgApcorrModel',
     'MirLrsApcorrModel', 'MirMrsApcorrModel', 'NrcWfssApcorrModel', 'NisWfssApcorrModel',
     'NrsMosApcorrModel', 'NrsFsApcorrModel', 'NrsIfuApcorrModel',

--- a/src/stdatamodels/jwst/datamodels/nrm.py
+++ b/src/stdatamodels/jwst/datamodels/nrm.py
@@ -1,0 +1,16 @@
+from .reference import ReferenceFileModel
+
+
+__all__ = ['NRMModel']
+
+
+class NRMModel(ReferenceFileModel):
+    """
+    A data model for Non-Redundant Mask.
+
+    Parameters
+    __________
+    nrm : numpy float32 array
+         Non-Redundant Mask
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrm.schema"

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2028,6 +2028,15 @@ properties:
                 type: string
                 fits_keyword: R_MRSPT
                 blend_table: True
+          nrm:
+            title: Non-Redundant mask reference file information
+            type: object
+            properties:
+              name:
+                title: Non-Redundant mask reference file name
+                type: string
+                fits_keyword: R_NRM
+                blend_table: True
           ote:
             title: Nirspec OTE Model reference file information
             type: object

--- a/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrm.schema"
+title: Non-Redundant Mask data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- type: object
+  properties:
+    nrm:
+      title: Non-Redundant Mask
+      fits_hdu: NRM
+      ndim: 2
+      datatype: float32

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -145,6 +145,7 @@ ref_to_datamodel_dict = {
     'mrsptcorr': dm.MirMrsPtCorrModel,
     'msa': dm.MSAModel,
     'msaoper': None,
+    'nrm': dm.NRMModel,
     'ote': dm.OTEModel,
     'persat': dm.PersistenceSatModel,
     'psfmask': dm.PsfMaskModel,


### PR DESCRIPTION
This PR adds support (a schema and model) for the new NIRISS `nrm`  reference file:
https://jwst-crds-test.stsci.edu/browse/jwst_niriss_nrm_0002.fits

Local tests were performed to confirm that this file loads and the `nrm` array is available at the `nrm` attribute:
```python
>> import stdatamodels.jwst.datamodels as dm
>> m = dm.open('jwst_niriss_nrm_0002.fits')
>> assert isinstance(m, dm.NRMModel)
>> m.nrm
array([[0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
       ...,
       [0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.],
       [0., 0., 0., ..., 0., 0., 0.]], dtype='>f4')
```
The local testing is important as this file only exists on https://jwst-crds-test.stsci.edu/ and the CI uses the non-test public crds: https://jwst-crds.stsci.edu/

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
