### PR TITLE
add erfa to devdeps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ git+https://github.com/asdf-format/asdf
 
 # Use weekly astropy dev build
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+--extra-index-url https://pypi.anaconda.org/liberfa/simple erfa --pre
 
 # Use Bi-weekly numpy/scipy dev builds
 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
Our `py3-devdeps-xdist` job is failing due to astropy expecting a dev version of erfa
https://github.com/spacetelescope/stdatamodels/actions/runs/8422253967/job/23061149990

This PR adds erfa to `requirements-dev.txt` which allows the job to pass.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
