### PR TITLE
provide existing asdf file to validate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 1.10.1 (unreleased)
 ===================
 
-- 
+- Provide existing ``AsdfFile`` instance to ``validate`` to
+  speed up assignment validation ``check_value``. [#276] 
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -152,7 +152,7 @@ def _check_value(value, schema, ctx):
         else:
             validators = YAML_VALIDATORS
 
-        asdf_schema.validate(value, schema=schema, validators=validators)
+        asdf_schema.validate(value, ctx=ctx._asdf, schema=schema, validators=validators)
 
 
 def _error_message(path, error):


### PR DESCRIPTION
During validation on assignment `check_value` a call is made to `asdf.schema.validate`. This PR speeds up that call by passing in a `ctx` `AsdfFile` instance (one used a few lines prior).

This should speed up all validated `DataModel` assignments including those performed during `open` (discussed: https://github.com/spacetelescope/stdatamodels/pull/270). For example opening:
https://bytesalad.stsci.edu/ui/repos/tree/General/jwst-pipeline/dev/nircam/image/jw01538046001_03105_00001_nrcblong_rate.fits?clearFilter=true
with `skip_fits_update=False` (which will result in assignment to all parts of the model linked to the fits data) without this PR takes 177 ms. With this PR opening the same model takes 72 ms.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
