### PR TITLE
JP-3664: Numpy 2.0 exposed implicit type promotion

### DIFF
--- a/changes/319.feature.rst
+++ b/changes/319.feature.rst
@@ -1,0 +1,1 @@
+Update JWST datamodel ``irs2`` datatype to provide ``numpy>=2.0`` compatibility.

--- a/src/stdatamodels/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/irs2.schema.yaml
@@ -34,8 +34,8 @@ allOf:
       fits_hdu: DQ
       datatype:
       - name: OUTPUT
-        datatype: uint8
+        datatype: uint16
       - name: ODD_EVEN
-        datatype: uint8
+        datatype: uint16
       - name: MASK
         datatype: uint32


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-3664](https://jira.stsci.edu/browse/JP-3664)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes [jwst/#8578](https://github.com/spacetelescope/jwst/issues/8578)
Partially addresses [jwst/#8580](https://github.com/spacetelescope/jwst/issues/8580)

<!-- describe the changes comprising this PR here -->
This PR addresses a bug exposed by testing numpy 2.0 - the irs2 datamodel specifies arrays to be of type uint8, but operations in refpix promoted them to uint16 implicitly in numpy<2.0. Numpy 2.0 does not implicitly type promote in this case, leading to an integer overflow. This PR updates the specified array datatype to uint16.

**Checklist**
- [x] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
