### PR TITLE
Free references to overwritten attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
 - Remove ``stdatamodels.jwst.datamodels.schema`` which is an out-of-date
   duplicate of ``stdatamodels.schema`` [#175]
 
+- Remove unnecessary references to overwritten datamodel
+  attributes to free up memory [#301]
+
 
 1.10.1 (2024-03-25)
 ===================

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -145,7 +145,10 @@ def _check_value(value, schema, ctx):
         # into nodes for custom types.
         value = remove_none_from_tree(value)
         value = convert_fitsrec_to_array_in_tree(value)
-        value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
+        # without this "write_context" asdf will queue up blocks for writing which
+        # will hold onto arrays after they have be overwritten
+        with ctx._asdf._blocks.write_context(None):
+            value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
 
         if ctx._validate_arrays:
             validators = _VALIDATORS


### PR DESCRIPTION
While looking into `resample` memory usage I found a way that repeated assignments to a datamodel attribute can result in accumulation of memory (until the model is written). An example is as follows:
```python
import jwst.datamodels as dm
import numpy as np
m = dm.ImageModel()
sci = m.data
m.data = np.zeros_like(sci)  # assign a "zeros" array to data
m.data = np.ones_like(sci)   # overwrite the "zeros" with a new "ones" array
```
Running the example the "zeros" array should be garbage collectable by python after the data is overwritten with the "ones" array. However this is not the case on the current main branch with the latest asdf and instead both the "zeros" and "ones" arrays will persist in memory until the model is written to disk (or freed). This is due to the assignment validation calling `custom_tree_to_tagged_tree` with the `DataModel._asdf` `AsdfFile` instance:
https://github.com/spacetelescope/stdatamodels/blob/4dfbff0bfb4e507502f793b4d199ec147f483d1c/src/stdatamodels/validate.py#L148
To validate the converted value, asdf has to generate a tree that contains a valid block number. This is accomplished by "queuing" the blocks to be written (even though in this case they are not immediately written, the order is needed). For normal file writes (where validation occurs) asdf uses a "options_context" to manage this write queue:
https://github.com/asdf-format/asdf/blob/d46fb6b3e327dfd4318891cf2c1cf39c5dd36222/asdf/_asdf.py#L614
This PR adds a "options_context" to similarly manage the queue which prevents holding onto the overwritten array (a test is added to confirm the behavior). The "options_context" is not currently part of the asdf "public" API (but perhaps it should be considered for inclusion or changes to `custom_tree_to_tagged_tree` considered).

Regression tests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1426/
show only unrelated failures (same as main: https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST/detail/JWST/2877/tests)

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
