### PR TITLE
Add `CALIB` and wcsinfo to ami schema

### DIFF
--- a/changes/357.feature.rst
+++ b/changes/357.feature.rst
@@ -1,0 +1,1 @@
+Add CALIB and PA keywords to amioi schema

--- a/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
@@ -9,8 +9,26 @@ allOf:
     meta:
       type: object
       properties:
-        calibrator_object_id:
-          title: "Calibration object identifier"
-          type: string
-          fits_keyword: CALIB
-          blend_table: True
+        ami:
+          type: object
+          properties:
+            calibrator_object_id:
+              title: "Calibration object identifier"
+              type: string
+              fits_keyword: CALIB
+              blend_table: True
+            roll_ref:
+              title: "[deg] V3 roll angle at the ref point (N over E)"
+              type: number
+              fits_keyword: ROLL_REF
+              blend_table: True
+            v3yangle:
+              title: "[deg] Angle from V3 axis to Ideal y axis"
+              type: number
+              fits_keyword: V3I_YANG
+              blend_table: True
+            vparity:
+              title: Relative sense of rotation between Ideal xy and V2V3
+              type: integer
+              fits_keyword: VPARITY
+              blend_table: True

--- a/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
@@ -3,6 +3,7 @@
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 id: "http://stsci.edu/schemas/jwst_datamodel/ami.schema"
 allOf:
+- $ref: wcsinfo.schema
 - type: object
   properties:
     meta:

--- a/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
@@ -14,8 +14,3 @@ allOf:
           type: string
           fits_keyword: CALIB
           blend_table: True
-        telescope_roll:
-          title: "[deg] Observation position angle"
-          type: number
-          fits_keyword: PA
-          blend_table: True

--- a/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ami.schema.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/ami.schema"
+allOf:
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        calibrator_object_id:
+          title: "Calibration object identifier"
+          type: string
+          fits_keyword: CALIB
+          blend_table: True
+        telescope_roll:
+          title: "[deg] Observation position angle"
+          type: number
+          fits_keyword: PA
+          blend_table: True

--- a/src/stdatamodels/jwst/datamodels/schemas/amioi.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/amioi.schema.yaml
@@ -5,3 +5,4 @@ id: "http://stsci.edu/schemas/jwst_datamodel/amioi.schema"
 title: AMI OIFITS analysis data model
 allOf:
 - $ref: oifits.schema
+- $ref: ami.schema

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -574,7 +574,7 @@ def test_amioi_model_oifits_extra_columns(tmp_path, oifits_ami_model, table_name
 
 
 def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
-    oifits_ami_model.meta.calibrator_object_id = "foo"
+    oifits_ami_model.meta.ami.calibrator_object_id = "foo"
     fn = tmp_path / "test.fits"
     oifits_ami_model.save(fn)
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -573,6 +573,13 @@ def test_amioi_model_oifits_extra_columns(tmp_path, oifits_ami_model, table_name
     oifits_ami_model.save(fn)
 
 
+def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
+    oifits_ami_model.meta.calibrator_object_id = "foo"
+    oifits_ami_model.meta.telescope_roll = 0
+    fn = tmp_path / "test.fits"
+    oifits_ami_model.save(fn)
+
+
 def test_dq_def_roundtrip(tmp_path):
     """
     Open a MaskModel with a defined DQ array and dq_def that modifies the

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -575,7 +575,6 @@ def test_amioi_model_oifits_extra_columns(tmp_path, oifits_ami_model, table_name
 
 def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
     oifits_ami_model.meta.calibrator_object_id = "foo"
-    oifits_ami_model.meta.telescope_roll = 0
     fn = tmp_path / "test.fits"
     oifits_ami_model.save(fn)
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema.py
@@ -92,3 +92,21 @@ def test_data_array(tmp_path):
         assert x == set(
             [('FOO', 2), ('FOO', 1), ('ASDF', None), ('DQ', 2),
              (None, None)])
+
+
+def test_ami_wcsinfo():
+    """
+    The ami and wcsinfo schemas contain duplicate information
+    since ami products don't otherwise contain a SCI extension.
+    This test checks that the schema entries for the duplicated
+    information stays in sync.
+    """
+    wcsinfo_schema = mschema.load_schema("http://stsci.edu/schemas/jwst_datamodel/wcsinfo.schema")
+    ami_schema = mschema.load_schema("http://stsci.edu/schemas/jwst_datamodel/ami.schema")
+    ami_def = ami_schema["allOf"][1]["properties"]["meta"]["properties"]["ami"]["properties"]
+    wcsinfo_def = wcsinfo_schema["properties"]["meta"]["properties"]["wcsinfo"]["properties"]
+    for keyword in ("roll_ref", "v3yangle", "vparity"):
+        ami = ami_def[keyword]
+        wcsinfo = wcsinfo_def[keyword]
+        for key in set(ami.keys()) | set(wcsinfo.keys()) - {"fits_hdu"}:
+            assert ami[key] == wcsinfo[key]


### PR DESCRIPTION
Required for https://github.com/spacetelescope/jwst/pull/8846

This PR adds the `CALIB` keyword and wcsinfo subschema to the `AmiOIModel` schema.

Regression tests running at https://github.com/spacetelescope/RegressionTests/actions/runs/11978383053

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
