### PR TITLE
JP-3790: MIRI MRS models to hold residual fringe correction 

### DIFF
--- a/changes/377.feature.rst
+++ b/changes/377.feature.rst
@@ -1,0 +1,1 @@
+Add new spectral models for MIRI MRS data, including new table columns for residual fringe corrected flux, surface brightness, and background.

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -40,7 +40,7 @@ from .multicombinedspec import MultiCombinedSpecModel
 from .multiexposure import MultiExposureModel
 from .multiextract1d import MultiExtract1dImageModel
 from .multislit import MultiSlitModel
-from .multispec import MultiSpecModel
+from .multispec import MultiSpecModel, MRSMultiSpecModel
 from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .nrm import NRMModel
 from .outlierpars import OutlierParsModel
@@ -69,7 +69,7 @@ from .slit import SlitModel, SlitDataModel
 from .pastasossmodel import PastasossModel
 from .sossextractmodel import SossExtractModel
 from .sosswavegrid import SossWaveGridModel
-from .spec import SpecModel, MrsSpecModel
+from .spec import SpecModel, MRSSpecModel
 from .speckernel import SpecKernelModel
 from .specprofile import SpecProfileModel, SpecProfileSingleModel
 from .specpsf import SpecPsfModel
@@ -123,7 +123,7 @@ __all__ = [
     'LinearityModel', 'MaskModel', 'MSAModel',
     'MultiCombinedSpecModel', 'MultiExposureModel',
     'MultiExtract1dImageModel', 'MultiSlitModel',
-    'MultiSpecModel',
+    'MultiSpecModel', 'MRSMultiSpecModel',
     'NIRCAMGrismModel', 'NIRISSGrismModel',
     'OTEModel',
     'OutlierParsModel','OutlierIFUOutputModel',
@@ -142,7 +142,7 @@ __all__ = [
     'ReferenceFileModel', 'ReferenceCubeModel', 'ReferenceImageModel', 'ReferenceQuadModel',
     'RegionsModel', 'ResetModel',
     'ResolutionModel', 'MiriResolutionModel',
-    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel','MrsSpecModel',
+    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel','MRSSpecModel',
     'SegmentationMapModel',
     'SossExtractModel',
     'SossWaveGridModel',

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -69,7 +69,7 @@ from .slit import SlitModel, SlitDataModel
 from .pastasossmodel import PastasossModel
 from .sossextractmodel import SossExtractModel
 from .sosswavegrid import SossWaveGridModel
-from .spec import SpecModel
+from .spec import SpecModel, MrsSpecModel
 from .speckernel import SpecKernelModel
 from .specprofile import SpecProfileModel, SpecProfileSingleModel
 from .specpsf import SpecPsfModel
@@ -142,7 +142,7 @@ __all__ = [
     'ReferenceFileModel', 'ReferenceCubeModel', 'ReferenceImageModel', 'ReferenceQuadModel',
     'RegionsModel', 'ResetModel',
     'ResolutionModel', 'MiriResolutionModel',
-    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel',
+    'RSCDModel', 'SaturationModel', 'SIRSKernelModel', 'SlitDataModel', 'SlitModel', 'SpecModel','MrsSpecModel',
     'SegmentationMapModel',
     'SossExtractModel',
     'SossWaveGridModel',

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -1,8 +1,8 @@
 from .model_base import JwstDataModel
-from .spec import SpecModel
+from .spec import SpecModel, MRSSpecModel
 
 
-__all__ = ['MultiSpecModel']
+__all__ = ['MultiSpecModel', 'MRSMultiSpecModel']
 
 
 class MultiSpecModel(JwstDataModel):
@@ -57,3 +57,25 @@ class MultiSpecModel(JwstDataModel):
             return
 
         super(MultiSpecModel, self).__init__(init=init, **kwargs)
+
+
+class MRSMultiSpecModel(JwstDataModel):
+    """
+    A data model for MIRI MRS multi-spec images.
+
+    This model has a special member `spec` that can be used to
+    deal with an entire spectrum at a time.  It behaves identically
+    to `MultiSpecModel`, except that the spectra have additional columns
+    for the MIRI MRS mode, containing residual fringe corrected values.
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mrs_multispec.schema"
+
+    def __init__(self, init=None, **kwargs):
+
+        if isinstance(init, MRSSpecModel):
+            super(MRSMultiSpecModel, self).__init__(init=None, **kwargs)
+            self.spec.append(self.spec.item())
+            self.spec[0].spec_table = init.spec_table
+            return
+
+        super(MRSMultiSpecModel, self).__init__(init=init, **kwargs)

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_multispec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_multispec.schema.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
-id: "http://stsci.edu/schemas/jwst_datamodel/multispec.schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mrs_multispec.schema"
 allOf:
 - $ref: core.schema
 - $ref: int_times.schema
@@ -15,5 +15,5 @@ allOf:
           - type: object
             properties:
               spec_table:
-                $ref: spectable.schema
+                $ref: mrs_spectable.schema
           - $ref: specmeta.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
@@ -2,10 +2,10 @@
 ---
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
-title: MRS residual fringe corrected Spectrum data model
+title: Spectrum data model with residual fringe correction for MIRI MRS
 allOf:
 - $ref: core.schema
 - type: object
   properties:
-    mrs_spec_table:
+    spec_table:
       $ref: mrs_spectable.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spec.schema.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
+title: MRS residual fringe corrected Spectrum data model
+allOf:
+- $ref: core.schema
+- type: object
+  properties:
+    mrs_spec_table:
+      $ref: mrs_spectable.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
@@ -2,8 +2,8 @@
 ---
 $schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
 id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spectable.schema"
-title: Residual fringe extracted spectral data table
-fits_hdu: RFCORR1D
+title: Extracted spectral data table with residual fringe correction for MIRI MRS
+fits_hdu: EXTRACT1D
 datatype:
 - name: WAVELENGTH
   datatype: float64

--- a/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mrs_spectable.schema.yaml
@@ -1,0 +1,49 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/mrs_spectable.schema"
+title: Residual fringe extracted spectral data table
+fits_hdu: RFCORR1D
+datatype:
+- name: WAVELENGTH
+  datatype: float64
+- name: FLUX
+  datatype: float64
+- name: FLUX_ERROR
+  datatype: float64
+- name: FLUX_VAR_POISSON
+  datatype: float64
+- name: FLUX_VAR_RNOISE
+  datatype: float64
+- name: FLUX_VAR_FLAT
+  datatype: float64
+- name: SURF_BRIGHT
+  datatype: float64
+- name: SB_ERROR
+  datatype: float64
+- name: SB_VAR_POISSON
+  datatype: float64
+- name: SB_VAR_RNOISE
+  datatype: float64
+- name: SB_VAR_FLAT
+  datatype: float64
+- name: DQ
+  datatype: uint32
+- name: BACKGROUND
+  datatype: float64
+- name: BKGD_ERROR
+  datatype: float64
+- name: BKGD_VAR_POISSON
+  datatype: float64
+- name: BKGD_VAR_RNOISE
+  datatype: float64
+- name: BKGD_VAR_FLAT
+  datatype: float64
+- name: NPIXELS
+  datatype: float64
+- name: RF_FLUX
+  datatype: float64
+- name: RF_SURF_BRIGHT
+  datatype: float64
+- name: RF_BACKGROUND
+  datatype: float64

--- a/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
@@ -1,0 +1,171 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/fits-schema/fits-schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/specmeta.schema"
+type: object
+properties:
+  name:
+    title: Slit name
+    type: string
+    fits_keyword: SLTNAME
+    fits_hdu: EXTRACT1D
+  slitlet_id:
+    title: Slitlet ID
+    type: integer
+    default: 0
+    fits_keyword: SLITID
+    fits_hdu: EXTRACT1D
+  source_id:
+    title: Source ID number
+    type: integer
+    default: 0
+    fits_keyword: SOURCEID
+    fits_hdu: EXTRACT1D
+  source_name:
+    title: Source name
+    type: string
+    fits_keyword: SRCNAME
+    fits_hdu: EXTRACT1D
+  source_alias:
+    title: Source alias
+    type: string
+    fits_keyword: SRCALIAS
+    fits_hdu: EXTRACT1D
+  stellarity:
+    title: Source stellarity
+    type: number
+    fits_keyword: STLARITY
+    fits_hdu: EXTRACT1D
+  source_type:
+    title: Source type used for calibration
+    type: string
+    fits_keyword: SRCTYPE
+    fits_hdu: EXTRACT1D
+  source_xpos:
+    title: Source position in slit (x-axis)
+    type: number
+    default: 0.0
+    fits_keyword: SRCXPOS
+    fits_hdu: EXTRACT1D
+  source_ypos:
+    title: Source position in slit (y-axis)
+    type: number
+    default: 0.0
+    fits_keyword: SRCYPOS
+    fits_hdu: EXTRACT1D
+  source_ra:
+    title: Right Ascension of the source
+    type: number
+    fits_keyword: SRCRA
+    fits_hdu: EXTRACT1D
+  source_dec:
+    title: Declination of the source
+    type: number
+    fits_keyword: SRCDEC
+    fits_hdu: EXTRACT1D
+  extraction_x:
+    title: X center of extraction region
+    type: number
+    fits_keyword: EXTR_X
+    fits_hdu: EXTRACT1D
+  extraction_y:
+    title: Y center of extraction region
+    type: number
+    fits_keyword: EXTR_Y
+    fits_hdu: EXTRACT1D
+  extraction_xstart:
+    title: X axis start of extraction region
+    type: number
+    fits_keyword: EXTRXSTR
+    fits_hdu: EXTRACT1D
+  extraction_xstop:
+    title: X axis end of extraction region
+    type: number
+    fits_keyword: EXTRXSTP
+    fits_hdu: EXTRACT1D
+  extraction_ystart:
+    title: Y axis start of extraction region
+    type: number
+    fits_keyword: EXTRYSTR
+    fits_hdu: EXTRACT1D
+  extraction_ystop:
+    title: Y axis end of extraction region
+    type: number
+    fits_keyword: EXTRYSTP
+    fits_hdu: EXTRACT1D
+  shutter_state:
+    title: All (open and close) shutters in a slit
+    type: string
+    default: ""
+    fits_keyword: SHUTSTA
+    fits_hdu: EXTRACT1D
+  slit_ra:
+    title: "[deg] Right Ascension at middle of slit"
+    type: number
+    default: 0.0
+    fits_keyword: SLIT_RA
+    fits_hdu: EXTRACT1D
+  slit_dec:
+    title: "[deg] Declination at middle of slit"
+    type: number
+    default: 0.0
+    fits_keyword: SLIT_DEC
+    fits_hdu: EXTRACT1D
+  spectral_order:
+    title: Spectral order number
+    type: integer
+    default: 1
+    fits_keyword: SPORDER
+    fits_hdu: EXTRACT1D
+  dispersion_direction:
+    title: Dispersion direction
+    type: integer
+    fits_keyword: DISPAXIS
+    fits_hdu: EXTRACT1D
+  int_num:
+    title: Integration number
+    type: integer
+    fits_keyword: INT_NUM
+    fits_hdu: EXTRACT1D
+  time_sys:
+    title: "principal time system for time-related keywords"
+    type: string
+    default: "UTC"
+    fits_keyword: TIMESYS
+    fits_hdu: EXTRACT1D
+  time_unit:
+    title: Default unit applicable to all time values
+    type: string
+    default: 's'
+    fits_keyword: TIMEUNIT
+    fits_hdu: EXTRACT1D
+  start_time_mjd:
+    title: "[d] integration start time in MJD"
+    type: number
+    fits_keyword: MJD-BEG
+    fits_hdu: EXTRACT1D
+  mid_time_mjd:
+    title: "[d] integration mid-point in MJD"
+    type: number
+    fits_keyword: MJD-AVG
+    fits_hdu: EXTRACT1D
+  end_time_mjd:
+    title: "[d] integration end time in MJD"
+    type: number
+    fits_keyword: MJD-END
+    fits_hdu: EXTRACT1D
+  start_tdb:
+    title: "TDB at start of integration [MJD]"
+    type: number
+    fits_keyword: TDB-BEG
+    fits_hdu: EXTRACT1D
+  mid_tdb:
+    title: "TDB at middle of integration [MJD]"
+    type: number
+    fits_keyword: TDB-MID
+    fits_hdu: EXTRACT1D
+  end_tdb:
+    title: "TDB at end of integration [MJD]"
+    type: number
+    fits_keyword: TDB-END
+    fits_hdu: EXTRACT1D

--- a/src/stdatamodels/jwst/datamodels/spec.py
+++ b/src/stdatamodels/jwst/datamodels/spec.py
@@ -1,7 +1,7 @@
 from .model_base import JwstDataModel
 
 
-__all__ = ['SpecModel']
+__all__ = ['SpecModel', 'MrsSpecModel']
 
 
 class SpecModel(JwstDataModel):
@@ -16,3 +16,18 @@ class SpecModel(JwstDataModel):
         estimate for the flux, and data quality flags.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/spec.schema"
+
+
+class MrsSpecModel(SpecModel):
+    """
+    A data model for residual fringe corrected MRS 1D spectra
+
+    Parameters
+    __________
+    spec_table : numpy table
+        Extracted spectral data table
+        A table with the standard spec model columns plus three residual
+        fringe corrected data: flux, surface brightness and background
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
+    

--- a/src/stdatamodels/jwst/datamodels/spec.py
+++ b/src/stdatamodels/jwst/datamodels/spec.py
@@ -1,7 +1,7 @@
 from .model_base import JwstDataModel
 
 
-__all__ = ['SpecModel', 'MrsSpecModel']
+__all__ = ['SpecModel', 'MRSSpecModel']
 
 
 class SpecModel(JwstDataModel):
@@ -11,23 +11,23 @@ class SpecModel(JwstDataModel):
     Parameters
     __________
     spec_table : numpy table
-        Extracted spectral data table
+        Extracted spectral data table.
         A table with at least four columns:  wavelength, flux, an error
         estimate for the flux, and data quality flags.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/spec.schema"
 
 
-class MrsSpecModel(SpecModel):
+class MRSSpecModel(SpecModel):
     """
-    A data model for residual fringe corrected MRS 1D spectra
+    A data model for MIRI MRS 1D spectra with residual fringe corrections.
 
     Parameters
     __________
     spec_table : numpy table
-        Extracted spectral data table
-        A table with the standard spec model columns plus three residual
-        fringe corrected data: flux, surface brightness and background
+        Extracted spectral data table.
+        A table with the standard spectral columns plus three extra
+        columns for residual fringe corrected data: flux, surface brightness,
+        and background.
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mrs_spec.schema"
-    


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3790](https://jira.stsci.edu/browse/JP-3790)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Adds spectral models to support a few extra columns for MIRI MRS spectral data: residual fringe corrected flux, surface brightness, and background.  

In order to be as minimally disruptive as possible to existing spectral data models and to MIRI MRS users, I implemented this as a new parallel set of datamodels, with the extra columns defined in the mrs_spectable schema (paralleling the spectable schema), to be stored in an EXTRACT1D HDU.   The mrs_spectable schema is included in MRSSpecModel (paralleling SpecModel) for a single spectrum and in MRSMultiSpecModel (paralleling MultiSpecModel) for lists of spectra, in the spec_table property for each.  In order to avoid duplicating the additional metadata in MultiSpecModel, I pulled those properties out into a separate schema, to be included in both MRSMultiSpecModel and MultiSpecModel.

This PR builds on and replaces #376.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
