### PR TITLE
deprecate check_memory_allocation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 - Remove ``TEXPTIME`` keyword from the JWST core datamodel schema
   because it duplicates the information of ``XPOSURE``. [#277]
 
+- Deprecate ``check_memory_allocation``. This function did not
+  work as intended. [#273] 
+
+
 1.10.0 (2024-02-29)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@
   because it duplicates the information of ``XPOSURE``. [#277]
 
 - Deprecate ``check_memory_allocation``. This function did not
-  work as intended. [#273] 
+  work as intended. [#273]
 
 
 1.10.0 (2024-02-29)

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -343,6 +343,7 @@ SKIP_FITS_UPDATE
   of the FITS header can be skipped or not.
 
 DMODEL_ALLOWED_MEMORY
+  DEPRECATED this function did not behave as intended
   Implemented by the utility function
   `jwst.datamodels.util.check_memory_allocation` and used by
   `~jwst.outlier_detection.OutlierDetectionStep` and

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -343,7 +343,6 @@ SKIP_FITS_UPDATE
   of the FITS header can be skipped or not.
 
 DMODEL_ALLOWED_MEMORY
-  DEPRECATED this function did not behave as intended
   Implemented by the utility function
   `jwst.datamodels.util.check_memory_allocation` and used by
   `~jwst.outlier_detection.OutlierDetectionStep` and

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -89,9 +89,10 @@ def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
         monkeypatch.setenv('DMODEL_ALLOWED_MEMORY', str(allowed_env))
 
     # Allocate amount that would fit at 100% + swap.
-    can_allocate, required = util.check_memory_allocation(
-        (MEMORY // 2, 1), allowed=allowed_explicit,
-    )
+    with pytest.warns(DeprecationWarning, match="check_memory_allocation is deprecated"):
+        can_allocate, required = util.check_memory_allocation(
+            (MEMORY // 2, 1), allowed=allowed_explicit,
+        )
     assert can_allocate is result
 
 
@@ -107,9 +108,10 @@ def test_check_memory_allocation_env(monkeypatch, mock_get_available_memory,
 )
 def test_check_memory_allocation(mock_get_available_memory, dim, allowed, include_swap, result):
     """Check general operation of check_memory_allocation"""
-    can_allocate, required = util.check_memory_allocation(
-        (dim, 1), allowed=allowed, include_swap=include_swap
-    )
+    with pytest.warns(DeprecationWarning, match="check_memory_allocation is deprecated"):
+        can_allocate, required = util.check_memory_allocation(
+            (dim, 1), allowed=allowed, include_swap=include_swap
+        )
     assert can_allocate is result
 
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_util.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_util.py
@@ -1,3 +1,5 @@
+import platform
+
 from stdatamodels.jwst.datamodels import util
 
 import pytest
@@ -6,8 +8,13 @@ import pytest
 @pytest.mark.parametrize("func_name", [
     "get_available_memory",
     "get_available_memory_linux",
-    "get_available_memory_darwin",
 ])
 def test_deprecated(func_name):
     with pytest.warns(DeprecationWarning, match=f"{func_name} is deprecated"):
         getattr(util, func_name)()
+
+
+@pytest.mark.skipif(platform.system() != 'Darwin', reason="only runs on darwin")
+def test_deprecated_get_available_memory_darwin():
+    with pytest.warns(DeprecationWarning, match="get_available_memory_darwin is deprecated"):
+        util.get_available_memory_darwin()

--- a/src/stdatamodels/jwst/datamodels/tests/test_util.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_util.py
@@ -1,0 +1,13 @@
+from stdatamodels.jwst.datamodels import util
+
+import pytest
+
+
+@pytest.mark.parametrize("func_name", [
+    "get_available_memory",
+    "get_available_memory_linux",
+    "get_available_memory_darwin",
+])
+def test_deprecated(func_name):
+    with pytest.warns(DeprecationWarning, match=f"{func_name} is deprecated"):
+        getattr(util, func_name)()

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -415,6 +415,10 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
     can_instantiate, required_memory : bool, number
         True if the model can be instantiated and the predicted memory footprint.
     """
+    warnings.warn(
+        "check_memory_allocation is deprecated and did not work as intended",
+        DeprecationWarning
+    )
     # Determine desired allowed amount.
     if allowed is None:
         allowed = os.environ.get('DMODEL_ALLOWED_MEMORY', None)

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -442,7 +442,9 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
         size *= dimension
 
     # Get available memory
-    available = get_available_memory(include_swap=include_swap)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        available = get_available_memory(include_swap=include_swap)
     log.debug(f'Model size {bytes2human(size)} available system memory {bytes2human(available)}')
 
     if size > available:
@@ -473,15 +475,22 @@ def get_available_memory(include_swap=True):
     available : number
         The amount available.
     """
+    warnings.warn(
+        "get_available_memory is deprecated. Please use psutil",
+        DeprecationWarning
+    )
     system = platform_system()
 
     # Apple MacOS
     log.debug(f'Running OS is "{system}"')
     if system in ['Darwin']:
-        return get_available_memory_darwin(include_swap=include_swap)
+        get_available_memory_os = get_available_memory_darwin
+    else:
+        get_available_memory_os = get_available_memory_linux
 
-    # Default to Linux-like:
-    return get_available_memory_linux(include_swap=include_swap)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        return get_available_memory_os(include_swap=include_swap)
 
 
 def get_available_memory_linux(include_swap=True):
@@ -500,6 +509,10 @@ def get_available_memory_linux(include_swap=True):
     available : number
         The amount available.
     """
+    warnings.warn(
+        "get_available_memory_linux is deprecated. Please use psutil",
+        DeprecationWarning
+    )
     vm_stats = psutil.virtual_memory()
     available = vm_stats.available
     if include_swap:
@@ -527,6 +540,10 @@ def get_available_memory_darwin(include_swap=True):
     available : number
         The amount available.
     """
+    warnings.warn(
+        "get_available_memory_darwin is deprecated. Please use psutil",
+        DeprecationWarning
+    )
     vm_stats = psutil.virtual_memory()
     available = vm_stats.available
     if include_swap:


### PR DESCRIPTION
See the below issue for the motivation behind this PR.

In brief, this PR deprecates `check_memory_allocation` which has 1 use in jwst:
https://github.com/spacetelescope/jwst/blob/e1215951096c2057df6abff6087b7f12d429ab25/jwst/resample/resample.py#L144-L146
Effectively this function:
- allocates a large array
- checks it's memory consumption against "allowed" amount
- then throws out the array
If the check passes, the array is re-allocated (and hopefully the original is garbage collected). If the check fails it is certain that the amount of "allowed" memory usage was already exceeded (to perform the check).

Work towards addressing: https://github.com/spacetelescope/stdatamodels/issues/272

https://github.com/spacetelescope/jwst/pull/8324 removes the 1 use in jwst. Keeping this PR draft until that PR is merged.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
