### PR TITLE
JP-3528: Add "IMAGER" as allowed value for MRSPRCHN keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@
 Bug Fixes
 ---------
 
--
+- Adding "IMAGER" as another allowed value for the "MRSPRCHN"
+  keyword, in order to support proper handling of MIRI MRS
+  and Imager exposures done in parallel. [#259]
 
 Changes to API
 --------------

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -1332,7 +1332,7 @@ properties:
           primary_channel:
             title: MRS primary channel
             type: string
-            enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4]
+            enum: [ALL, CHANNEL1, CHANNEL2, CHANNEL3, CHANNEL4, IMAGER]
             fits_keyword: MRSPRCHN
           dithered_ra:
             title: RA of dithered pointing location


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3528](https://jira.stsci.edu/browse/JP-3528)
Closes spacetelescope/jwst#8252

<!-- describe the changes comprising this PR here -->
This PR adds "IMAGER" as another allowed value for the "MRSPRCHN" keyword, in order to support proper handling of MIRI MRS and Imager exposures done in parallel.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
