### PR TITLE
add fits keywords to NRMModel schema

### DIFF
--- a/changes/361.feature.rst
+++ b/changes/361.feature.rst
@@ -1,0 +1,1 @@
+Add NRM reference file keywords to schema.

--- a/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
@@ -13,46 +13,46 @@ allOf:
       title: "[m] flat2flat hole size"
     x_a1:
       fits_keyword: NRM_X_A1
-      title: "[m] X coordinate (m) of NRM sub-aperture 1"
+      title: "[m] X coordinate of NRM sub-aperture 1"
     y_a1:
       fits_keyword: NRM_Y_A1
-      title: "[m] Y coordinate (m) of NRM sub-aperture 1"
+      title: "[m] Y coordinate of NRM sub-aperture 1"
     x_a2:
       fits_keyword: NRM_X_A2
-      title: "[m] X coordinate (m) of NRM sub-aperture 2"
+      title: "[m] X coordinate of NRM sub-aperture 2"
     y_a2:
       fits_keyword: NRM_Y_A2
-      title: "[m] Y coordinate (m) of NRM sub-aperture 2"
+      title: "[m] Y coordinate of NRM sub-aperture 2"
     x_a3:
       fits_keyword: NRM_X_A3
-      title: "[m] X coordinate (m) of NRM sub-aperture 3"
+      title: "[m] X coordinate of NRM sub-aperture 3"
     y_a3:
       fits_keyword: NRM_Y_A3
-      title: "[m] Y coordinate (m) of NRM sub-aperture 3"
+      title: "[m] Y coordinate of NRM sub-aperture 3"
     x_a4:
       fits_keyword: NRM_X_A4
-      title: "[m] X coordinate (m) of NRM sub-aperture 4"
+      title: "[m] X coordinate of NRM sub-aperture 4"
     y_a4:
       fits_keyword: NRM_Y_A4
-      title: "[m] Y coordinate (m) of NRM sub-aperture 4"
+      title: "[m] Y coordinate of NRM sub-aperture 4"
     x_a5:
       fits_keyword: NRM_X_A5
-      title: "[m] X coordinate (m) of NRM sub-aperture 5"
+      title: "[m] X coordinate of NRM sub-aperture 5"
     y_a5:
       fits_keyword: NRM_Y_A5
-      title: "[m] Y coordinate (m) of NRM sub-aperture 5"
+      title: "[m] Y coordinate of NRM sub-aperture 5"
     x_a6:
       fits_keyword: NRM_X_A6
-      title: "[m] X coordinate (m) of NRM sub-aperture 6"
+      title: "[m] X coordinate of NRM sub-aperture 6"
     y_a6:
       fits_keyword: NRM_Y_A6
-      title: "[m] Y coordinate (m) of NRM sub-aperture 6"
+      title: "[m] Y coordinate of NRM sub-aperture 6"
     x_a7:
       fits_keyword: NRM_X_A7
-      title: "[m] X coordinate (m) of NRM sub-aperture 7"
+      title: "[m] X coordinate of NRM sub-aperture 7"
     y_a7:
       fits_keyword: NRM_Y_A7
-      title: "[m] Y coordinate (m) of NRM sub-aperture 7"
+      title: "[m] Y coordinate of NRM sub-aperture 7"
     nrm:
       title: Non-Redundant Mask
       fits_hdu: NRM

--- a/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
@@ -8,6 +8,51 @@ allOf:
 - $ref: keyword_exptype.schema
 - type: object
   properties:
+    flat_to_flat:
+      fits_keyword: F2F
+      title: "[m] flat2flat hole size"
+    x_a1:
+      fits_keyword: NRM_X_A1
+      title: "[m] X coordinate (m) of NRM sub-aperture 1"
+    y_a1:
+      fits_keyword: NRM_Y_A1
+      title: "[m] Y coordinate (m) of NRM sub-aperture 1"
+    x_a2:
+      fits_keyword: NRM_X_A2
+      title: "[m] X coordinate (m) of NRM sub-aperture 2"
+    y_a2:
+      fits_keyword: NRM_Y_A2
+      title: "[m] Y coordinate (m) of NRM sub-aperture 2"
+    x_a3:
+      fits_keyword: NRM_X_A3
+      title: "[m] X coordinate (m) of NRM sub-aperture 3"
+    y_a3:
+      fits_keyword: NRM_Y_A3
+      title: "[m] Y coordinate (m) of NRM sub-aperture 3"
+    x_a4:
+      fits_keyword: NRM_X_A4
+      title: "[m] X coordinate (m) of NRM sub-aperture 4"
+    y_a4:
+      fits_keyword: NRM_Y_A4
+      title: "[m] Y coordinate (m) of NRM sub-aperture 4"
+    x_a5:
+      fits_keyword: NRM_X_A5
+      title: "[m] X coordinate (m) of NRM sub-aperture 5"
+    y_a5:
+      fits_keyword: NRM_Y_A5
+      title: "[m] Y coordinate (m) of NRM sub-aperture 5"
+    x_a6:
+      fits_keyword: NRM_X_A6
+      title: "[m] X coordinate (m) of NRM sub-aperture 6"
+    y_a6:
+      fits_keyword: NRM_Y_A6
+      title: "[m] Y coordinate (m) of NRM sub-aperture 6"
+    x_a7:
+      fits_keyword: NRM_X_A7
+      title: "[m] X coordinate (m) of NRM sub-aperture 7"
+    y_a7:
+      fits_keyword: NRM_Y_A7
+      title: "[m] Y coordinate (m) of NRM sub-aperture 7"
     nrm:
       title: Non-Redundant Mask
       fits_hdu: NRM

--- a/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrm.schema.yaml
@@ -8,9 +8,15 @@ allOf:
 - $ref: keyword_exptype.schema
 - type: object
   properties:
+    diameter:
+      fits_keyword: DIAM
+      title: "[m] Flat-to-flat distance across pupil in V3 axis"
     flat_to_flat:
       fits_keyword: F2F
       title: "[m] flat2flat hole size"
+    pupil_circumscribed:
+      fits_keyword: PUPL_CRC
+      title: "[m] Circumscribing diameter for JWST primary"
     x_a1:
       fits_keyword: NRM_X_A1
       title: "[m] X coordinate of NRM sub-aperture 1"


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #359

The NRM reference files contain FITS keywords useful to CAL.
https://jwst-crds.stsci.edu/browse/jwst_niriss_nrm_0001.fits

This PR adds those keywords to the schema so they are accessible via the datamodel interface:
- `model.flat_to_flat`
- `model.x_a1` etc...

Regression tests running at https://github.com/spacetelescope/RegressionTests/actions/runs/11802888443

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
