### PR TITLE
JP-3581: add badpix_selfcal step to core schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@
 
 - Increase minimum required asdf version [#288]
 
+- Add ``S_BPXSLF`` keyword to the JWST core schema to reflect the addition
+  of the ``badpix_selfcal`` step. [#305]
+
 
 1.10.0 (2024-02-29)
 ===================

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2319,6 +2319,11 @@ properties:
             type: string
             fits_keyword: S_BKDSUB
             blend_table: True
+          badpix_selfcal:
+            title: Bad Pixel Self-Calibration
+            type: string
+            fits_keyword: S_BPXSLF
+            blend_table: True
           barshadow:
             title: Bar shadow correction
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3581](https://jira.stsci.edu/browse/JP-3581)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #8369

<!-- describe the changes comprising this PR here -->
This PR adds a new header keyword to the cal_step in the core schema to reflect the addition of the new badpix_selfcal step in JWST.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [x] added relevant label(s)
