### PR TITLE
JP-3465: removed product exposure time TEXPTIME

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 1.10.1 (unreleased)
 ===================
 
-- 
+- Remove ``TEXPTIME`` keyword from the JWST core datamodel schema
+  because it duplicates the information of ``XPOSURE``. [#277]
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2597,10 +2597,6 @@ properties:
             title: "Number of groups/pointings included in resampled product"
             type: integer
             fits_keyword: NDRIZ
-          product_exposure_time:
-            title: "[s] Total exposure time for product"
-            type: number
-            fits_keyword: TEXPTIME
           weight_type:
             title: Type of drizzle weighting to use in resampling input
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3465](https://jira.stsci.edu/browse/JP-3465)

<!-- describe the changes comprising this PR here -->
This PR addresses removal of the TEXPTIME (product exposure time) keyword, since it is functionally redundant with XPOSURE and EFFEXPTM and is not used by any high-level data processing scripts we know about.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
