### PR TITLE
deprecate schema_editor

### DIFF
--- a/changes/352.removal.rst
+++ b/changes/352.removal.rst
@@ -1,0 +1,1 @@
+Deprecate schema_editor submodule.

--- a/src/stdatamodels/jwst/datamodels/conftest.py
+++ b/src/stdatamodels/jwst/datamodels/conftest.py
@@ -2,6 +2,10 @@ import pytest
 import os
 
 
+# this submodule is deprecated and contains no tests
+collect_ignore = ["schema_editor.py"]
+
+
 @pytest.fixture
 def jail_environ():
     """Lock changes to the environment"""

--- a/src/stdatamodels/jwst/datamodels/schema_editor.py
+++ b/src/stdatamodels/jwst/datamodels/schema_editor.py
@@ -71,7 +71,7 @@ __all__ = ["enquote", "is_long_line", "leading_length", "new_path",
 
 warnings.warn(
     "The schema_editor submodule and it's contents are deprecated "
-    "and will be removed in an upcoming relese",
+    "and will be removed in an upcoming release",
     UserWarning,
 )
 

--- a/src/stdatamodels/jwst/datamodels/schema_editor.py
+++ b/src/stdatamodels/jwst/datamodels/schema_editor.py
@@ -51,6 +51,7 @@ import os
 import os.path
 import re
 import sys
+import warnings
 from urllib.parse import urlparse
 import yaml
 
@@ -67,6 +68,12 @@ __all__ = ["enquote", "is_long_line", "leading_length", "new_path",
            "save_scalar", "save_short_line", "save_simple_list",
            "Keyword_db", "Model_db", "Options", "Schema_editor",]
 
+
+warnings.warn(
+    "The schema_editor submodule and it's contents are deprecated "
+    "and will be removed in an upcoming relese",
+    UserWarning,
+)
 
 def enquote(value):
     """


### PR DESCRIPTION
This PR adds a UserWarning if the schema_editor submodule is imported.

https://github.com/spacetelescope/jwst/pull/8909 removed its use in jwst

before merging this PR I'll make an issue to track the removal of schema_editor. I'm not sure if this qualifies as "public API" (since it's undocumented and untested in this package) so I'm ok removing it in the next minor version (so it's not picked up by current jwst releases).

Regression tests running at: https://github.com/spacetelescope/RegressionTests/actions/runs/11632063641

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
