### PR TITLE
MIRI LRS specwcs datamodel 

### DIFF
--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -86,7 +86,7 @@ from .wcs_ref_models import (DistortionModel, DistortionMRSModel, SpecwcsModel,
                              RegionsModel, WavelengthrangeModel, CameraModel, CollimatorModel, OTEModel,
                              FOREModel, FPAModel, IFUPostModel, IFUFOREModel, IFUSlicerModel, MSAModel,
                              FilteroffsetModel, DisperserModel, NIRCAMGrismModel, NIRISSGrismModel,
-                             WaveCorrModel, MIRILrsModel)
+                             WaveCorrModel, MiriLRSSpecwcsModel)
 from .wfssbkg import WfssBkgModel
 from .util import open
 
@@ -132,6 +132,7 @@ __all__ = [
     'PixelAreaModel', 'NirspecSlitAreaModel', 'NirspecMosAreaModel', 'NirspecIfuAreaModel',
     'FgsImgPhotomModel',
     'MirImgPhotomModel', 'MirLrsPhotomModel', 'MirMrsPhotomModel',
+    'MiriLRSSpecwcsModel',
     'NrcImgPhotomModel', 'NrcWfssPhotomModel',
     'NisImgPhotomModel', 'NisSossPhotomModel', 'NisWfssPhotomModel',
     'NrsFsPhotomModel', 'NrsMosPhotomModel',

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -86,7 +86,7 @@ from .wcs_ref_models import (DistortionModel, DistortionMRSModel, SpecwcsModel,
                              RegionsModel, WavelengthrangeModel, CameraModel, CollimatorModel, OTEModel,
                              FOREModel, FPAModel, IFUPostModel, IFUFOREModel, IFUSlicerModel, MSAModel,
                              FilteroffsetModel, DisperserModel, NIRCAMGrismModel, NIRISSGrismModel,
-                             WaveCorrModel)
+                             WaveCorrModel, MIRILrsModel)
 from .wfssbkg import WfssBkgModel
 from .util import open
 

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -13,7 +13,7 @@ allOf:
 - $ref: subarray.schema
 - type: object
   properties:
-    wave_table:
+    wavetable:
       title: Wavelengths and x, y locations of wavelengths
       fits_hdu: WAVETABLE
       datatype:

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -20,36 +20,47 @@ allOf:
       - name: x_center
         datatype: float32
         unit: pixels
+        title: x location of the center of a given wavelength element
       - name: y_center
         datatype: float32
         unit: pixels
+        title: y location of the center of a given wavelength element
       - name: wavelength
         datatype: float32
         unit: microns
+        title: central wavelength of the wavelength element at x_center, y_center
       - name: x0
         datatype: float32
         unit: pixels
+        title: x location of the upper left corner of a given wavelength element
       - name: y0
         datatype: float32
         unit: pixels
+        title: y location of the upper left corner of a given wavelength element
       - name: x1
         datatype: float32
         unit: pixels
+        title: x location of the upper right corner of a given wavelength element
       - name: y1
         datatype: float32
         unit: pixels
+        title: y location of the upper right corner of a given wavelength element
       - name: x2
         datatype: float32
         unit: pixels
+        title: x location of the lower right corner of a given wavelength element
       - name: y2
         datatype: float32
         unit: pixels
+        title: y location of the lower right corner of a given wavelength element
       - name: x3
         datatype: float32
         unit: pixels
+        title: x location of the lower left corner of a given wavelength element 
       - name: y3
         datatype: float32
         unit: pixels
+        title: y location of the lower left corner of a given wavelength element
 - type: object
   properties:
     meta:

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -1,0 +1,109 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
+title: MIRI LRS Spec Schema
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_band.schema
+- $ref: subarray.schema
+- type: object
+  properties:
+    wave_table:
+      title: Wavelengths and x, y locations of wavelengths
+      fits_hdu: WAVETABLE
+      datatype:
+      - name: x_center
+        datatype: float32
+        unit: pixels
+      - name: y_center
+        datatype: float32
+        unit: pixels
+      - name: wavelength
+        datatype: float32
+        unit: microns
+      - name: x0
+        datatype: float32
+        unit: pixels
+      - name: y0
+        datatype: float32
+        unit: pixels
+      - name: x1
+        datatype: float32
+        unit: pixels
+      - name: y1
+        datatype: float32
+        unit: pixels
+      - name: x2
+        datatype: float32
+        unit: pixels
+      - name: y2
+        datatype: float32
+        unit: pixels
+      - name: x3
+        datatype: float32
+        unit: pixels
+      - name: y3
+        datatype: float32
+        unit: pixels
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        x_ref:
+          type: number
+          title: x coord of ref position of MIRIM_SLIT
+          default: pixels
+          fits_keyword: IMX
+        y_ref:
+          type: number
+          title: y coord of ref position of MIRIM_SLIT
+          default: pixels
+          fits_keyword: IMY
+        x_ref_slitless:
+          type: number
+          title: x coord of ref position of MIRIM_SLITLESS
+          default: pixels
+          fits_keyword: IMXSLTL
+        y_ref_slitless:
+          type: number
+          title: y coord of ref position of MIRIM_SLITLESS
+          default: pixels
+          fits_keyword: IMYSLTL
+        v2_vert1:
+          type: number
+          title: Slit vertex 1 in V2 frame
+          fits_keyword: V2VERT1
+        v2_vert2:
+          type: number
+          title: Slit vertex 2 in V2 frame
+          fits_keyword: V2VERT2
+        v2_vert3:
+          type: number
+          title: Slit vertex 3 in V2 frame
+          fits_keyword: V2VERT3
+        v2_vert4:
+          type: number
+          title: Slit vertex 4 in V2 frame
+          fits_keyword: V2VERT4
+        v3_vert1:
+          type: number
+          title: Slit vertex 1 in V3 frame
+          fits_keyword: V3VERT1
+        v3_vert2:
+          type: number
+          title: Slit vertex 2 in V3 frame
+          fits_keyword: V3VERT2
+        v3_vert3:
+          type: number
+          title: Slit vertex 3 in V3 frame
+          fits_keyword: V3VERT3
+        v3_vert4:
+          type: number
+          title: Slit vertex 4 in V3 frame
+          fits_keyword: V3VERT4

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -346,7 +346,7 @@ class NIRISSGrismModel(ReferenceFileModel):
 class MIRILrsModel(ReferenceFileModel):
     """
     A model for a reference file of type "specwcs" for MIRI LRS Slit.
-
+    The model is for the specwcs for LRS Fixed Slit and LRSSlitless
     Parameters
     ----------
     x_ref : float
@@ -379,6 +379,69 @@ class MIRILrsModel(ReferenceFileModel):
     """
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
     reftype = "specwcs"
+
+    def __init__(self, init=None,
+                 wavetable=None,
+                 x_ref=None,
+                 y_ref=None,
+                 x_ref_slitless=None,
+                 y_ref_slitless=None,
+                 v2_vert1=None,
+                 v2_vert2=None,
+                 v2_vert3=None,
+                 v2_vert4=None,
+                 v3_vert1=None,
+                 v3_vert2=None,
+                 v3_vert3=None,
+                 v3_vert4=None,
+                 **kwargs):
+        super().__init__(init=init, **kwargs)
+
+        if init is None:
+            self.populate_meta()
+        if wavetable is not None:
+            self.wavetable = wavetable
+        if x_ref is not None:
+            self.meta.x_ref = x_ref
+        if y_ref is not None:
+            self.meta.y_ref = y_ref
+        if x_ref_slitless is not None:
+            self.meta.x_ref_slitless = x_ref_slitless
+        if y_ref_slitless is not None:
+            self.meta.y_ref_slitless = y_ref_slitless
+        if v2_vert1 is not None:
+            self.meta.v2_vert1 = v2_vert1
+        if v2_vert2 is not None:
+            self.meta.v2_vert2 = v2_vert2
+        if v2_vert3 is not None:
+            self.meta.v2_vert3 = v2_vert3
+        if v2_vert4 is not None:
+            self.meta.v2_vert4 = v2_vert4
+        if v3_vert1 is not None:
+            self.meta.v3_vert1 = v3_vert1
+        if v3_vert2 is not None:
+            self.meta.v3_vert2 = v3_vert2
+        if v3_vert3 is not None:
+            self.meta.v3_vert3 = v3_vert3
+        if v3_vert4 is not None:
+            self.meta.v3_vert4 = v3_vert4
+
+    def populate_meta(self):
+        self.meta.instrument.name = "MIRI"
+        self.meta.instrument.detector = "MIRIMAGE"
+        self.meta.reftype = self.reftype
+
+    def validate(self):
+        super(MIRILrsModel, self).validate()
+        try:
+            assert self.meta.instrument.name == "MIRI"
+            assert self.meta.instrument.detector == "MIRIMAGE"
+            assert self.meta.reftype == self.reftype
+        except AssertionError:
+            if self._strict_validation:
+                raise
+            else:
+                warnings.warn(traceback.format_exc(), ValidationWarning)
        
 class RegionsModel(ReferenceFileModel):
     """

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -13,7 +13,8 @@ __all__ = ['DistortionModel', 'DistortionMRSModel', 'SpecwcsModel', 'RegionsMode
            'WavelengthrangeModel', 'CameraModel', 'CollimatorModel', 'OTEModel',
            'FOREModel', "FPAModel", 'IFUPostModel', 'IFUFOREModel', 'IFUSlicerModel',
            'MSAModel', 'FilteroffsetModel', 'DisperserModel',
-           'NIRCAMGrismModel', 'NIRISSGrismModel', 'WaveCorrModel', 'MIRILrsModel']
+           'NIRCAMGrismModel', 'NIRISSGrismModel', 'WaveCorrModel',
+           'MiriLRSSpecwcsModel']
 
 
 class _SimpleModel(ReferenceFileModel):
@@ -343,7 +344,7 @@ class NIRISSGrismModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
 
-class MIRILrsModel(ReferenceFileModel):
+class MiriLRSSpecwcsModel(ReferenceFileModel):
     """
     A model for a reference file of type "specwcs" for MIRI LRS Slit.
     The model is for the specwcs for LRS Fixed Slit and LRSSlitless
@@ -432,7 +433,7 @@ class MIRILrsModel(ReferenceFileModel):
         self.meta.reftype = self.reftype
 
     def validate(self):
-        super(MIRILrsModel, self).validate()
+        super(MiriLRSSpecwcsModel, self).validate()
         try:
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.instrument.detector == "MIRIMAGE"

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -13,7 +13,7 @@ __all__ = ['DistortionModel', 'DistortionMRSModel', 'SpecwcsModel', 'RegionsMode
            'WavelengthrangeModel', 'CameraModel', 'CollimatorModel', 'OTEModel',
            'FOREModel', "FPAModel", 'IFUPostModel', 'IFUFOREModel', 'IFUSlicerModel',
            'MSAModel', 'FilteroffsetModel', 'DisperserModel',
-           'NIRCAMGrismModel', 'NIRISSGrismModel', 'WaveCorrModel']
+           'NIRCAMGrismModel', 'NIRISSGrismModel', 'WaveCorrModel', 'MIRILrsModel']
 
 
 class _SimpleModel(ReferenceFileModel):
@@ -343,6 +343,43 @@ class NIRISSGrismModel(ReferenceFileModel):
         raise NotImplementedError("FITS format is not supported for this file.")
 
 
+class MIRILrsModel(ReferenceFileModel):
+    """
+    A model for a reference file of type "specwcs" for MIRI LRS Slit.
+
+    Parameters
+    ----------
+    x_ref : float
+         x coordinate of reference position of fixed slit aperture
+    y_ref : float
+        y coordinate of reference position of fixed slit aperture
+    x_ref_slitless : float
+         x coordinate of reference position of slitless aperture
+    y_ref_slitless : float
+        y coordinate of reference position of slitless aperture
+    v2vert1 : float
+        slit vertex 1 in V2 frame
+    v2vert2 : float
+        slit vertex 2 in V2 frame
+    v2vert3 : float
+        slit vertex 3 in V2 frame
+    v2vert4 : float
+        slit vertex 4 in V2 frames
+    v3vert1 : float
+        slit vertex 1 in V3 frames
+    v3vert2 : float
+        slit vertex 2 in V3 frames
+    v3vert3 : float
+        slit vertex 3 in V3 frames
+    v3vert4 : float
+        slit vertex 4 in V3 frames
+    wavetable : numpy  2-D array
+        For each row in the slit hold  wavelength, and 
+        x center, ycenter, x and y box region cooresponding to the wavelength
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
+    reftype = "specwcs"
+       
 class RegionsModel(ReferenceFileModel):
     """
     A model for a reference file of type "regions".


### PR DESCRIPTION
CLOSING PR in favor of #393 
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Helps to resolve[JP-3848](https://jira.stsci.edu/browse/JP-3848)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds a datamodel for the reference file type, specwcs, for the LRS. It can be used for Fixed slit and slitless. 
The reference file for Fixed slit contains the V2, V3 corners of the slit. These values are not in the slitless reference file
and default to None when the reference files are read in using datamodels. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
