### PR TITLE
add grating keyword to dark and superbias reference model schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - replace usages of ``copy_arrays`` with ``memmap`` [#306]
 
+- add grating keyword to dark and superbias schemas [#317]
+
 2.0.0 (2024-06-24)
 ===================
 

--- a/src/stdatamodels/jwst/datamodels/schemas/dark.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/dark.schema.yaml
@@ -15,6 +15,7 @@ allOf:
 - $ref: keyword_gainfact.schema
 - $ref: keyword_psubarray.schema
 - $ref: keyword_darkcurrent.schema
+- $ref: keyword_grating.schema
 - $ref: subarray.schema
 - type: object
   properties:

--- a/src/stdatamodels/jwst/datamodels/schemas/superbias.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/superbias.schema.yaml
@@ -9,6 +9,7 @@ allOf:
 - $ref: keyword_preadpatt.schema
 - $ref: keyword_gainfact.schema
 - $ref: keyword_noutputs.schema
+- $ref: keyword_grating.schema
 - $ref: bunit.schema
 - type: object
   properties:

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
-    jwst: stpipe @ git+https://github.com/spacetelescope/stpipe.git
 package=
     cov: editable
     !cov: wheel


### PR DESCRIPTION
A new crds context added grating as selection criteria requiring updates to the dark and superbias reference model schemas.

This PR also removes installing dev stpipe for the jwst test. That dependency should be left up to jwst.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
