### PR TITLE
Check datamodels against schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 - Added ``MEDIUMDEEP2`` and ``MEDIUMDEEP8`` to allowed readout patterns
   in JWST core schema, ``READPATT``, and ``PREADPATT``. [#315]
 
+- Add test to check datamodels against their schema. [#324]
+
 2.0.0 (2024-06-24)
 ===================
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema.py
@@ -1,8 +1,17 @@
 from asdf import schema as mschema
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import stdatamodels.jwst.datamodels as dm
 
-from stdatamodels.jwst.datamodels import JwstDataModel
+def test_schema_validation():
+    model_list = [model for model in dm.__all__ if 'Model' in model]
+    for model in model_list:
+        class_ = getattr(dm, model)
+        m = class_()
+        try:
+            assert mschema.check_schema(m.schema) is None
+        except Exception as e:
+            print(f"{model} failed: {e}")
 
 
 def test_data_array(tmp_path):
@@ -48,7 +57,7 @@ def test_data_array(tmp_path):
     array2 = np.random.rand(5, 5)
     array3 = np.random.rand(5, 5)
 
-    with JwstDataModel(schema=data_array_schema) as x:
+    with dm.JwstDataModel(schema=data_array_schema) as x:
         x.arr.append(x.arr.item())
         x.arr[0].data = array1
         assert len(x.arr) == 1
@@ -61,7 +70,7 @@ def test_data_array(tmp_path):
         assert len(x.arr) == 2
         x.save(path)
 
-    with JwstDataModel(path, schema=data_array_schema) as x:
+    with dm.JwstDataModel(path, schema=data_array_schema) as x:
         assert len(x.arr) == 2
         assert_array_almost_equal(x.arr[0].data, array1)
         assert_array_almost_equal(x.arr[1].data, array3)


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Partially addresses #323 

<!-- describe the changes comprising this PR here -->
This PR adds a test to check schemas against instance of jwst datamodels. Might want to add additional test to address second bullet of #323.

**Checklist**
- [ ] added entry in `CHANGES.rst` (either in `Bug Fixes` or `Changes to API`)
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] updated relevant milestone(s)
- [ ] added relevant label(s)
