### PR TITLE
Add cal_step status keyword for clean_flicker_noise

### DIFF
--- a/changes/328.feature.rst
+++ b/changes/328.feature.rst
@@ -1,0 +1,1 @@
+Add keyword to JWST core schema to track status of new step ``clean_flicker_noise``.

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2334,6 +2334,11 @@ properties:
             type: string
             fits_keyword: S_CHGMIG
             blend_table: True
+          clean_flicker_noise:
+            title: Clean flicker noise
+            type: string
+            fits_keyword: S_CLNFNS
+            blend_table: True
           combine_1d:
             title: 1-D Spectral Combination
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Addresses [JP-3639](https://jira.stsci.edu/browse/JP-3639)


<!-- describe the changes comprising this PR here -->
This PR adds the cal_step keyword for the newly added step `clean_flicker_noise`.  

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
