### PR TITLE
add filter for ValidationWarning

### DIFF
--- a/changes/367.feature.rst
+++ b/changes/367.feature.rst
@@ -1,0 +1,1 @@
+Modify warning filters to re-show identical ValidationWarnings on re-validation.

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -18,6 +18,11 @@ class ValidationWarning(Warning):
     pass
 
 
+# always show validation warnings unless another filter was added that
+# matches these warnings (by passing append=True)
+warnings.filterwarnings("always", category=ValidationWarning, append=True)
+
+
 def value_change(path, value, schema, ctx):
     """
     Validate a change in value against a schema.


### PR DESCRIPTION
This PR adds an "always" filter for `ValidationWarning`s at the end of the warning filter list.

This addresses an issue where for an interactive python session (using the standard python REPL) only the first call to "validate" for a particular validation error will result in a warning:

```python
> from stdatamodels.jwst import datamodels as dm
> m = dm.ImageModel()
> m.meta.instrument._instance['detector'] = "foo"
> m.validate()
ValidationWarning: While validating...
> m.validate()
# no validation warning
```
This is a byproduct of the "default" python warning filter which for a particular warning based on message, category and line number will only show the warning the first time. This PR adds an "always" for `ValidationWarning` to override this behavior but adds it to the end of the filter list so that a user can still control these warnings (for example by using `-Werror` to turn all warnings into errors).

I can't sort out how we can test this due to a couple factors:
- pytest adjusts warning filters so that the filters inside a test are different than those in an interactive session. Attempts to reset filters aren't having the expected results (likely because pytest uses additional warning hooks) and the test quickly becomes a bad test of the actual change
- attempts to completely reset filters and capture stderr fail. I'm not sure why but I suspect this is also related to pytest handling of stderr (which I've never found to be reliable)

I'm going to open this for review knowing that this doesn't include a test for change. I am ok with that given the scope of the change but please let me know if anyone sorts out a way to test this.

Regtests running: https://github.com/spacetelescope/RegressionTests/actions/runs/11979991732

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
