### PR TITLE
increase asdf version, switch _force_raw_types for load_yaml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@
   ``skip_fits_update`` was ``False`` and the FITS headers
   will always be read [#270]
 
+- Increase minimum required asdf version [#288]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf>=2.15.0",
+    "asdf>=3.1.0",
     "asdf-transform-schemas>=0.5.0",
     "asdf-astropy>=0.3.0",
     "psutil>=5.7.2",

--- a/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
@@ -73,8 +73,8 @@ def test_niriss_soss(tmpdir):
     with asdf.AsdfFile({"model": soss_model}) as af:
         af.write_to(path)
 
-    with asdf.open(path, _force_raw_types=True) as af:
-        assert af.tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss_soss-1.0.0"
+    tagged_tree = asdf.util.load_yaml(path, tagged=True)
+    assert "tag:stsci.edu:jwst_pipeline/niriss_soss" in tagged_tree["model"]._tag
 
 
 def test_niriss_soss_legacy():
@@ -82,8 +82,8 @@ def test_niriss_soss_legacy():
     data = os.path.join(data_path, 'niriss_soss.asdf')
 
     # confirm that the file contains the legacy tag
-    with asdf.open(data, _force_raw_types=True) as af:
-        assert af.tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0"
+    tagged_tree = asdf.util.load_yaml(data, tagged=True)
+    assert tagged_tree["model"]._tag == "tag:stsci.edu:jwst_pipeline/niriss-soss-0.7.0"
 
     # test that it opens with the legacy tag
     with asdf.open(data) as af:

--- a/tests/test_embedded_asdf.py
+++ b/tests/test_embedded_asdf.py
@@ -25,9 +25,9 @@ def create_fits_model():
 
 def open_embedded_asdf(file_path):
     with fits.open(file_path) as hdul:
-        return asdf.open(
+        return asdf.util.load_yaml(
             BytesIO(hdul["ASDF"].data["ASDF_METADATA"].tobytes()),
-            _force_raw_types=True,
+            tagged=True,
         )
 
 
@@ -60,7 +60,7 @@ def test_asdf_hdu_format(tmp_path):
         # Force raw types to avoid errors when the ndarray converter
         # encounters the linked FITS arrays.
         fd = BytesIO(asdf_bytes)
-        asdf.open(fd, _force_raw_types=True)
+        asdf.open(fd)
 
 
 def test_linked_arrays(tmp_path):
@@ -69,26 +69,26 @@ def test_linked_arrays(tmp_path):
     model, data, dq, err = create_fits_model()
     model.save(file_path)
 
-    af = open_embedded_asdf(file_path)
+    tagged_tree = open_embedded_asdf(file_path)
 
-    assert "data" in af
-    tagged_data = af["data"]
+    assert "data" in tagged_tree
+    tagged_data = tagged_tree["data"]
     assert tagged_data._tag == _NDARRAY_TAG
     assert tagged_data["source"] == "fits:SCI,1"
     assert tagged_data["datatype"] == "float32"
     assert tagged_data["byteorder"] == "big"
     assert tagged_data["shape"] == [50, 50]
 
-    assert "dq" in af
-    tagged_dq = af["dq"]
+    assert "dq" in tagged_tree
+    tagged_dq = tagged_tree["dq"]
     assert tagged_dq._tag == _NDARRAY_TAG
     assert tagged_dq["source"] == "fits:DQ,1"
     assert tagged_dq["datatype"] == "uint32"
     assert tagged_dq["byteorder"] == "big"
     assert tagged_dq["shape"] == [50, 50]
 
-    assert "err" in af
-    tagged_err = af["err"]
+    assert "err" in tagged_tree
+    tagged_err = tagged_tree["err"]
     assert tagged_err._tag == _NDARRAY_TAG
     assert tagged_err["source"] == "fits:ERR,1"
     assert tagged_err["datatype"] == "float32"
@@ -120,10 +120,10 @@ def test_non_fits_array(tmp_path):
         # We shouldn't have gained an HDU:
         assert len(hdul) == 5
 
-    af = open_embedded_asdf(file_path)
-    assert "favorite_integers" in af
+    tagged_tree = open_embedded_asdf(file_path)
+    assert "favorite_integers" in tagged_tree
     # Should be an integer internal block source and not a string FITS source:
-    assert isinstance(af["favorite_integers"]["source"], int)
+    assert isinstance(tagged_tree["favorite_integers"]["source"], int)
 
     with FitsModel(file_path) as dm:
         assert_array_equal(dm.favorite_integers, favorite_integers)
@@ -139,8 +139,8 @@ def test_non_fits_metadata(tmp_path):
     with fits.open(file_path) as hdul:
         assert "splines" not in hdul[0].header
 
-    af = open_embedded_asdf(file_path)
-    assert af["splines"] == "reticulated"
+    tagged_tree = open_embedded_asdf(file_path)
+    assert tagged_tree["splines"] == "reticulated"
 
     with FitsModel(file_path) as dm:
         assert dm.splines == "reticulated"
@@ -158,8 +158,8 @@ def test_array_update_and_save_new_file(tmp_path):
         dm.data = new_data
         dm.save(updated_file_path)
 
-    af = open_embedded_asdf(updated_file_path)
-    assert af["data"]["source"] == "fits:SCI,1"
+    tagged_tree = open_embedded_asdf(updated_file_path)
+    assert tagged_tree["data"]["source"] == "fits:SCI,1"
 
     with fits.open(updated_file_path) as hdul:
         with FitsModel(hdul) as dm:
@@ -178,8 +178,8 @@ def test_array_update_and_save_same_file(tmp_path):
         dm.data = new_data
         dm.save(file_path)
 
-    af = open_embedded_asdf(file_path)
-    assert af["data"]["source"] == "fits:SCI,1"
+    tagged_tree = open_embedded_asdf(file_path)
+    assert tagged_tree["data"]["source"] == "fits:SCI,1"
 
     with fits.open(file_path) as hdul:
         with FitsModel(hdul) as dm:
@@ -202,8 +202,8 @@ def test_fits_array_view(tmp_path):
     model["view"] = view
     model.save(file_path)
 
-    af = open_embedded_asdf(file_path)
-    assert isinstance(af["view"]["source"], int)
+    tagged_tree = open_embedded_asdf(file_path)
+    assert isinstance(tagged_tree["view"]["source"], int)
 
     with fits.open(file_path) as hdul:
         # We shouldn't have gained an HDU:


### PR DESCRIPTION
Increases minimum asdf version to 3.1.0 (inline with jwst: https://github.com/spacetelescope/jwst/blob/master/pyproject.toml#L22) and switches `_force_raw_types` usage to `load_tree`.

Also updates one test that fails with ASDF standard 1.6.0 as the default due to an incorrect assumption about the tag version:
https://github.com/spacetelescope/stdatamodels/blob/50751a8f91a4cd8a685dfb7bc692a4fe30c08f18/src/stdatamodels/jwst/transforms/converters/tests/test_models.py#L76-L77
assumes the tag will be `1.0.0`. With ASDF standard 1.6.0 the tag will be `1.1.0`:
https://github.com/spacetelescope/stdatamodels/blob/50751a8f91a4cd8a685dfb7bc692a4fe30c08f18/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml#L46-L47

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
