### PR TITLE
allow non-integer ngroups for mask ref file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Bug Fixes
   keyword, in order to support proper handling of MIRI MRS
   and Imager exposures done in parallel. [#259]
 
+- Fix mask schema to allow for non-integer ngroups selectors [#256]
+
 Changes to API
 --------------
 

--- a/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
@@ -8,7 +8,17 @@ allOf:
 - $ref: keyword_exptype.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_preadpatt.schema
-- $ref: keyword_ngroups.schema
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        exposure:
+          type: object
+          properties:
+            ngroups:
+              title: Number of groups in integration
+              fits_keyword: NGROUPS
 - type: object
   properties:
     dq:


### PR DESCRIPTION
Resolves [JP-3520](https://jira.stsci.edu/browse/JP-3520)

https://github.com/spacetelescope/stdatamodels/pull/249 followed the normal pattern of adding new keywords/attributes to reference file schemas. This involves adding a `$ref` to the existing `keyword_<...>` schema for the new keyword used as a selector in crds.

However, in this case (perhaps the first of its kind in JWST) the selector type does not match the keyword type where the selector is a string `BETWEEN 0 50` and the keyword `NGROUPS` expects an `integer`. See:
https://jwst-crds.stsci.edu/browse/jwst_miri_mask_0055.fits
and:
https://github.com/spacetelescope/stdatamodels/blob/b7c7bcd83b7a32d908e3f63c5dece313b3611f7a/src/stdatamodels/jwst/datamodels/schemas/keyword_ngroups.schema.yaml#L13-L16

This PR fixes the issue by largely duplicating the `keyword_ngroups` schema (leaving of the `type` restriction) in the `mask` schema.

This likely highlights a more widespread issue where crds appears to support more for selector types than the current datamodels and schemas allow. This means that a crds update may result in failures to validate models.

Additionally this was uncaught by the current tests. Adding tests for this case seems prudent.

Regression tests: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1189/pipeline/193

show 3 errors which appear to be unrelated:
- `test_nirspec_missing_msa_fail`
- `test_nirspec_missing_msa_nofail` (these two often fail)
- `test_duplicate_names`

They all failed due to missing test in `caplog.text` suggesting these are due to the known issue with log messaging getting lost during regression test runs.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
