### PR TITLE
deprecate skip_fits_update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,11 @@
   hdu was linked in the old schema (but is no longer linked)
   when rewriting files. [#268]
 
+- Deprecate ``skip_fits_update`` and environment variable
+  ``SKIP_FITS_UPDATE``. Future behavior will be as if
+  ``skip_fits_update`` was ``False`` and the FITS headers
+  will always be read [#270]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -334,6 +334,7 @@ STRICT_VALIDATION
   Default is ``False``.
 
 SKIP_FITS_UPDATE
+  DEPRECATED in the future the fits header will always be used
   Used by `~jwst.datamodels.DataModel` when instantiating a
   model from a FITS file. When ``False``, models opened from FITS files will
   proceed and load the FITS header values into the model. When ``True`` and the

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -334,7 +334,7 @@ STRICT_VALIDATION
   Default is ``False``.
 
 SKIP_FITS_UPDATE
-  DEPRECATED in the future the fits header will always be used
+  DEPRECATED: In the future the FITS header will always be used.
   Used by `~jwst.datamodels.DataModel` when instantiating a
   model from a FITS file. When ``False``, models opened from FITS files will
   proceed and load the FITS header values into the model. When ``True`` and the

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -698,6 +698,7 @@ def from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
         The `DataModel` to update
 
     skip_fits_update : bool or None
+        DEPRECATED
         When `False`, models opened from FITS files will proceed
         and load the FITS header values into the model.
         When `True` and the FITS file has an ASDF extension, the
@@ -850,6 +851,9 @@ def _verify_skip_fits_update(skip_fits_update, hdulist, asdf_struct, context):
     """
     if skip_fits_update is None:
         skip_fits_update = util.get_envar_as_boolean('SKIP_FITS_UPDATE', None)
+    if skip_fits_update is not None:
+        # warn if the value was not None (defined by the user)
+        warnings.warn("skip_fits_update is deprecated and will be removed", DeprecationWarning)
 
     # If skipping has been explicitly disallowed, indicate as such.
     if skip_fits_update is False:

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import warnings
 
@@ -89,13 +90,20 @@ def test_skip_fits_update(jail_environ,
         except KeyError:
             # No need to worry, environmental doesn't exist anyways
             pass
+
+        if skip_fits_update is not None:
+            ctx = pytest.warns(DeprecationWarning, match="skip_fits_update is deprecated")
+        else:
+            ctx = contextlib.nullcontext()
+
         if use_env:
             if skip_fits_update is not None:
                 os.environ['SKIP_FITS_UPDATE'] = str(skip_fits_update)
                 skip_fits_update = None
 
-        with datamodels.open(hduls, skip_fits_update=skip_fits_update) as model:
-            assert model.meta.exposure.type == expected_exp_type
+        with ctx:
+            with datamodels.open(hduls, skip_fits_update=skip_fits_update) as model:
+                assert model.meta.exposure.type == expected_exp_type
 
 
 def test_asnmodel_table_size_zero():

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -80,6 +80,7 @@ def open(init=None, guess=True, memmap=False, **kwargs):
         - FITS
 
            skip_fits_update :  bool or None
+              DEPRECATED
               `True` to skip updating the ASDF tree from the FITS headers, if possible.
               If `None`, value will be taken from the environmental SKIP_FITS_UPDATE.
               Otherwise, the default value is `True`.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -138,6 +138,7 @@ class DataModel(properties.ObjectNode):
             - FITS
 
               skip_fits_update - bool or None
+                  DEPRECATED
                   `True` to skip updating the ASDF tree from the FITS headers, if possible.
                   If `None`, value will be taken from the environmental SKIP_FITS_UPDATE.
                   Otherwise, the default value is `True`.

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 import warnings
 
@@ -421,13 +422,19 @@ def test_skip_fits_update(tmp_path,
     with fits.open(file_path) as hduls:
         hduls[0].header['EXP_TYPE'] = 'FGS_DARK'
 
+        if skip_fits_update is not None:
+            ctx = pytest.warns(DeprecationWarning, match="skip_fits_update is deprecated")
+        else:
+            ctx = contextlib.nullcontext()
+
         if use_env:
             if skip_fits_update is not None:
                 monkeypatch.setenv("SKIP_FITS_UPDATE", str(skip_fits_update))
                 skip_fits_update = None
 
-        model = FitsModel(hduls, skip_fits_update=skip_fits_update)
-        assert model.meta.exposure.type == expected_exp_type
+        with ctx:
+            model = FitsModel(hduls, skip_fits_update=skip_fits_update)
+            assert model.meta.exposure.type == expected_exp_type
 
 
 def test_from_hdulist(tmp_path):


### PR DESCRIPTION
`skip_fits_update` is [unused in jwst](https://github.com/search?q=repo%3Aspacetelescope%2Fjwst+skip_fits_update&type=code)
as is [SKIP_FITS_UPDATE](https://github.com/search?q=repo%3Aspacetelescope%2Fjwst+SKIP_FITS_UPDATE&type=code).

This PR deprecates their usage. Their eventual removal will allow `stdatamodels` to reduce data duplicated between the fits headers/hdus and the `ASDF` extension (including `extra_fits` which is entirely duplicated in both).

This is a step towards the eventual removal of `skip_fits_update`, see: https://github.com/spacetelescope/stdatamodels/issues/271

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
