### PR TITLE
JP-3558: update integration_number dtype in group schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 - Decrease size of ``SPECTYP`` and ``TARGET`` columns in
   ``OI_TARGET`` table of oifits schema to 16 characters. [#281]
 
+- Change ``integration_number`` from int16 to int32 in ``group``
+  schema. [#283]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/jwst/datamodels/schemas/group.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/group.schema.yaml
@@ -9,7 +9,7 @@ properties:
     fits_hdu: GROUP
     datatype:
     - name: integration_number
-      datatype: int16
+      datatype: int32
     - name: group_number
       datatype: int16
     - name: end_day


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3558](https://jira.stsci.edu/browse/JP-3558)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes [#8323](https://github.com/spacetelescope/jwst/issues/8323)

<!-- describe the changes comprising this PR here -->
This PR prevents values from wrapping around the limit of the int16 range in observations with a large number of integrations.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
