### PR TITLE
add check that all schemas have understood keywords

### DIFF
--- a/changes/327.bugfix.rst
+++ b/changes/327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix invalid abvegaoffset and coords schemas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ jwst_pipeline = "stdatamodels.jwst.transforms.integration:get_resource_mappings"
 [project.optional-dependencies]
 test = [
     "psutil",
+    "pyyaml",
     "pytest>=4.6.0",
     "pytest-doctestplus",
     "crds>=11.17.1",

--- a/src/stdatamodels/jwst/_tests/test_schemas.py
+++ b/src/stdatamodels/jwst/_tests/test_schemas.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import asdf
+import pytest
+import yaml
+
+from stdatamodels.fits_support import _get_validators
+from stdatamodels.schema import walk_schema
+
+
+# relative paths to schema directories
+SCHEMA_RELATIVE_PATHS = [
+    "../datamodels/schemas",
+    "../transforms/resources/schemas/stsci.edu/jwst_pipeline",
+]
+
+
+def _get_schema_ids():
+    root_path = Path(__file__).parent
+    schema_ids = []
+    for schema_relative_path in SCHEMA_RELATIVE_PATHS:
+        path = root_path / schema_relative_path
+        for schema_path in path.glob("*.yaml"):
+            with open(schema_path, "r") as f:
+                schema_ids.append(yaml.load(f, yaml.SafeLoader)["id"])
+    return schema_ids
+
+
+SCHEMA_IDS = _get_schema_ids()
+
+
+@pytest.fixture(scope="module")
+def known_validators():
+    # what validators do we understand?
+    # since we aren't going to use these we can feed it
+    # anything in place of a valid hdulist
+    class Foo:
+        pass
+
+    validators = _get_validators(Foo())[0]
+    known_validators = set(validators.keys())
+    return known_validators
+
+
+@pytest.fixture(scope="module")
+def valid_keywords(known_validators):
+    return known_validators | {
+        "id",
+        "$schema",
+        "title",
+        "description",
+        "default",
+        "examples",
+        "blend_table",
+        "blend_rule",
+        "fits_hdu",
+        "definitions",
+        "allow_extra_columns",
+    }
+
+
+def test_found_schemas():
+    """
+    Make sure we found some schemas
+    """
+    assert SCHEMA_IDS
+
+
+@pytest.mark.parametrize("schema_id", SCHEMA_IDS)
+def test_schema_contains_only_known_keywords(schema_id, valid_keywords):
+    # load the schema from asdf instead of the file to
+    # verify that asdf knows about the schema
+    schema = asdf.schema.load_schema(schema_id)
+
+
+    def callback(schema, path, combiner, ctx, recurse):
+        extra = schema.keys() - ctx["valid_keywords"]
+        assert not extra, f"{extra} found at {path} in {schema_id}"
+
+    ctx = {"valid_keywords": valid_keywords}
+    walk_schema(schema, callback, ctx)

--- a/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml
@@ -10,18 +10,4 @@ allOf:
     abvega_offset:
       title: Offsets to convert AB to Vega magnitudes
       type: object
-      properties:
-        abvega_offset:
-          title: AB_mag - Vega_mag
-          type: number
-        anyOf:
-          detector:
-            title: Detector name
-            type: string
-          filter:
-            title: Filter wheel element name
-            type: string
-          pupil:
-            title: Pupil wheel element name
-            type: string
 ...

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-0.7.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-0.7.0.yaml
@@ -29,7 +29,7 @@ examples:
 
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.1.0"
-  - object:
+  - type: object
     properties:
       model_type:
         description: |

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.0.0.yaml
@@ -29,7 +29,7 @@ examples:
 
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
-  - object:
+  - type: object
     properties:
       model_type:
         description: |

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.1.0.yaml
@@ -28,7 +28,7 @@ examples:
 
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
-  - object:
+  - type: object
     properties:
       model_type:
         description: |


### PR DESCRIPTION
Adds a test that checks that schemas (both datamodels and transforms) contain keywords that are "understood" by stdatamodels. This compares keywords against:

- known validation keywords (by polling the validator)
- extra known keywords (like title, description, fits_hdu, blend_table, etc)

The test is failing due to schema issues:
```
FAILED test_schemas.py::test_schema_contains_only_known_keywords[http:/stsci.edu/schemas/jwst_datamodel/abvegaoffset.schema] - AssertionError: {'detector', 'pupil', 'filter'} found at ['abvega_offset', 'anyOf'] in http://stsci.edu/schemas/jwst_datamodel/abvegaoffset.schema
FAILED test_schemas.py::test_schema_contains_only_known_keywords[http:/stsci.edu/schemas/jwst_pipeline/coords-1.0.0] - AssertionError: {'object'} found at [] in http://stsci.edu/schemas/jwst_pipeline/coords-1.0.0
FAILED test_schemas.py::test_schema_contains_only_known_keywords[http:/stsci.edu/schemas/jwst_pipeline/coords-0.7.0] - AssertionError: {'object'} found at [] in http://stsci.edu/schemas/jwst_pipeline/coords-0.7.0
FAILED test_schemas.py::test_schema_contains_only_known_keywords[http:/stsci.edu/schemas/jwst_pipeline/coords-1.1.0] - AssertionError: {'object'} found at [] in http://stsci.edu/schemas/jwst_pipeline/coords-1.1.0
```
All coords schemas are invalid due to an errant `object` in an unknown location:
https://github.com/spacetelescope/stdatamodels/blob/738e14c6de4ade9d20a96bbc082147c181091595/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.1.0.yaml#L30-L33
I think this should be `type: object` etc. I updated these schemas to use `type: object` (and so far everything seems ok).


The abvegaoffset schema is failing as what looks like properties are not in a `properties` block:
https://github.com/spacetelescope/stdatamodels/blob/738e14c6de4ade9d20a96bbc082147c181091595/src/stdatamodels/jwst/datamodels/schemas/abvegaoffset.schema.yaml#L13-L26
`anyOf` expects schemas as children and can't be used directly with property names.

I fixed this by removing the invalid column definitions in the schema. The schema was attempting to validate column names for the table found in the reference files (here's one example: https://jwst-crds.stsci.edu/browse/jwst_miri_abvegaoffset_0001.asdf). The required columns depend on the instrument (a condition that can't be included in the schema). The ABVegaOffsetModel already has custom python validation code that correctly handles this: https://github.com/spacetelescope/stdatamodels/blob/738e14c6de4ade9d20a96bbc082147c181091595/src/stdatamodels/jwst/datamodels/abvega_offset.py#L45

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #323 

Regtests show only 1 unrelated error: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1715/

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
