### PR TITLE
add cache for slow hdu indexing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@
 
 - Deprecate ``deprecate_class`` unused by downstream. [#274] 
 
+- Add cache to hdu accesses during ``_load_from_schema``
+  to speed up file opening. [#278]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -128,8 +128,10 @@ def _get_hdu_pair(hdu_name, index=None):
     return pair
 
 
-def get_hdu(hdulist, hdu_name, index=None):
+def get_hdu(hdulist, hdu_name, index=None, _cache=None):
     pair = _get_hdu_pair(hdu_name, index=index)
+    if _cache is not None and pair in _cache:
+        return _cache[pair]
     try:
         hdu = hdulist[pair]
     except (KeyError, IndexError, AttributeError):
@@ -153,6 +155,8 @@ def get_hdu(hdulist, hdu_name, index=None):
                 "{0!r} HDU".format(
                     pair))
 
+    if _cache is not None:
+        _cache[pair] = hdu
     return hdu
 
 
@@ -517,11 +521,11 @@ def _create_asdf_hdu(tree):
 # READER
 
 
-def _fits_keyword_loader(hdulist, fits_keyword, schema, hdu_index, known_keywords):
+def _fits_keyword_loader(hdulist, fits_keyword, schema, hdu_index, known_keywords, fits_hdu_cache):
 
     hdu_name = _get_hdu_name(schema)
     try:
-        hdu = get_hdu(hdulist, hdu_name, hdu_index)
+        hdu = get_hdu(hdulist, hdu_name, hdu_index, _cache=fits_hdu_cache)
     except AttributeError:
         return None
 
@@ -539,11 +543,11 @@ def _fits_keyword_loader(hdulist, fits_keyword, schema, hdu_index, known_keyword
     return val
 
 
-def _fits_array_loader(hdulist, schema, hdu_index, known_datas, context):
+def _fits_array_loader(hdulist, schema, hdu_index, known_datas, context, fits_hdu_cache):
     hdu_name = _get_hdu_name(schema)
     _assert_non_primary_hdu(hdu_name)
     try:
-        hdu = get_hdu(hdulist, hdu_name, hdu_index)
+        hdu = get_hdu(hdulist, hdu_name, hdu_index, _cache=fits_hdu_cache)
     except AttributeError:
         return None
 
@@ -577,13 +581,19 @@ def _load_from_schema(hdulist, schema, tree, context, skip_fits_update=False):
     # This is needed to constrain the loop over HDU's when resolving arrays.
     max_extver = max(hdu.ver for hdu in hdulist) if len(hdulist) else 0
 
+    # hdulist.__getitem__ is surprisingly slow (2 ms per call on my system
+    # for a nirspec mos file with ~500 extensions) so we use a cache
+    # here to handle repeated accesses. A lru_cache around get_hdu
+    # was not used as hdulist is not hashable.
+    hdu_cache = {}
+
     def callback(schema, path, combiner, ctx, recurse):
         result = None
         if not skip_fits_update and 'fits_keyword' in schema:
             fits_keyword = schema['fits_keyword']
             result = _fits_keyword_loader(
                 hdulist, fits_keyword, schema,
-                ctx.get('hdu_index'), known_keywords)
+                ctx.get('hdu_index'), known_keywords, hdu_cache)
 
             if result is None and context._validate_on_assignment:
                 validate.value_change(path, result, schema, context)
@@ -597,7 +607,7 @@ def _load_from_schema(hdulist, schema, tree, context, skip_fits_update=False):
         elif 'fits_hdu' in schema and (
                 'max_ndim' in schema or 'ndim' in schema or 'datatype' in schema):
             result = _fits_array_loader(
-                hdulist, schema, ctx.get('hdu_index'), known_datas, context)
+                hdulist, schema, ctx.get('hdu_index'), known_datas, context, hdu_cache)
 
             if result is None and context._validate_on_assignment:
                 validate.value_change(path, result, schema, context)


### PR DESCRIPTION
Opening a jwst file with many (~550) extensions (level 2 output for nirspec mos mode) take ~9 seconds (when `skip_fits_update=True`). Opening the same file with `skip_fits_update=False` takes longer, ~26 seconds. Surprisingly, a large portion of the added time is spent in calls to `get_hdu`.

Using `cProfile` and `skip_fits_update=False` opening now takes ~60 seconds (due to profiling overhead) and the rendered profile (with snakeviz) is as follows:

<img width="1023" alt="Screen Shot 2024-03-06 at 10 17 06 AM" src="https://github.com/spacetelescope/stdatamodels/assets/114267/2c570ac9-4435-4886-979a-c8f1fdfd3198">

zooming into `_load_from_schema` reveals ~40 seconds in `get_hdu`
<img width="1030" alt="Screen Shot 2024-03-06 at 10 17 57 AM" src="https://github.com/spacetelescope/stdatamodels/assets/114267/5d090851-83a1-43ca-b27b-2c0284d9b36e">

This PR adds a `hdu_cache` to skip repeated indexing the hdulist (which in some conditions for this file takes 2-3 ms). With this PR opening the same file with `skip_fits_update=False` (and no profiling) takes 12 seconds and with `skip_fits_update=True` still takes 9 seconds (most of this is spent in `asdf.open` as the tree is quite large). Running `cProfile` with `skip_fits_update=False` takes 24 seconds and zooming in to `get_hdu` reveals 5 seconds spent in `get_hdu` (20% down from 66% without this PR):
<img width="1027" alt="Screen Shot 2024-03-06 at 10 23 19 AM" src="https://github.com/spacetelescope/stdatamodels/assets/114267/560e5e1e-5538-45a7-a997-a14ff14b43a0">

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
