### PR TITLE
update asdf docs link to latest

### DIFF
--- a/docs/source/asdf_in_fits.rst
+++ b/docs/source/asdf_in_fits.rst
@@ -23,7 +23,7 @@ statement. ::
         pass
 
 It is recommended that a with statement is used to ensure the resulting
-`asdf.AsdfFile <https://asdf.readthedocs.io/en/stable/api/asdf.AsdfFile.html>`_
+`asdf.AsdfFile <https://asdf.readthedocs.io/en/latest/api/asdf.AsdfFile.html>`_
 and `astropy.io.fits.HDUList <https://docs.astropy.org/en/stable/io/fits/api/hdulists.html#hdulist>`_ are closed properly.
 
 If a ``with`` statement cannot be used,


### PR DESCRIPTION
Updates a link in the docs to point to the latest asdf docs (instead of the infrequently updated "stable" docs).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
