### PR TITLE
JP-2349: Add workaround to load old files with new moving_target_table schema

### DIFF
--- a/changes/329.feature.rst
+++ b/changes/329.feature.rst
@@ -1,0 +1,1 @@
+Add function to ``jwst.Level1bModel`` twhich fills moving target tables with missing columns

--- a/changes/329.feature.rst
+++ b/changes/329.feature.rst
@@ -1,1 +1,1 @@
-Add function to ``jwst.Level1bModel`` twhich fills moving target tables with missing columns
+Add function to ``jwst.Level1bModel`` which fills moving target tables with missing columns

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -1,5 +1,4 @@
 from .model_base import JwstDataModel
-from astropy.io import fits
 import numpy as np
 from numpy.lib.recfunctions import merge_arrays
 

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -53,8 +53,5 @@ class Level1bModel(JwstDataModel):
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/level1b.schema"
 
-    def __init__(self, init=None, **kwargs):
-        if isinstance(init, fits.HDUList):
-            init = _migrate_moving_target_table(init)
-
-        super(Level1bModel, self).__init__(init=init, **kwargs)
+    def _migrate_hdulist(self, hdulist):
+        return _migrate_moving_target_table(hdulist)

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -1,7 +1,32 @@
 from .model_base import JwstDataModel
-
+from astropy.io import fits
+import numpy as np
+from numpy.lib.recfunctions import merge_arrays
 
 __all__ = ['Level1bModel']
+
+
+def _migrate_moving_target_table(hdulist):
+    """Add missing columns to prevent validation issues for `jwst` 1.16.0
+
+    Files produced prior to Build 11.1 will not have columns `mt_v2` or
+    `mt_v3` in the moving_target_table; loading these old files with
+    stdatamodels>=2.1.0 will encounter validation errors due to the
+    missing columns. This function adds NaN-filled columns where needed
+    to pass validation.
+    """
+    for ext in hdulist:
+        if ext.name != 'MOVING_TARGET_POSITION':
+            continue
+        table_data = ext.data
+        if 'mt_v2' not in table_data.dtype.fields:
+            dtype_v2 = [('mt_v2', '>f8')]
+            dtype_v3 = [('mt_v3', '>f8')]
+            mt_v2_col = np.full(table_data.shape[0], np.nan, dtype=dtype_v2)
+            mt_v3_col = np.full(table_data.shape[0], np.nan, dtype=dtype_v3)
+            table_data = merge_arrays((table_data, mt_v2_col, mt_v3_col), flatten=True)
+            ext.data = table_data
+    return hdulist
 
 
 class Level1bModel(JwstDataModel):
@@ -27,3 +52,9 @@ class Level1bModel(JwstDataModel):
 
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/level1b.schema"
+
+    def __init__(self, init=None, **kwargs):
+        if isinstance(init, fits.HDUList):
+            init = _migrate_moving_target_table(init)
+
+        super(Level1bModel, self).__init__(init=init, **kwargs)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2349](https://jira.stsci.edu/browse/JP-2349)

<!-- describe the changes comprising this PR here -->
This PR addresses validation issues encountered when opening `jwst` uncal files generated with DMS Ops builds <11.1 and using `stdatamodels`>=2.1.0. This most recent release of `stdatamodels` changed the number of columns in the `moving_target_table` schema, which leads to validation errors when opening any existing file with an old moving target extension. For any users attempting to load an outdated uncal file, this PR will check for the missing columns and add nan-filled columns if they are missing.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
