### PR TITLE
JP-3736: Add hybrid full-frame boolean to core exposure schema

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -740,6 +740,11 @@ properties:
               NRSSLOW, RAPID, SHALLOW2, SHALLOW4, SLOW, SLOWR1, TRACK, ANY, N/A]
             fits_keyword: READPATT
             blend_table: True
+          hybrid_full_frame:
+            title: HFF/IRS2TA readout mode used
+            type: boolean
+            fits_keyword: IRS2TA
+            blend_table: True
           segment_number:
             title: Sequential segment number
             type: integer


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3736](https://jira.stsci.edu/browse/JP-3736)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/jwst#8766

<!-- describe the changes comprising this PR here -->
This PR adds a header keyword to indicate if the new hybrid readout mode was used for a NIRSpec MSA target acquisition.  It wasn't clear what the FITS header keyword should be named based on the various tickets; I'm curious what others think of the choice I made (`IRS2TA`).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
