### PR TITLE
Update test_schema_against_crds

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -160,6 +160,7 @@ ref_to_datamodel_dict = {
     'rscd': dm.RSCDModel,
     'saturation': dm.SaturationModel,
     'sflat': dm.NirspecFlatModel,
+    'sirskernel': dm.SIRSKernelModel,
     'speckernel': dm.SpecKernelModel,
     'specprofile': dm.SpecProfileModel,
     'spectrace': dm.SpecTraceModel,
@@ -196,8 +197,13 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
 
     # get the reftypes
     reftypes = imap.get_filekinds()
+
     # remove pars- files
     _ = [reftypes.remove(name) for name in reftypes[::-1] if name.startswith(ignored_stems)]
+
+    # remove known missing
+    if 'psf' in reftypes:
+        reftypes.remove('psf')
 
     # iterate over reftypes for this instrument
     for reftype in reftypes:


### PR DESCRIPTION
This PR updates `test_schema_against_crds` to accommodate the new crds ops context with `sirskernel` and `psf` reftypes.

This test checks that all reftypes available on CRDS can be opened as mapped reference type datamodels. Since the new context has new `sirskernel` and `psf` reftypes the test is failing on main.
https://github.com/spacetelescope/stdatamodels/actions/runs/12437996127/job/34729034726

This PR adds a sirskernel reftype mapping (to `SIRSKernelModel`) to allow these to be tested and ignores psf (since the model is not yet supported: https://github.com/spacetelescope/stdatamodels/pull/336).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
