### PR TITLE
add grating keyword to barshadow schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,11 +11,11 @@ Changes to API
 
 -
 
-
 Other
 -----
 
--
+- Add ``grating`` keyword to JWST ``barshadow`` ref file schema to match
+  parkeys on crds [#260]
 
 
 1.9.1 (2024-01-25)

--- a/src/stdatamodels/jwst/datamodels/schemas/barshadow.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/barshadow.schema.yaml
@@ -7,6 +7,7 @@ allOf:
 - $ref: referencefile.schema
 - $ref: keyword_pexptype.schema
 - $ref: keyword_exptype.schema
+- $ref: keyword_grating.schema
 - type: object
   properties:
     data1x1:


### PR DESCRIPTION
CRDS now uses `GRATING` for `barshadow` reference files.

This PR updates the `barshadow` schema to include the `grating` keyword schema.

See: https://jwst-crds.stsci.edu/browse/jwst_nirspec_barshadow_0007.rmap

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
