### PR TITLE
Drop python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py310-xdist
         - macos: py311-xdist
         - linux: py311-cov-xdist
           coverage: codecov

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -56,7 +56,6 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - windows: py310-xdist
         - macos: py311-xdist
         - windows: py311-xdist
         - windows: py3-xdist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,3 @@ repos:
     hooks:
     - id: codespell
       args: ["--write-changes"]
-      additional_dependencies:
-        - tomli

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -11,7 +11,7 @@ exclude = [
     ".eggs",
 ]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [format]
 quote-style = "double"

--- a/changes/392.removal.rst
+++ b/changes/392.removal.rst
@@ -1,0 +1,1 @@
+Drop support for python 3.10

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -3,7 +3,7 @@ channels:
  - conda-forge
  - defaults
 dependencies:
- - python=3.10
+ - python=3.13
  - pip
  - graphviz
  - sphinx_rtd_theme>1.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,11 +4,7 @@ import sys
 from configparser import ConfigParser
 from datetime import datetime
 import importlib
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
+import tomllib
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "stdatamodels"
 description = "Core support for DataModel classes used in calibration pipelines"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "STScI" },
 ]
@@ -15,8 +15,8 @@ dependencies = [
     "asdf>=3.1.0",
     "asdf-transform-schemas>=0.5.0",
     "asdf-astropy>=0.3.0",
-    "numpy>=1.18",
-    "astropy>=5.0.4",
+    "numpy>=1.25",
+    "astropy>=5.2",
 ]
 dynamic = [
     "version",
@@ -57,7 +57,6 @@ docs = [
     "numpydoc",
     "sphinx-rtd-theme",
     "sphinx-asdf>=0.1.1",
-    'tomli; python_version <"3.11"',
 ]
 
 [build-system]

--- a/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
@@ -5,12 +5,8 @@ from pathlib import Path
 import numpy as np
 
 from astropy.modeling.models import Shift, Rotation2D, Const1D
-from astropy.utils import minversion
 
-if minversion("asdf_astropy", "0.3.0", False):
-    from asdf_astropy.testing.helpers import assert_model_roundtrip
-else:
-    from asdf_astropy.converters.transform.tests.test_transform import assert_model_roundtrip
+from asdf_astropy.testing.helpers import assert_model_roundtrip
 
 from stdatamodels.jwst.transforms.models import (
     NirissSOSSModel,

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -228,7 +228,7 @@ def create_history_entry(description, software=None):
     elif software is not None:
         software = Software(software)
 
-    dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    dt = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
     entry = HistoryEntry({"description": description, "time": dt})
 
     if software is not None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
@@ -291,7 +291,7 @@ def test_create_history_entry():
     assert isinstance(entry, HistoryEntry)
     assert entry["description"] == "Once upon a time..."
     assert entry.get("software") is None
-    dt = datetime.now(timezone.utc).replace(tzinfo=None)
+    dt = datetime.now(UTC).replace(tzinfo=None)
     assert (dt - entry["time"]) < timedelta(seconds=10)
 
     software = {"name": "PolarBearSoft", "version": "1.2.3"}


### PR DESCRIPTION
Now that jwst has dropped 3.10 this package can drop 3.10 (per SPEC 0).

This PR:
- drops python 3.10 support
- increases the numpy and astropy minimum versions (by SPEC 0)
- updates the CI and docs removing 3.10 usage

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
