### PR TITLE
make IRS2Model inherit from ReferenceFileModel

### DIFF
--- a/changes/348.bugfix.rst
+++ b/changes/348.bugfix.rst
@@ -1,0 +1,1 @@
+Change IRS2Model parent class to ReferenceFileModel

--- a/src/stdatamodels/jwst/datamodels/irs2.py
+++ b/src/stdatamodels/jwst/datamodels/irs2.py
@@ -1,4 +1,4 @@
-from .model_base import ReferenceFileModel
+from .reference import ReferenceFileModel
 
 
 __all__ = ['IRS2Model']

--- a/src/stdatamodels/jwst/datamodels/irs2.py
+++ b/src/stdatamodels/jwst/datamodels/irs2.py
@@ -1,10 +1,10 @@
-from .model_base import JwstDataModel
+from .model_base import ReferenceFileModel
 
 
 __all__ = ['IRS2Model']
 
 
-class IRS2Model(JwstDataModel):
+class IRS2Model(ReferenceFileModel):
     """
     A data model for the IRS2 refpix reference file.
 


### PR DESCRIPTION
Closes #347

This changes the parent class for IRS2Model to ReferenceFileModel.

Testing locally I was able to (with this PR) open https://jwst-crds.stsci.edu/browse/jwst_nirspec_refpix_0017.fits and run "validate" without issue. Let me know if more tests (not covered by the CI and regtests) would be helpful.

Will need regression tests run (when they're working again). Opening for review in the meantime.

Regression tests all passed: https://github.com/spacetelescope/RegressionTests/actions/runs/11484201187/job/31961401428

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
