### PR TITLE
limit oifits SPECTYP and TARGET to 16 characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,15 @@
 
 - Deprecate ``deprecate_class`` unused by downstream. [#274] 
 
+<<<<<<< HEAD
 - Remove ``TEXPTIME`` keyword from the JWST core datamodel schema
   because it duplicates the information of ``XPOSURE``. [#277]
 
 - Deprecate ``check_memory_allocation``. This function did not
   work as intended. [#273]
+
+- Decrease size of ``SPECTYP`` and ``TARGET`` columns in
+  ``OI_TARGET`` table of oifits schema to 16 characters. [#281]
 
 
 1.10.0 (2024-02-29)

--- a/src/stdatamodels/jwst/datamodels/schemas/oifits.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/oifits.schema.yaml
@@ -220,7 +220,7 @@ allOf:
       - name: TARGET_ID
         datatype: int16
       - name: TARGET
-        datatype: [ascii, 32]
+        datatype: [ascii, 16]
       - name: RAEP0
         datatype: float64
       - name: DECEP0
@@ -250,7 +250,7 @@ allOf:
       - name: PARA_ERR
         datatype: float32
       - name: SPECTYP
-        datatype: [ascii, 32]
+        datatype: [ascii, 16]
     t3:
       title: OIFITS OI_T3 table
       fits_hdu: OI_T3


### PR DESCRIPTION
The oifits standard:
https://www.aanda.org/articles/aa/pdf/2017/01/aa26405-15.pdf
limits the `SPECTYP` and `TARGET` columns of `OI_TARGET` to 16 characters. The schema currently defines them as 32. This does not raise validation errors with `oifits-check` (part of [oifitslib](https://github.com/jsy1001/oifitslib)) but does raise validation errors for the online validator: http://oival.jmmc.fr/validate.xql

This PR reduces the number of characters to 16.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
