### PR TITLE
fix error in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@
 
 - Deprecate ``deprecate_class`` unused by downstream. [#274] 
 
-<<<<<<< HEAD
 - Remove ``TEXPTIME`` keyword from the JWST core datamodel schema
   because it duplicates the information of ``XPOSURE``. [#277]
 


### PR DESCRIPTION
During conflict resolution a changelog error was introduced in:
https://github.com/spacetelescope/stdatamodels/pull/281

This PR fixes the changelog by removing the extra `<<<<<<< HEAD`.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
