### PR TITLE
Add asdf resources test and update schemas for new transform schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@
 - Change ``integration_number`` from int16 to int32 in ``group``
   schema. [#283]
 
+- Fix datamodel schema ids for abvegaoffset, keyword_lampmode, nrsfs_apcorr [#258]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     "pytest-doctestplus",
     "crds>=11.16.14",
     "scipy>=1.5",
+    "importlib_resources; python_version < '3.10'"
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 ]
 dependencies = [
     "asdf>=2.15.0",
+    "asdf-transform-schemas>=0.5.0",
     "asdf-astropy>=0.3.0",
     "psutil>=5.7.2",
     "numpy>=1.18",

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -35,7 +35,10 @@ __all__ = ['to_fits', 'from_fits', 'fits_hdu_name', 'get_hdu', 'is_builtin_fits_
 
 _ASDF_EXTENSION_NAME = "ASDF"
 _FITS_SOURCE_PREFIX = "fits:"
-_NDARRAY_TAG = "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+if asdf.versioning.default_version > "1.5.0":
+    _NDARRAY_TAG = "tag:stsci.edu:asdf/core/ndarray-1.1.0"
+else:
+    _NDARRAY_TAG = "tag:stsci.edu:asdf/core/ndarray-1.0.0"
 
 _builtin_regexes = [
     '', 'NAXIS[0-9]{0,3}', 'BITPIX', 'XTENSION', 'PCOUNT', 'GCOUNT',

--- a/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
-id: "http://stsci.edu/schemas/jwst_datamodel/abvegamag_offset.schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/abvegaoffset.schema"
 title: AB to Vega magnitude offset reference file model
 allOf:
 - $ref: referencefile.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/ifuslicer.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ifuslicer.schema.yaml
@@ -14,7 +14,7 @@ allOf:
         An instance of astropy.modeling.Model.
       type: object
     data:
-      $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*
     meta:
       type: object
       properties:

--- a/src/stdatamodels/jwst/datamodels/schemas/keyword_lampstate.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/keyword_lampstate.schema.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
-id: "http://stsci.edu/schemas/jwst_datamodel/keyword_lampmode.schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_lampstate.schema"
 type: object
 properties:
   meta:

--- a/src/stdatamodels/jwst/datamodels/schemas/msa.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/msa.schema.yaml
@@ -18,7 +18,7 @@ allOf:
             An instance of astropy.modeling.Model.
           type: object
         data:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          tag: tag:stsci.edu:asdf/core/ndarray-1.*
     Q2:
       type: object
       properties:
@@ -27,7 +27,7 @@ allOf:
             An instance of astropy.modeling.Model.
           type: object
         data:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          tag: tag:stsci.edu:asdf/core/ndarray-1.*
     Q3:
       type: object
       properties:
@@ -36,7 +36,7 @@ allOf:
             An instance of astropy.modeling.Model.
           type: object
         data:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          tag: tag:stsci.edu:asdf/core/ndarray-1.*
     Q4:
       type: object
       properties:
@@ -45,7 +45,7 @@ allOf:
             An instance of astropy.modeling.Model.
           type: object
         data:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          tag: tag:stsci.edu:asdf/core/ndarray-1.*
     Q5:
       type: object
       properties:
@@ -54,7 +54,7 @@ allOf:
             An instance of astropy.modeling.Model.
           type: object
         data:
-          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          tag: tag:stsci.edu:asdf/core/ndarray-1.*
     meta:
       type: object
       properties:

--- a/src/stdatamodels/jwst/datamodels/schemas/nrsfs_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrsfs_apcorr.schema.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
-id: "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/nrsfs_apcorr.schema"
 title: NIRSpec Fixed Slit aperture correction data model
 allOf:
 - $ref: referencefile.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/regions.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/regions.schema.yaml
@@ -11,4 +11,4 @@ allOf:
 - type: object
   properties:
     regions:
-      $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+      tag: tag:stsci.edu:asdf/core/ndarray-1.*

--- a/src/stdatamodels/jwst/datamodels/schemas/wavecorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/wavecorr.schema.yaml
@@ -18,7 +18,7 @@ definitions:
           [SLIT] or pitch [MOS]).  An instance of astropy.modeling.Model.
         type: object
       variance:
-        $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+        tag: tag:stsci.edu:asdf/core/ndarray-1.*
         title: Variance of the zero-point offset
         description: |
           Estimated variance on the zero-point offset (in units of detector pixel)

--- a/src/stdatamodels/jwst/datamodels/tests/test_integration.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_integration.py
@@ -1,4 +1,9 @@
-import importlib
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 import asdf
 import pytest
@@ -6,16 +11,16 @@ import yaml
 
 
 METASCHEMAS = list(
-    importlib.resources.files("stdatamodels.jwst.datamodels.metaschema").glob("*.yaml")
+    importlib_resources.files("stdatamodels.jwst.datamodels.metaschema").glob("*.yaml")
 )
 
 DATAMODEL_SCHEMAS = list(
-    importlib.resources.files("stdatamodels.jwst.datamodels.schemas").glob("*.yaml")
+    importlib_resources.files("stdatamodels.jwst.datamodels.schemas").glob("*.yaml")
 )
 # transform schemas are nested in a directory with a '.'
 TRANSFORM_SCHEMAS = list(
     next(
-        importlib.resources.files(
+        importlib_resources.files(
             "stdatamodels.jwst.transforms.resources.schemas"
         ).iterdir()
     ).glob("**/*.yaml")
@@ -24,7 +29,7 @@ TRANSFORM_SCHEMAS = list(
 SCHEMAS = METASCHEMAS + DATAMODEL_SCHEMAS + TRANSFORM_SCHEMAS
 
 TRANSFORM_MANIFESTS = list(
-    importlib.resources.files("stdatamodels.jwst.transforms.resources.manifests").glob(
+    importlib_resources.files("stdatamodels.jwst.transforms.resources.manifests").glob(
         "*.yaml"
     )
 )

--- a/src/stdatamodels/jwst/datamodels/tests/test_integration.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_integration.py
@@ -1,0 +1,54 @@
+import importlib
+
+import asdf
+import pytest
+import yaml
+
+
+METASCHEMAS = list(
+    importlib.resources.files("stdatamodels.jwst.datamodels.metaschema").glob("*.yaml")
+)
+
+DATAMODEL_SCHEMAS = list(
+    importlib.resources.files("stdatamodels.jwst.datamodels.schemas").glob("*.yaml")
+)
+# transform schemas are nested in a directory with a '.'
+TRANSFORM_SCHEMAS = list(
+    next(
+        importlib.resources.files(
+            "stdatamodels.jwst.transforms.resources.schemas"
+        ).iterdir()
+    ).glob("**/*.yaml")
+)
+
+SCHEMAS = METASCHEMAS + DATAMODEL_SCHEMAS + TRANSFORM_SCHEMAS
+
+TRANSFORM_MANIFESTS = list(
+    importlib.resources.files("stdatamodels.jwst.transforms.resources.manifests").glob(
+        "*.yaml"
+    )
+)
+
+RESOURCES = SCHEMAS + TRANSFORM_MANIFESTS
+
+
+@pytest.mark.parametrize("resource", RESOURCES)
+def test_resource_id(resource):
+    """
+    Test that all "resources" (schemas, metaschemas and manifests) are
+    registered with asdf using the "id" in the resource.
+    """
+    with open(resource, "rb") as f:
+        contents = f.read()
+    schema = yaml.safe_load(contents.decode("ascii"))
+    resource_manager = asdf.get_config().resource_manager
+
+    # check that asdf is aware of the "id"
+    assert (
+        schema["id"] in resource_manager
+    ), f"id[{schema['id']}] for resource[{resource}] was not registered with asdf"
+
+    # and that using the "id" to fetch the resource returns the contents of the file
+    assert (
+        resource_manager[schema["id"]] == contents
+    ), f"id[{schema['id']}] for resource[{resource}] did not return the contents of the resource"

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -8,44 +8,38 @@ from .converters.jwst_models import (Gwa2SlitConverter, Slit2MsaConverter, Logic
                                      CoordsConverter, V23ToSkyConverter)
 
 
+_CONVERTERS = [
+    CoordsConverter(),
+    Gwa2SlitConverter(),
+    Slit2MsaConverter(),
+    LogicalConverter(),
+    NirissSOSSConverter(),
+    RefractionIndexConverter(),
+    Rotation3DToGWAConverter(),
+    MIRI_AB2SliceConverter(),
+    NIRCAMGrismDispersionConverter(),
+    NIRISSGrismDispersionConverter(),
+    GratingEquationConverter(),
+    SnellConverter(),
+]
+
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.
 TRANSFORM_EXTENSIONS = [
     ManifestExtension.from_uri(
+        "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.1.0",
+        legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
+        converters=_CONVERTERS,
+    ),
+    ManifestExtension.from_uri(
         "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.0.0",
         legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
-        converters=[
-            CoordsConverter(),
-            Gwa2SlitConverter(),
-            Slit2MsaConverter(),
-            LogicalConverter(),
-            NirissSOSSConverter(),
-            RefractionIndexConverter(),
-            Rotation3DToGWAConverter(),
-            MIRI_AB2SliceConverter(),
-            NIRCAMGrismDispersionConverter(),
-            NIRISSGrismDispersionConverter(),
-            GratingEquationConverter(),
-            SnellConverter(),
-        ],
+        converters=_CONVERTERS,
     ),
     ManifestExtension.from_uri(
         "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-0.7.0",
         legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
-        converters=[
-            CoordsConverter(),
-            Gwa2SlitConverter(),
-            Slit2MsaConverter(),
-            LogicalConverter(),
-            NirissSOSSConverter(),
-            RefractionIndexConverter(),
-            Rotation3DToGWAConverter(),
-            MIRI_AB2SliceConverter(),
-            NIRCAMGrismDispersionConverter(),
-            NIRISSGrismDispersionConverter(),
-            GratingEquationConverter(),
-            SnellConverter(),
-            V23ToSkyConverter(),
-        ],
+        # 0.7.0 support v23tosky, register it's converter
+        converters=_CONVERTERS + [V23ToSkyConverter(),],
     )
 ]

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
@@ -68,7 +68,7 @@ tags:
   description: |-
     A sequence of 3D rotations around different axes.
 - tag_uri: "tag:stsci.edu:jwst_pipeline/snell-1.1.0"
-  schema_uri: http://stsci.edu/schemas/jwst_pipeline/snell-1.0.0
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/snell-1.1.0
   title: NIRSpec transforms through the prism.
   description: |-
     This model does all transforms through the NIRSpec prism:

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
@@ -1,0 +1,94 @@
+id: asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.1.0
+extension_uri: asdf://stsci.edu/jwst_pipeline/extensions/jwst_transforms-1.1.0
+title: JWST Transform extension 1.1.0
+description: |-
+  A set of tags for serializing data transforms for the JWST pipeline.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+- tag_uri: "tag:stsci.edu:jwst_pipeline/nircam_grism_dispersion-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/nircam_grism_dispersion-1.1.0
+  title: NIRCAM Grism dispersion model
+  description: |-
+    Supports two models:
+    Given x, y, wave, order in effective direct image returns
+    x,y,wave,order in dispersed
+    Given x, y, x0, y0, order in dispersed image returns x, y, wave, order
+    in effective direct
+- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss_grism_dispersion-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_grism_dispersion-1.1.0
+  title: NIRISS Grism dispersion model
+  description: |-
+    Supports two models:
+    Given x, y, wave, order in effective direct image returns
+    x, y, wave, order in dispersed
+    Given x, y, x0, y0, order in dispersed image returns
+    x, y, wave, order in effective direct
+- tag_uri: "tag:stsci.edu:jwst_pipeline/gwa_to_slit-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/gwa_to_slit-1.1.0
+  title: NIRSPEC set of models from GWA to slit_frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It maps slit to the transform from the Grating Wheel Assembly (GWA)
+    to the coordinate frame of the slit, where (0, 0) is the center of
+    the slit.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_msa-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.1.0
+  title: NIRSPEC set of models from slit_frame to the MSA frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It maps a slit to its position in the MSA plane.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/logical-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/logical-1.1.0
+  title: A model performing logical operations on arrays.
+  description: |-
+    Implements the Numpy logical operators
+- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss_soss-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_soss-1.1.0
+  title: NIRISS SOSS transforms.
+  description: |-
+    This model is used by the NIRISS SOSS WCS pipeline.
+    It maps spectral order to transform
+- tag_uri: "tag:stsci.edu:jwst_pipeline/refraction_index_from_prism-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/refraction_index_from_prism-1.1.0
+  title: Computes the refraction index for the NIRSpec prism.
+  description: |-
+    Given the prism angle and the incident and refracted angles, compute the
+    index of refraction.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/miri_ab2slice-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/miri_ab2slice-1.1.0
+  title: MIRI MRS (alpha, beta) to slice number transform.
+  description: |-
+    This model is used by the MIRI MRS WCS pipeline.
+    Given a (beta, ) coordinate it computes the slice number
+    that the coordinate belongs to in detector coordinates.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/rotation_sequence-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/rotation_sequence-1.1.0
+  title: A sequence of 3D rotations.
+  description: |-
+    A sequence of 3D rotations around different axes.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/snell-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/snell-1.0.0
+  title: NIRSpec transforms through the prism.
+  description: |-
+    This model does all transforms through the NIRSpec prism:
+    - computes the refraction index as a function of lambda.
+    - Applies Snell's law through front surface.
+    - Rotates to back surface.
+    - Applies reflection from back surface.
+    - Rotates to front surface
+    - Applies Snell's law through front surface.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/grating_equation-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/grating_equation-1.1.0
+  title: A grating equation model.
+  description: |-
+    Supports two models:
+    - Given incident angle and wavelength compute the refraction/diffraction angle.
+    - Given an incident angle and a refraction angle compute the wavelength.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/coords-1.1.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/coords-1.1.0
+  title: Convert coordinates between vector and directional cosine form.
+  description: |-
+    This schema is for representing any model that takes coordinates and does
+    some computation with them. Models have no parameters. Currently it supports
+    DirCos2Unitless, Unitless2DirCos.

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.1.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/coords-1.1.0"
+
+title: >
+  Convert coordinates between vector and directional cosine form.
+
+description: |
+  This schema is for representing any model that takes coordinates and does
+  some computation with them. Models have no parameters. Currently it supports
+  DirCos2Unitless, Unitless2DirCos.
+
+examples:
+  -
+    - Convert directional cosines to vectors.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/coords-1.1.0>
+          model_type: directional2unitless
+
+  -
+    - Convert vectors to directional cosines.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/coords-1.1.0>
+          model_type: unitless2directional
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - object:
+    properties:
+      model_type:
+        description: |
+          The type of class to initialize.
+        type: string
+    required: [model_type]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-1.1.0.yaml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/grating_equation-1.1.0"
+
+title: >
+  A grating equation model.
+description: |
+  Supports two models:
+   - Given incident angle and wavelength compute the refraction/diffraction angle.
+   - Given an incident angle and a refraction angle compute the wavelength.
+
+examples:
+  -
+    - AngleFromGratingEquation model.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/grating_equation-1.1.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: angle
+
+  -
+    - WavelengthFromGratingEquation model.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/grating_equation-1.1.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: wavelength
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      groove_density:
+        description: |
+          The groove density of the grating
+        type: number
+      order:
+        description: |
+          Spectral order
+        type: number
+
+    required: [groove_density, order]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-1.1.0.yaml
@@ -1,0 +1,36 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/gwa_to_slit-1.1.0"
+title: >
+  NIRSPEC set of models from GWA to slit_frame.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It maps slit to the transform from the Grating Wheel Assembly (GWA)
+  to the coordinate frame of the slit, where (0, 0) is the center of
+  the slit.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      slits:
+        description: |
+          An array with slit numbers.
+          The slit number is computed from the quadrant and
+          the slit ID in this quadrant using
+
+          $P = quadrant * number_of_shutters_quadrant + slit_id$
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+      models:
+        description: |
+          A compound model transferring positions at the GWA to
+          position in the slit frame.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-1.1.0.yaml
@@ -1,0 +1,53 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/logical-1.1.0"
+title: >
+  A model performing logical operations on arrays.
+
+examples:
+  -
+    - If the input is less that 10, set its value to NaN.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/logical-1.1.0>
+          compareto: 10
+          condition: LT
+          value: .nan
+  -
+    - |
+        If the input is less that [1,2,3,4], set its value to [5,6,7,8].
+        The input array should have the same shape.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/logical-1.1.0>
+          compareto: [1 ,2, 3, 4]
+          condition: LT
+          value: [5, 6, 7, 8]
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      condition:
+        description: |
+          A string representing the logical operation,
+          one of GT, LT, NE, EQ
+        type: string
+        enum: [GT, LT, NE, EQ]
+      compareto:
+        description: |
+          A number or ndarray to compare to using the condition.
+          If ndarray then the input array, compareto and value should have the same shape.
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+          - type: array
+          - type: number
+      value:
+        description: |
+          Value to substitute where condition is True.
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+          - type: array
+          - type: number

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-1.1.0.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/miri_ab2slice-1.1.0"
+title: >
+  MIRI MRS (alpha, beta) to slice number transform.
+
+description: |
+  This model is used by the MIRI MRS WCS pipeline.
+  Given a (beta, ) coordinate it computes the slice number
+  that the coordinate belongs to in detector coordinates.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      beta_zero:
+        description: |
+          Beta coordinate of the center of slice 1 in the MIRI MRS.
+        type: number
+      beta_del:
+        description: |
+          Slice width.
+        type: number
+      channel:
+        description: |
+          MIRI channel number.
+        type:
+          number
+        enum: [1, 2, 3, 4]
+    required: [beta_zero, beta_del, channel]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.1.0.yaml
@@ -1,0 +1,64 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/nircam_grism_dispersion-1.1.0"
+title: >
+  NIRCAM Grism dispersion model
+description: |
+  Supports two models:
+   - given x,y,wave,order in effective direct image return x, y, wave, order in dispersed.
+   - given x,y,x0,y0,order in dispersed image returns x, y, wave, order in effective direct.
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      xmodels:
+        description: |
+         NIRCAM row dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      ymodels:
+        description: |
+          NIRCAM column dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      lmodels:
+        description: |
+          NIRCAM wavelength dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      orders:
+        description: |
+          NIRCAM available grism orders, in-sync with the model arrays
+        type: array
+        items:
+          type: integer
+      class_name:
+        description: |
+          The model class which should instantiate this data
+        type: string
+        items:
+          minItems: 1
+          maxItems: 1
+    required: [lmodels, xmodels, ymodels, orders]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-1.1.0.yaml
@@ -1,0 +1,52 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/niriss_grism_dispersion-1.1.0"
+title: >
+  NIRISS Grism dispersion model
+description: |
+  Supports two models:
+    - Given x,y,wave,order in effective direct image return x, y, wave, order in dispersed.
+    - Given x,y,x0,y0,order in dispersed image returns x, y, wave, order in effective direct.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      theta:
+        description: |
+          NIRISS filter wheel differential position in degrees
+        type: number
+      xmodels:
+        description: |
+          NIRISS Grism row dispersion model
+        type: array
+        items:
+          type: array
+          items:
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      ymodels:
+        description: |
+          NIRISS Grism column dispersion model
+        type: array
+        items:
+          type: array
+          items:
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      lmodels:
+        description: |
+          NIRISS wavelength-models for dispersion
+        type: array
+        items:
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+      orders:
+        description: |
+          NIRISS available grism orders, in-sync with the model arrays
+        type: array
+        items:
+          type: integer
+      class_name:
+        description: |
+          The model class which should instantiate this data
+        type: string
+    required: [lmodels, xmodels, ymodels, theta, orders]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-1.1.0.yaml
@@ -1,0 +1,26 @@
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/niriss_soss-1.1.0"
+title: >
+  NIRISS SOSS transforms.
+
+description: |
+  This model is used by the NIRISS SOSS WCS pipeline.
+  It maps spectral order to transform.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      spectral_orders:
+        type: array
+        items:
+          type: integer
+        description: |
+          An array with spectral order numbers.
+      models:
+        description: |
+          A compound model transferring pixel to worlds coordinates.
+        type: array
+        items:
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+    required: [spectral_orders, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-1.1.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/refraction_index_from_prism-1.1.0"
+title: >
+  Computes the refraction index for the NIRSpec prism.
+
+description: |
+  Given the prism angle and the incident and refracted angles, compute the
+  index of refraction.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      prism_angle:
+        description: |
+          The angle of the prism in deg.
+        type: number
+    required: [prism_angle]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-1.1.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/rotation_sequence-1.1.0"
+title: >
+  A sequence of 3D rotations.
+
+description: |
+  A sequence of 3D rotations around different axes.
+
+examples:
+  -
+    - Rotate by angles [45, -60, 60] about axes 'x', 'y', 'x'
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/rotation_sequence-1.1.0>
+          angles: [45.0, -60., 60.]
+          axes_order: xyx
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      angles:
+        description: |
+          The angles of rotation.
+        type: array
+        items:
+          type: number
+      axes_order:
+        description: |
+          A sequence of "x", "y" or "z" characters representing an axis of rotation.
+          The number of characters must equal the number of angles.
+        type: string
+
+    required: [angles, axes_order]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.0.0.yaml
@@ -19,7 +19,7 @@ allOf:
               anyOf:
                 - type: array
                 - type: number
-          - tag: "http://stsci.edu/schemas/asdf/core/ndarray-*"
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
       models:
         description: |
           A compound model transferring positions in the slit frame to

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.1.0.yaml
@@ -1,0 +1,28 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.1.0"
+title: >
+  NIRSPEC set of models from slit_frame to the MSA frame.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It maps a slit to its position in the MSA plane.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      slits:
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+      models:
+        description: |
+          A compound model transferring positions in the slit frame to
+          positions in the MSA frame.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-1.1.0.yaml
@@ -1,0 +1,65 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/snell-1.1.0"
+title: >
+  NIRSpec transforms through the prism.
+
+description: |
+  This model does all transforms through the NIRSpec prism:
+  - computes the refraction index as a function of lambda.
+  - Applies Snell's law through front surface.
+  - Rotates to back surface.
+  - Applies reflection from back surface.
+  - Rotates to front surface
+  - Applies Snell's law through front surface.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      prism_angle:
+        description: |
+          The angle of the prism in deg.
+        type: number
+      kcoef:
+        description: |
+          K coefficients in Sellmeier equation.
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      lcoef:
+        description: |
+          L coefficients in Sellmeier equation.
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      tcoef:
+        description: |
+          Thermal coefficients of the glass.
+        type: array
+        items:
+          type: number
+        minItems: 6
+        maxItems: 6
+      ref_temp:
+        description: |
+          Reference temperature of the glass in [K].
+        type: number
+      ref_pressure:
+        description: |
+          Reference pressure of the glass in [ATM].
+        type: number
+      temp:
+        description: |
+          System temperature in [K].
+        type: number
+      pressure:
+        description: |
+          System pressure in [ATM].
+        type: number
+    required: [prism_angle, kcoef, lcoef, tcoef, ref_temp, ref_pressure, temp, pressure]

--- a/tests/test_embedded_asdf.py
+++ b/tests/test_embedded_asdf.py
@@ -7,9 +7,7 @@ from numpy.testing import assert_array_equal
 from astropy.io import fits
 
 from models import FitsModel
-
-
-_NDARRAY_TAG = "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+from stdatamodels.fits_support import _NDARRAY_TAG
 
 
 def create_fits_model():


### PR DESCRIPTION
This PR adds a test for "resources" (schemas, manifests, metaschemas) registered with asdf. The test checks:

- that every resource in the various resource directories is registered with asdf
- that the "id" in the resource matches the "uri" used to register the resource

There are a few issues with the resources that this test revealed:
```
===================================================================================================== short test summary info ======================================================================================================
FAILED test_integration.py::test_resource_id[resource19] - AssertionError: id[http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema] for resource[/Users/bgraham/projects/src/stdatamodels/src/stdatamodels/jwst/datamodels/schemas/nrsfs_apcorr.schema.yaml] did not return the co...
FAILED test_integration.py::test_resource_id[resource34] - AssertionError: id[http://stsci.edu/schemas/jwst_datamodel/abvegamag_offset.schema] for resource[/Users/bgraham/projects/src/stdatamodels/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml] was not registered...
FAILED test_integration.py::test_resource_id[resource82] - AssertionError: id[http://stsci.edu/schemas/jwst_datamodel/keyword_lampmode.schema] for resource[/Users/bgraham/projects/src/stdatamodels/src/stdatamodels/jwst/datamodels/schemas/keyword_lampstate.schema.yaml] did not retur...
```

These are all due to the "id" in the resource not matching the "uri" used to register the resource (although the errors differ if the "id" used matches a different "uri" as is the case for nrsfs_apcorr.schema.yaml and keyword_lampstate.schema.yaml). The "uri" is constructed based on the location of the file by the `DirectoryResourceMapping` used to register the resource. For the datamodels schemas:
https://github.com/spacetelescope/stdatamodels/blob/b7c7bcd83b7a32d908e3f63c5dece313b3611f7a/src/stdatamodels/jwst/datamodels/integration.py#L34-L37
using `nrsfs_apcorr.schema.yaml` as an example. This schema will be registered using the uri `http://stsci.edu/schemas/jwst_datamodel/nrsfs_apcorr.schema` which does not match the id in the file (which uses `nrsmos` instead of `nrsfs`).

The issues fixed with this PR are somewhat innocuous as they would only cause problems if the fixed schemas contained `$ref`s (which none do).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
