### PR TITLE
Retain `id` and other top-level attributes in `merge_property_trees`

### DIFF
--- a/changes/364.bugfix.rst
+++ b/changes/364.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``model.schema["id"]`` to match schema id.

--- a/changes/364.bugfix.rst
+++ b/changes/364.bugfix.rst
@@ -1,1 +1,1 @@
-Fix ``model.schema["id"]`` to match schema id.
+Allow ``merge_property_trees`` to retain input schema id in ``model.schema["id"]``.

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -129,7 +129,7 @@ def test_imagemodel():
 
 
 def test_model_with_nonstandard_primary_array():
-    class NonstandardPrimaryArrayModel(JwstDataModel):
+    class _NonstandardPrimaryArrayModel(JwstDataModel):
         schema_url = os.path.join(ROOT_DIR, "nonstandard_primary_array.schema.yaml")
 
         # The wavelength array is the primary array.
@@ -137,7 +137,7 @@ def test_model_with_nonstandard_primary_array():
         def get_primary_array_name(self):
             return 'wavelength'
 
-    m = NonstandardPrimaryArrayModel((10,))
+    m = _NonstandardPrimaryArrayModel((10,))
     assert 'wavelength' in list(m.keys())
     assert m.wavelength.sum() == 0
 

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -168,11 +168,17 @@ def merge_property_trees(schema):
     can be represented in individual files and then referenced elsewhere. They
     are then combined by this function into a single schema data structure.
     """
-    newschema = {}
+    # track the "combined" and "top" items separately
+    # this allows the top level "id", "$schema", etc to overwrite
+    # combined items (so that the schema["id"] doesn't change).
+    combined_items = {}
+    top_items = {}
 
     def add_entry(path, schema, combiner):
+        if not top_items:
+            top_items.update(schema)
         # TODO: Simplify?
-        cursor = newschema
+        cursor = combined_items
         for i in range(len(path)):
             part = path[i]
             if part == combiner:
@@ -195,12 +201,12 @@ def merge_property_trees(schema):
         cursor.update(schema)
 
     def callback(schema, path, combiner, ctx, recurse):
-        type = schema.get('type')
-        schema = dict(schema)
-        if type == 'object':
+        schema_type = schema.get('type')
+        schema = dict(schema)  # shallow copy
+        if schema_type == 'object':
             if 'properties' in schema:
                 del schema['properties']
-        elif type == 'array':
+        elif schema_type == 'array':
             del schema['items']
         if 'allOf' in schema:
             del schema['allOf']
@@ -209,7 +215,7 @@ def merge_property_trees(schema):
 
     walk_schema(schema, callback)
 
-    return newschema
+    return combined_items | top_items
 
 
 def build_docstring(klass, template="{fits_hdu} {title}"):

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import re
-from collections import OrderedDict
 
 
 # return_result included for backward compatibility
@@ -169,7 +168,7 @@ def merge_property_trees(schema):
     can be represented in individual files and then referenced elsewhere. They
     are then combined by this function into a single schema data structure.
     """
-    newschema = OrderedDict()
+    newschema = {}
 
     def add_entry(path, schema, combiner):
         # TODO: Simplify?
@@ -185,19 +184,19 @@ def merge_property_trees(schema):
                     cursor.append({})
                 cursor = cursor[part]
             elif part == 'items':
-                cursor = cursor.setdefault('items', OrderedDict())
+                cursor = cursor.setdefault('items', {})
             else:
-                cursor = cursor.setdefault('properties', OrderedDict())
+                cursor = cursor.setdefault('properties', {})
                 if i < len(path) - 1 and isinstance(path[i + 1], int):
                     cursor = cursor.setdefault(part, [])
                 else:
-                    cursor = cursor.setdefault(part, OrderedDict())
+                    cursor = cursor.setdefault(part, {})
 
         cursor.update(schema)
 
     def callback(schema, path, combiner, ctx, recurse):
         type = schema.get('type')
-        schema = OrderedDict(schema)
+        schema = dict(schema)
         if type == 'object':
             if 'properties' in schema:
                 del schema['properties']

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -206,6 +206,19 @@ def test_merge_property_trees(combiner):
     assert f == s
 
 
+def test_merge_property_tree_top():
+    s = {
+        "id": "foo",
+        "allOf": [
+            {
+                "id": "bar",
+            },
+        ]
+    }
+    f = merge_property_trees(s)
+    assert f["id"] == "foo"
+
+
 def test_schema_docstring():
     template = "{fits_hdu} {title}"
     docstring = build_docstring(FitsModel, template).split("\n")


### PR DESCRIPTION
This PR updates `merge_property_trees` to retain the schema `id` (and other "top level" items/attributes). This fixes the issue where `model.schema["id"]` does not match the "id" of the schema (see #308).

This PR also drops the use of OrderedDict fixing #40.

Finally the CI goblins revealed that shuffling order of tests can cause `test_defined_models_up_to_date` to fail:
https://github.com/spacetelescope/stdatamodels/actions/runs/11901768169/job/33165405951
if executed after `test_model_with_nonstandard_primary_array` which defines a test model class that isn't prefixed with `_`. This PR adds a `_` prefix to the test class to avoid this intermittent issue.

Fixes: https://jira.stsci.edu/browse/JP-2137
Closes #308
Closes #40

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/11914331392
produce 5 "failures" which look like improvements to me. The failures are in the niriss ami tests:
```
        Headers contain differences:
         Keyword          has different values:
            a> AMI OIFITS analysis data model
            b> OIFITS required meta data (not otherwise defined in core.schema)
```
Since this PR retains the top level schema items this is keeping the title from the datamodel schema:
https://github.com/spacetelescope/stdatamodels/blob/2c3985336e54fb4989460b08a94777dfb33640b7/src/stdatamodels/jwst/datamodels/schemas/amioi.schema.yaml#L5
which in the truth file ends up being overwritten by the referenced oifits schema:
https://github.com/spacetelescope/stdatamodels/blob/2c3985336e54fb4989460b08a94777dfb33640b7/src/stdatamodels/jwst/datamodels/schemas/oifits.schema.yaml#L5
Keeping the datamodel schema title seems preferable.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
