### PR TITLE
remove global changes to warning filters

### DIFF
--- a/src/stdatamodels/jwst/datamodels/drizproduct.py
+++ b/src/stdatamodels/jwst/datamodels/drizproduct.py
@@ -6,7 +6,6 @@ __all__ = ['DrizProductModel']
 
 
 def DrizProductModel(*args, **kwargs):
-    warnings.simplefilter('default')
     warnings.warn(message="DrizProduct is deprecated and will be removed.  "
                   "Use ImageModel.", category=DeprecationWarning)
     return ImageModel(*args, **kwargs)

--- a/src/stdatamodels/jwst/datamodels/multiprod.py
+++ b/src/stdatamodels/jwst/datamodels/multiprod.py
@@ -7,7 +7,6 @@ __all__ = ['MultiProductModel']
 
 
 def MultiProductModel(*args, **kwargs):
-    warnings.simplefilter('default')
     warnings.warn(message="MultiProductModel is deprecated and will be removed.  "
                   "Use MultiSlitModel.", category=DeprecationWarning)
     return MultiSlitModel(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ commands =
     bandit -r -ll src
 
 [testenv]
+allowlist_externals =
+    jwst: touch
 description =
     run tests
     xdist: using parallel processing
@@ -51,6 +53,8 @@ package=
 commands_pre =
     devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
     pip freeze
+# make an empty pytest.ini so jwst tests don't use the settings in pyprojec.toml
+    jwst: touch pytest.ini
 commands =
     pytest \
     xdist: -n auto \

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,6 @@ commands =
     xdist: -n auto \
     cov: --cov=src --cov-report=term-missing --cov-report=xml \
     jwst: --pyargs jwst --ignore-glob=*/scripts/* \
-    jwst: -o filterwarnings="[]" \
     # TODO: fix bug with `.finalize()` in `jwst.associations`
     jwst: --ignore-glob=*/associations/tests/test_dms.py \
     {posargs}


### PR DESCRIPTION
This PR removes some warnings filters including:
- filter resets for jwst tests in the CI for this package
- non-context calls to `warnings.simplefilter('default')` during creation of deprecated models `DrizProductModel` and `MultiProductModel`

The second item above may help jwst cleanup of warning filters as the non-context use of `simplefilter('default')` will reset any prior calls to `simplefilter('error')` (or similar).

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
