### PR TITLE
safely convert FITS_rec for non-schema data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@
 
 - Drop support for python 3.9 [#287]
 
+- Convert ``FITS_rec`` instances read from old files where a
+  hdu was linked in the old schema (but is no longer linked)
+  when rewriting files. [#268]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -504,9 +504,7 @@ def to_fits(tree, schema, hdulist=None):
     if _ASDF_EXTENSION_NAME in hdulist:
         del hdulist[_ASDF_EXTENSION_NAME]
 
-    # Do not pass "extra_fits" to _create_asdf_hdu
-    # as we've already saved the contents above in _save_extra_fits
-    hdulist.append(_create_asdf_hdu({k: v for k, v in tree.items() if k != 'extra_fits'}))
+    hdulist.append(_create_asdf_hdu(tree))
 
     return hdulist
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -697,3 +697,14 @@ def test_table_linking(tmp_path):
         tree_string = asdf_bytes.split(b'...')[0].decode('ascii')
         unlinked_arrays = re.findall(r'source:\s+[^f]', tree_string)
         assert not len(unlinked_arrays), unlinked_arrays
+
+
+def test_fitsrec_for_non_schema_data(tmp_path):
+    # make a file where some non-schema data is linked between
+    # the asdf extension and another hdu. This simulates an old
+    # file where this condition might occur (perhaps after a schema
+    # update).
+    m = DataModel()
+    m._instance['sneaky_table'] = fits.FITS_rec(np.array([('a', 1),], dtype=[('foo', 'S3'), ('bar', 'f4')]))
+    fn = tmp_path / "test.fits"
+    m.save(fn)


### PR DESCRIPTION
Convert ``FITS_rec`` instances read from old files where a hdu was linked in the old schema (but is no longer linked) when rewriting files.

Resolves [JP-3555](https://jira.stsci.edu/browse/JP-3555)

Regression tests run:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1250/

As this is aimed to fix warnings like:
```
  /data1/jenkins/workspace/RT/JWST-devdeps/miniconda/envs/tmp_env0/lib/python3.11/site-packages/asdf/yamlutil.py:282: AsdfConversionWarning: A ndarray subclass (<class 'astropy.io.fits.fitsrec.FITS_rec'>) was converted as a ndarray. This behavior will be removed from a future version of ASDF. See https://asdf.readthedocs.io/en/latest/asdf/config.html#convert-unknown-ndarray-subclasses
```
which by-default do not produce errors. The log output of the regression test run will need to be manually checked (as I did not start this run with `-W error::asdf.exceptions.AsdfConversionWarning`.

No warnings about ndarray subclass conversions are in the above regtest run log.

1 common and unrelated error occurred for `[stable-deps] test_duplicate_names – jwst.associations.tests.test_level3_duplicate` failing to find a log message (likely due to stpipe logging issues).

1 related warning can be seen in the regtest run:
```
jwst/regtest/test_fgs_guider.py::test_fgs_guider[exptype_fgs_id_stack-cal]
/data1/jenkins/workspace/RT/JWST-Developers-Pull-Requests/miniconda/envs/tmp_env2/lib/python3.11/site-packages/asdf/yamlutil.py:333: AsdfConversionWarning: tag:stsci.edu:asdf/core/asdf-1.0.0 is not recognized, converting to raw Python data structure
```
This is caused by the regtest input file:
https://bytesalad.stsci.edu/ui/repos/tree/General/jwst-pipeline/dev/fgs/level1b/exptype_fgs_id_stack_uncal.fits?clearFilter=true
containing outdated and invalid asdf
```yaml
#ASDF 1.0.0
#ASDF_STANDARD 1.2.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.0.0
```
The file reports `ASDF_STANDARD 1.2.0` yet uses the `asdf-1.0.0` tag which should be `asdf-1.1.0` in this [version of the standard](https://github.com/asdf-format/asdf-standard/blob/7d75d4341a9d73b27a2d3d7c1327ef6267b4c80a/resources/manifests/asdf-format.org/core/core-1.2.0.yaml#L7). The same error can be seen by opening the file with `stdatamodels`. Re-saving the file fixes this issue.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
