### PR TITLE
Update MultiSpec schema to provide keywords for recording extraction characteristics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,10 +25,6 @@ Other
   options to ``DarkModel`` and ``MIRIDarkModel``. Add the array extension
   to the ``RampModel``, for tracking the average dark current. [#265]
 
-- Add new JWST keywords ``EXTRXSTR``, ``EXTRXSTP``, ``EXTRYSTR``, and ``EXTRYSTP``
-  to the ``MultiSpecModel`` schema for extracted 1-D spectra. [#264]
-
-
 1.9.1 (2024-01-25)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Other
   options to ``DarkModel`` and ``MIRIDarkModel``. Add the array extension
   to the ``RampModel``, for tracking the average dark current. [#265]
 
+- Add ``EXTRXSTR``, ``EXTRXSTP``, ``EXTRYSTR``, and ``EXTRYSTP`` keywords
+  to the jwst ``MultiSpec`` schema. [#264]
+
+
 1.9.1 (2024-01-25)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Other
   options to ``DarkModel`` and ``MIRIDarkModel``. Add the array extension
   to the ``RampModel``, for tracking the average dark current. [#265]
 
+- Add new JWST keywords ``EXTRXSTR``, ``EXTRXSTP``, ``EXTRYSTR``, and ``EXTRYSTP``
+  to the ``MultiSpecModel`` schema for extracted 1-D spectra. [#264]
+
+
 1.9.1 (2024-01-25)
 ==================
 

--- a/src/stdatamodels/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/multispec.schema.yaml
@@ -84,6 +84,26 @@ allOf:
             type: number
             fits_keyword: EXTR_Y
             fits_hdu: EXTRACT1D
+          extraction_xstart:
+            title: X axis start of extraction region
+            type: number
+            fits_keyword: EXTRXSTR
+            fits_hdu: EXTRACT1D
+          extraction_xstop:
+            title: X axis end of extraction region
+            type: number
+            fits_keyword: EXTRXSTP
+            fits_hdu: EXTRACT1D
+          extraction_ystart:
+            title: Y axis start of extraction region
+            type: number
+            fits_keyword: EXTRYSTR
+            fits_hdu: EXTRACT1D
+          extraction_ystop:
+            title: Y axis end of extraction region
+            type: number
+            fits_keyword: EXTRYSTP
+            fits_hdu: EXTRACT1D
           shutter_state:
             title: All (open and close) shutters in a slit
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3169](https://jira.stsci.edu/browse/JP-3169)
<!Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn) -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Is needed to close spacetelescope/jwst#7773

<!-- describe the changes comprising this PR here -->
This PR updates the MultiSpec model to include the xstart, xstop, ystart, ystop values (if they are defined) so they can be recorded in the FITS header

The extraction x center and y center were already defined with keyword values of EXTR_X, EXTR_Y.
Since the extraction locations are related to these values I picked
EXTRXSTR: x start of extraction region
EXTRXSTP: x stop of extraction region
EXTRYSTR: y start of extraction region
EXTRYSTP: y stop of extraction region

But these value can be changed if a better set can be found

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
