### PR TITLE
remove unused ignore_version_mismatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - add grating keyword to dark and superbias schemas [#317]
 
+- remove uses of now unused ``ignore_version_mismatch`` [#313]
+
 2.0.0 (2024-06-24)
 ===================
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -729,7 +729,6 @@ def from_fits(hdulist, schema, context, skip_fits_update=None, **kwargs):
 
 
 def from_fits_asdf(hdulist,
-                   ignore_version_mismatch=True,
                    ignore_unrecognized_tag=False,
                    **kwargs):
     """
@@ -742,7 +741,6 @@ def from_fits_asdf(hdulist,
     except (KeyError, IndexError, AttributeError):
         # This means there is no ASDF extension
         return asdf.AsdfFile(
-            ignore_version_mismatch=ignore_version_mismatch,
             ignore_unrecognized_tag=ignore_unrecognized_tag,
         )
 
@@ -754,7 +752,6 @@ def from_fits_asdf(hdulist,
     }
     af = asdf.open(
         generic_file,
-        ignore_version_mismatch=ignore_version_mismatch,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         ignore_missing_extensions=ignore_missing_extensions,
         **akwargs

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -556,7 +556,6 @@ class DataModel(properties.ObjectNode):
 
     @staticmethod
     def open_asdf(init=None,
-                  ignore_version_mismatch=True,
                   ignore_unrecognized_tag=False,
                   **kwargs):
         """
@@ -564,13 +563,11 @@ class DataModel(properties.ObjectNode):
         """
         if isinstance(init, str):
             asdffile = asdf.open(init,
-                                 ignore_version_mismatch=ignore_version_mismatch,
                                  ignore_unrecognized_tag=ignore_unrecognized_tag,
                                  **kwargs)
 
         else:
             asdffile = AsdfFile(init,
-                            ignore_version_mismatch=ignore_version_mismatch,
                             ignore_unrecognized_tag=ignore_unrecognized_tag
                             )
         return asdffile

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -159,8 +159,7 @@ def test_initialize_arrays_with_arglist():
 
 def test_open_asdf_model(tmp_path):
     # Open an empty asdf file, pass extra arguments
-    with DataModel(ignore_version_mismatch=False, ignore_unrecognized_tag=True) as model:
-        assert not model._asdf._ignore_version_mismatch
+    with DataModel(ignore_unrecognized_tag=True) as model:
         assert model._asdf._ignore_unrecognized_tag
 
     file_path = tmp_path/"test.asdf"
@@ -168,8 +167,7 @@ def test_open_asdf_model(tmp_path):
     with asdf.AsdfFile() as af:
         af.write_to(file_path)
 
-    with DataModel(file_path, ignore_version_mismatch=False, ignore_unrecognized_tag=True) as model:
-        assert not model._asdf._ignore_version_mismatch
+    with DataModel(file_path, ignore_unrecognized_tag=True) as model:
         assert model._asdf._ignore_unrecognized_tag
 
 


### PR DESCRIPTION
`ignore_version_mismatch` no longer does anything (see https://github.com/asdf-format/asdf/issues/1812) since it was only used by the legacy asdf extension API removed in asdf 3.0.0.

This PR removes all uses of the setting.

There are no uses of `ignore_version_mismatch` in jwst: https://github.com/search?q=repo%3Aspacetelescope%2Fjwst%20ignore_version_mismatch&type=code

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
