### PR TITLE
JP-3463: Add average dark current to dark models and ramp model

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/dark.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/dark.schema.yaml
@@ -14,6 +14,7 @@ allOf:
 - $ref: keyword_groupgap.schema
 - $ref: keyword_gainfact.schema
 - $ref: keyword_psubarray.schema
+- $ref: keyword_darkcurrent.schema
 - $ref: subarray.schema
 - type: object
   properties:
@@ -34,5 +35,10 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       ndim: 3
+      datatype: float32
+    average_dark_current:
+      title: Average dark current
+      fits_hdu: AVDRKCUR
+      ndim: 2
       datatype: float32
 - $ref: dq_def.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/darkMIRI.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/darkMIRI.schema.yaml
@@ -11,6 +11,7 @@ allOf:
 - $ref: keyword_nframes.schema
 - $ref: keyword_ngroups.schema
 - $ref: keyword_groupgap.schema
+- $ref: keyword_darkcurrent.schema
 - $ref: subarray.schema
 - type: object
   properties:
@@ -31,5 +32,10 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       ndim: 4
+      datatype: float32
+    average_dark_current:
+      title: Average dark current
+      fits_hdu: AVDRKCUR
+      ndim: 2
       datatype: float32
 - $ref: dq_def.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/keyword_darkcurrent.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/keyword_darkcurrent.schema.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/keyword_darkcurrent.schema"
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      exposure:
+        type: object
+        properties:
+          average_dark_current:
+            title: Average dark current
+            type: number
+            fits_keyword: AVDRKCUR

--- a/src/stdatamodels/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ramp.schema.yaml
@@ -44,6 +44,11 @@ allOf:
       default: 0.0
       ndim: 4
       datatype: float32
+    average_dark_current:
+      title: Average dark current
+      fits_hdu: AVDRKCUR
+      ndim: 2
+      datatype: float32
 - $ref: group.schema
 - $ref: int_times.schema
 - $ref: msatargacq.schema


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Addresses [JP-3463](https://jira.stsci.edu/browse/JP-3463)

<!-- describe the changes comprising this PR here -->
This PR adds necessary datamodel updates to hold the average dark current, a parameter being added for tracking contributions to the poisson variance from the dark current.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
