### PR TITLE
Add mrs_spectable to support residual fringe corrected spec tables  

### DIFF
--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -69,7 +69,7 @@ from .slit import SlitModel, SlitDataModel
 from .pastasossmodel import PastasossModel
 from .sossextractmodel import SossExtractModel
 from .sosswavegrid import SossWaveGridModel
-from .spec import SpecModel
+from .spec import SpecModel, MrsSpecModel
 from .speckernel import SpecKernelModel
 from .specprofile import SpecProfileModel, SpecProfileSingleModel
 from .specpsf import SpecPsfModel
@@ -142,7 +142,7 @@ __all__ = [
     'ReferenceFileModel', 'ReferenceCubeModel', 'ReferenceImageModel', 'ReferenceQuadModel',
     'RegionsModel', 'ResetModel',
     'ResolutionModel', 'MiriResolutionModel',
-    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel',
+    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel','MrsSpecModel',
     'SegmentationMapModel',
     'SossExtractModel',
     'SossWaveGridModel',

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
+title: MRS residual fringe corrected Spectrum data model
+allOf:
+- $ref: core.schema
+- type: object
+  properties:
+    mrs_spec_table:
+      $ref: mrs_spectable.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
@@ -1,0 +1,49 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spectable.schema"
+title: Residual fringe extracted spectral data table
+fits_hdu: RFCORR1D
+datatype:
+- name: WAVELENGTH
+  datatype: float64
+- name: FLUX
+  datatype: float64
+- name: FLUX_ERROR
+  datatype: float64
+- name: FLUX_VAR_POISSON
+  datatype: float64
+- name: FLUX_VAR_RNOISE
+  datatype: float64
+- name: FLUX_VAR_FLAT
+  datatype: float64
+- name: SURF_BRIGHT
+  datatype: float64
+- name: SB_ERROR
+  datatype: float64
+- name: SB_VAR_POISSON
+  datatype: float64
+- name: SB_VAR_RNOISE
+  datatype: float64
+- name: SB_VAR_FLAT
+  datatype: float64
+- name: DQ
+  datatype: uint32
+- name: BACKGROUND
+  datatype: float64
+- name: BKGD_ERROR
+  datatype: float64
+- name: BKGD_VAR_POISSON
+  datatype: float64
+- name: BKGD_VAR_RNOISE
+  datatype: float64
+- name: BKGD_VAR_FLAT
+  datatype: float64
+- name: NPIXELS
+  datatype: float64
+- name: RF_FLUX
+  datatype: float64
+- name: RF_SURF_BRIGHT
+  datatype: float64
+- name: RF_BACKGROUND
+  datatype: float64

--- a/src/stdatamodels/jwst/datamodels/spec.py
+++ b/src/stdatamodels/jwst/datamodels/spec.py
@@ -1,7 +1,7 @@
 from .model_base import JwstDataModel
 
 
-__all__ = ['SpecModel']
+__all__ = ['SpecModel', 'MrsSpecModel']
 
 
 class SpecModel(JwstDataModel):
@@ -16,3 +16,18 @@ class SpecModel(JwstDataModel):
         estimate for the flux, and data quality flags.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/spec.schema"
+
+
+class MrsSpecModel(SpecModel):
+    """
+    A data model for residual fringe corrected MRS 1D spectra
+
+    Parameters
+    __________
+    spec_table : numpy table
+        Extracted spectral data table
+        A table with the standard spec model columns plus three residual
+        fringe corrected data: flux, surface brightness and background
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
+    


### PR DESCRIPTION
Work in progress. I openned a PR for feedback. Not ready for formal review
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
