### PR TITLE
update test mapping emicorr reference files to EmiModel

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -126,6 +126,7 @@ ref_to_datamodel_dict = {
     'dflat': dm.NirspecFlatModel,
     'disperser': dm.DisperserModel,
     'drizpars': dm.DrizParsModel,
+    'emicorr': dm.EmiModel,
     'extract1d': dm.Extract1dIFUModel,
     'fflat': dm.NirspecFlatModel,
     'filteroffset': dm.FilteroffsetModel,


### PR DESCRIPTION
The `test_schema_against_crds` tests are failing on main:
https://github.com/spacetelescope/stdatamodels/actions/runs/8096660095/job/22125905730
due to a lack of mapping between the now-available `emicorr` reference file and the `EmiModel` model used for this file type.

This PR updates the test for the mapping in the test to map `emicorr` to `EmiModel`.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
