### PR TITLE
Add miri lrs spec wcs model

### DIFF
--- a/changes/393.feature.rst
+++ b/changes/393.feature.rst
@@ -1,0 +1,1 @@
+added MIRI LRS specwcs datamodel to jwst models

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -108,6 +108,7 @@ from .wcs_ref_models import (
     DisperserModel,
     NIRCAMGrismModel,
     NIRISSGrismModel,
+    MiriLRSSpecwcsModel,
     WaveCorrModel,
 )
 from .wfssbkg import WfssBkgModel
@@ -175,6 +176,7 @@ __all__ = [
     "Level1bModel",
     "LinearityModel",
     "MaskModel",
+    "MiriLRSSpecwcsModel",
     "MSAModel",
     "MultiCombinedSpecModel",
     "MultiExposureModel",

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -2,14 +2,12 @@
 ---
 $schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
 id: "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
-title: MIRI LRS Spec Schema
+title: MIRI LRS Fixed Slit Specwcs Schema
 allOf:
 - $ref: referencefile.schema
 - $ref: keyword_pexptype.schema
 - $ref: keyword_exptype.schema
-- $ref: keyword_readpatt.schema
 - $ref: keyword_filter.schema
-- $ref: keyword_band.schema
 - $ref: subarray.schema
 - type: object
   properties:

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -67,22 +67,22 @@ allOf:
         x_ref:
           type: number
           title: x coord of ref position of MIRIM_SLIT
-          default: pixels
+          units: pixels
           fits_keyword: IMX
         y_ref:
           type: number
           title: y coord of ref position of MIRIM_SLIT
-          default: pixels
+          units: pixels
           fits_keyword: IMY
         x_ref_slitless:
           type: number
           title: x coord of ref position of MIRIM_SLITLESS
-          default: pixels
+          units: pixels
           fits_keyword: IMXSLTL
         y_ref_slitless:
           type: number
           title: y coord of ref position of MIRIM_SLITLESS
-          default: pixels
+          units: pixels
           fits_keyword: IMYSLTL
         v2_vert1:
           type: number

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -17,47 +17,36 @@ allOf:
       datatype:
       - name: x_center
         datatype: float32
-        unit: pixels
         title: "[pixels] x location of the center of a given wavelength element"
       - name: y_center
         datatype: float32
-        unit: pixels
         title: "[pixels] y location of the center of a given wavelength element"
       - name: wavelength
         datatype: float32
-        unit: microns
         title: "[microns] central wavelength of the wavelength element at x_center, y_center"
       - name: x0
         datatype: float32
-        unit: pixels
         title: "[pixels] x location of the upper left corner of a given wavelength element"
       - name: y0
         datatype: float32
-        unit: pixels
         title: "[pixels] y location of the upper left corner of a given wavelength element"
       - name: x1
         datatype: float32
-        unit: pixels
         title: "[pixels] x location of the upper right corner of a given wavelength element"
       - name: y1
         datatype: float32
-        unit: pixels
         title: "[pixels] y location of the upper right corner of a given wavelength element"
       - name: x2
         datatype: float32
-        unit: pixels
         title: "[pixels] x location of the lower right corner of a given wavelength element"
       - name: y2
         datatype: float32
-        unit: pixels
         title: "[pixels] y location of the lower right corner of a given wavelength element"
       - name: x3
         datatype: float32
-        unit: pixels
         title: "[pixels] x location of the lower left corner of a given wavelength element"
       - name: y3
         datatype: float32
-        unit: pixels
         title: "[pixels] y location of the lower left corner of a given wavelength element"
 - type: object
   properties:
@@ -66,7 +55,7 @@ allOf:
       properties:
         x_ref:
           type: number
-          title: "[pixels]  x coord of ref position of MIRIM_SLIT
+          title: "[pixels]  x coord of ref position of MIRIM_SLIT"
           fits_keyword: IMX
         y_ref:
           type: number

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -55,7 +55,7 @@ allOf:
       properties:
         x_ref:
           type: number
-          title: "[pixels]  x coord of ref position of MIRIM_SLIT"
+          title: "[pixels] x coord of ref position of MIRIM_SLIT"
           fits_keyword: IMX
         y_ref:
           type: number

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -1,0 +1,120 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
+title: MIRI LRS Spec Schema
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_pexptype.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_band.schema
+- $ref: subarray.schema
+- type: object
+  properties:
+    wavetable:
+      title: Wavelengths and x, y locations of wavelengths
+      fits_hdu: WAVETABLE
+      datatype:
+      - name: x_center
+        datatype: float32
+        unit: pixels
+        title: x location of the center of a given wavelength element
+      - name: y_center
+        datatype: float32
+        unit: pixels
+        title: y location of the center of a given wavelength element
+      - name: wavelength
+        datatype: float32
+        unit: microns
+        title: central wavelength of the wavelength element at x_center, y_center
+      - name: x0
+        datatype: float32
+        unit: pixels
+        title: x location of the upper left corner of a given wavelength element
+      - name: y0
+        datatype: float32
+        unit: pixels
+        title: y location of the upper left corner of a given wavelength element
+      - name: x1
+        datatype: float32
+        unit: pixels
+        title: x location of the upper right corner of a given wavelength element
+      - name: y1
+        datatype: float32
+        unit: pixels
+        title: y location of the upper right corner of a given wavelength element
+      - name: x2
+        datatype: float32
+        unit: pixels
+        title: x location of the lower right corner of a given wavelength element
+      - name: y2
+        datatype: float32
+        unit: pixels
+        title: y location of the lower right corner of a given wavelength element
+      - name: x3
+        datatype: float32
+        unit: pixels
+        title: x location of the lower left corner of a given wavelength element 
+      - name: y3
+        datatype: float32
+        unit: pixels
+        title: y location of the lower left corner of a given wavelength element
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        x_ref:
+          type: number
+          title: x coord of ref position of MIRIM_SLIT
+          default: pixels
+          fits_keyword: IMX
+        y_ref:
+          type: number
+          title: y coord of ref position of MIRIM_SLIT
+          default: pixels
+          fits_keyword: IMY
+        x_ref_slitless:
+          type: number
+          title: x coord of ref position of MIRIM_SLITLESS
+          default: pixels
+          fits_keyword: IMXSLTL
+        y_ref_slitless:
+          type: number
+          title: y coord of ref position of MIRIM_SLITLESS
+          default: pixels
+          fits_keyword: IMYSLTL
+        v2_vert1:
+          type: number
+          title: Slit vertex 1 in V2 frame
+          fits_keyword: V2VERT1
+        v2_vert2:
+          type: number
+          title: Slit vertex 2 in V2 frame
+          fits_keyword: V2VERT2
+        v2_vert3:
+          type: number
+          title: Slit vertex 3 in V2 frame
+          fits_keyword: V2VERT3
+        v2_vert4:
+          type: number
+          title: Slit vertex 4 in V2 frame
+          fits_keyword: V2VERT4
+        v3_vert1:
+          type: number
+          title: Slit vertex 1 in V3 frame
+          fits_keyword: V3VERT1
+        v3_vert2:
+          type: number
+          title: Slit vertex 2 in V3 frame
+          fits_keyword: V3VERT2
+        v3_vert3:
+          type: number
+          title: Slit vertex 3 in V3 frame
+          fits_keyword: V3VERT3
+        v3_vert4:
+          type: number
+          title: Slit vertex 4 in V3 frame
+          fits_keyword: V3VERT4

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -18,47 +18,47 @@ allOf:
       - name: x_center
         datatype: float32
         unit: pixels
-        title: x location of the center of a given wavelength element
+        title: "[pixels] x location of the center of a given wavelength element"
       - name: y_center
         datatype: float32
         unit: pixels
-        title: y location of the center of a given wavelength element
+        title: "[pixels] y location of the center of a given wavelength element"
       - name: wavelength
         datatype: float32
         unit: microns
-        title: central wavelength of the wavelength element at x_center, y_center
+        title: "[microns] central wavelength of the wavelength element at x_center, y_center"
       - name: x0
         datatype: float32
         unit: pixels
-        title: x location of the upper left corner of a given wavelength element
+        title: "[pixels] x location of the upper left corner of a given wavelength element"
       - name: y0
         datatype: float32
         unit: pixels
-        title: y location of the upper left corner of a given wavelength element
+        title: "[pixels] y location of the upper left corner of a given wavelength element"
       - name: x1
         datatype: float32
         unit: pixels
-        title: x location of the upper right corner of a given wavelength element
+        title: "[pixels] x location of the upper right corner of a given wavelength element"
       - name: y1
         datatype: float32
         unit: pixels
-        title: y location of the upper right corner of a given wavelength element
+        title: "[pixels] y location of the upper right corner of a given wavelength element"
       - name: x2
         datatype: float32
         unit: pixels
-        title: x location of the lower right corner of a given wavelength element
+        title: "[pixels] x location of the lower right corner of a given wavelength element"
       - name: y2
         datatype: float32
         unit: pixels
-        title: y location of the lower right corner of a given wavelength element
+        title: "[pixels] y location of the lower right corner of a given wavelength element"
       - name: x3
         datatype: float32
         unit: pixels
-        title: x location of the lower left corner of a given wavelength element 
+        title: "[pixels] x location of the lower left corner of a given wavelength element"
       - name: y3
         datatype: float32
         unit: pixels
-        title: y location of the lower left corner of a given wavelength element
+        title: "[pixels] y location of the lower left corner of a given wavelength element"
 - type: object
   properties:
     meta:
@@ -66,19 +66,19 @@ allOf:
       properties:
         x_ref:
           type: number
-          title:  x coord in pixels of ref position of MIRIM_SLIT
+          title: "[pixels]  x coord of ref position of MIRIM_SLIT
           fits_keyword: IMX
         y_ref:
           type: number
-          title: y coord in pixels in pixel  of ref position of MIRIM_SLIT
+          title: "[pixels] y coord of ref position of MIRIM_SLIT"
           fits_keyword: IMY
         x_ref_slitless:
           type: number
-          title: x coord in pixel of ref position of MIRIM_SLITLESS
+          title: "[pixels] x coord of ref position of MIRIM_SLITLESS"
           fits_keyword: IMXSLTL
         y_ref_slitless:
           type: number
-          title: y coord in pixels of ref position of MIRIM_SLITLESS
+          title: "[pixels] y coord of ref position of MIRIM_SLITLESS"
           fits_keyword: IMYSLTL
         v2_vert1:
           type: number

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_miri_lrs.schema.yaml
@@ -66,23 +66,19 @@ allOf:
       properties:
         x_ref:
           type: number
-          title: x coord of ref position of MIRIM_SLIT
-          units: pixels
+          title:  x coord in pixels of ref position of MIRIM_SLIT
           fits_keyword: IMX
         y_ref:
           type: number
-          title: y coord of ref position of MIRIM_SLIT
-          units: pixels
+          title: y coord in pixels in pixel  of ref position of MIRIM_SLIT
           fits_keyword: IMY
         x_ref_slitless:
           type: number
-          title: x coord of ref position of MIRIM_SLITLESS
-          units: pixels
+          title: x coord in pixel of ref position of MIRIM_SLITLESS
           fits_keyword: IMXSLTL
         y_ref_slitless:
           type: number
-          title: y coord of ref position of MIRIM_SLITLESS
-          units: pixels
+          title: y coord in pixels of ref position of MIRIM_SLITLESS
           fits_keyword: IMYSLTL
         v2_vert1:
           type: number

--- a/src/stdatamodels/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
@@ -8,6 +8,7 @@ allOf:
 - $ref: keyword_module.schema
 - $ref: keyword_pupil.schema
 - $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
 - type: object
   properties:
     displ:

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -112,9 +112,10 @@ resol_model_map = {
 }
 
 specwcs_model_map = {
-    "MIR_IMAGE": dm.MiriLRSSpecwcsModel,
-    "NIRCAM": dm.NIRCAMGrismModel,
-    "NIRISS": dm.NIRISSGrismModel,
+    "MIR_LRS-FIXEDSLIT": dm.MiriLRSSpecwcsModel,
+    "MIR_LRS-SLITLESS": dm.MiriLRSSpecwcsModel,
+    # "NRS_WFSS": dm.NIRCAMGrismModel,
+    # "NIS_WFSS": dm.NIRISSGrismModel,
     "other": dm.SpecwcsModel,
 }
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -111,6 +111,13 @@ resol_model_map = {
     "other": dm.ResolutionModel,
 }
 
+specwcs_model_map = {
+    "MIR_IMAGE": dm.MiriLRSSpecwcsModel,
+    "NIRCAM": dm.NIRCAMGrismModel,
+    "NIRISS": dm.NIRISSGrismModel,
+    "other": dm.SpecwcsModel,
+}
+
 ref_to_multiples_dict = {
     "apcorr": apcorr_model_map,
     "area": area_model_map,
@@ -120,6 +127,7 @@ ref_to_multiples_dict = {
     "pathloss": pathloss_model_map,
     "photom": photom_model_map,
     "resol": resol_model_map,
+    "specwcs": specwcs_model_map,
 }
 
 ref_to_datamodel_dict = {
@@ -167,7 +175,7 @@ ref_to_datamodel_dict = {
     "speckernel": dm.SpecKernelModel,
     "specprofile": dm.SpecProfileModel,
     "spectrace": dm.SpecTraceModel,
-    "specwcs": dm.SpecwcsModel,
+    #    "specwcs": dm.SpecwcsModel,
     "straymask": dm.StrayLightModel,
     "superbias": dm.SuperBiasModel,
     "throughput": dm.ThroughputModel,

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -114,8 +114,8 @@ resol_model_map = {
 specwcs_model_map = {
     "MIR_LRS-FIXEDSLIT": dm.MiriLRSSpecwcsModel,
     "MIR_LRS-SLITLESS": dm.MiriLRSSpecwcsModel,
-    # "NRS_WFSS": dm.NIRCAMGrismModel,
-    # "NIS_WFSS": dm.NIRISSGrismModel,
+    "NRC_WFSS": dm.NIRCAMGrismModel,
+    "NIS_WFSS": dm.NIRISSGrismModel,
     "other": dm.SpecwcsModel,
 }
 
@@ -176,7 +176,6 @@ ref_to_datamodel_dict = {
     "speckernel": dm.SpecKernelModel,
     "specprofile": dm.SpecProfileModel,
     "spectrace": dm.SpecTraceModel,
-    #    "specwcs": dm.SpecwcsModel,
     "straymask": dm.StrayLightModel,
     "superbias": dm.SuperBiasModel,
     "throughput": dm.ThroughputModel,

--- a/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
@@ -1,0 +1,59 @@
+import numpy as np
+from stdatamodels.jwst import datamodels
+
+
+def test_miri_lrs_specwcs():
+    """Test the MIRI LRS specwcs data is loaded correctly."""
+    xc = np.array([1.0, 2.0, 3.0])
+    yc = np.array([4.0, 5.0, 6.0])
+    wave = np.array([12.4, 13.4, 14.5])
+    x0 = np.array([1.0, 2.0, 3.0])
+    x1 = np.array([1, 2, 3])
+    x2 = np.array([1, 2, 3])
+    x3 = np.array([1, 2, 3])
+    y0 = np.array([1, 2, 3])
+    y1 = np.array([1, 2, 3])
+    y2 = np.array([1, 2, 3])
+    y3 = np.array([1, 2, 3])
+
+    d = np.dtype(
+        [
+            ("x_center", np.float32),
+            ("y_center", np.float32),
+            ("wavelength", np.float32),
+            ("x0", np.float32),
+            ("y0", np.float32),
+            ("x1", np.float32),
+            ("y1", np.float32),
+            ("x2", np.float32),
+            ("y2", np.float32),
+            ("x3", np.float32),
+            ("y3", np.float32),
+        ]
+    )
+    wavetable = np.array(
+        [
+            (xc[0], yc[0], wave[0], x0[0], y0[0], x1[0], y1[0], x2[0], y2[0], x3[0], y3[0]),
+            (xc[1], yc[1], wave[1], x0[1], y0[1], x1[1], y1[1], x2[1], y2[1], x3[1], y3[1]),
+            (xc[2], yc[2], wave[2], x0[2], y0[2], x1[2], y1[2], x2[2], y2[2], x3[2], y3[2]),
+        ],
+        dtype=d,
+    )
+
+    model = datamodels.MiriLRSSpecwcsModel(x_ref=430, y_ref=400, wavetable=wavetable)
+    assert model.meta.instrument.name == "MIRI"
+    assert model.meta.instrument.detector == "MIRIMAGE"
+    assert model.meta.reftype == "specwcs"
+    assert model.meta.x_ref == 430
+    assert model.meta.y_ref == 400
+
+    # for slitless case assert the v2/v3 vertices are None if not in the file
+    assert model.meta.v2_vert1 is None
+    assert model.meta.v2_vert2 is None
+    assert model.meta.v2_vert3 is None
+    assert model.meta.v2_vert4 is None
+
+    assert model.meta.v3_vert1 is None
+    assert model.meta.v3_vert2 is None
+    assert model.meta.v3_vert3 is None
+    assert model.meta.v3_vert4 is None

--- a/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
@@ -41,6 +41,10 @@ def test_miri_lrs_specwcs():
     )
 
     model = datamodels.MiriLRSSpecwcsModel(x_ref=430, y_ref=400, wavetable=wavetable)
+    model.meta.description = "MIRI LRS SPECWCS reference file"
+    model.meta.author = "Jane Morrison"
+    model.meta.pedigree = "FLIGHT"
+    model.meta.useafter = "2022-05-01T00:00:00"
     assert model.meta.instrument.name == "MIRI"
     assert model.meta.instrument.detector == "MIRIMAGE"
     assert model.meta.reftype == "specwcs"
@@ -57,3 +61,4 @@ def test_miri_lrs_specwcs():
     assert model.meta.v3_vert2 is None
     assert model.meta.v3_vert3 is None
     assert model.meta.v3_vert4 is None
+    model.validate()

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -489,7 +489,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
     def populate_meta(self):
         self.meta.instrument.name = "MIRI"
         self.meta.instrument.detector = "MIRIMAGE"
-        self.meta.reftype = self.reftype
+        self.meta.reftype = self.reftype.lower()
         self.meta.instrument.filter = "P750L"
 
     def validate(self):

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -489,7 +489,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
     def populate_meta(self):
         self.meta.instrument.name = "MIRI"
         self.meta.instrument.detector = "MIRIMAGE"
-        self.meta.reftype = self.reftype.lower()
+        self.meta.reftype = self.reftype
         self.meta.instrument.filter = "P750L"
 
     def validate(self):
@@ -497,7 +497,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
         try:
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.instrument.detector == "MIRIMAGE"
-            assert self.meta.reftype == self.reftype
+            assert self.meta.reftype.lower() == self.reftype
         except AssertionError:
             if self._strict_validation:
                 raise

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -29,6 +29,7 @@ __all__ = [
     "NIRCAMGrismModel",
     "NIRISSGrismModel",
     "WaveCorrModel",
+    "MiriLRSSpecwcsModel"
 ]
 
 
@@ -396,6 +397,107 @@ class NIRISSGrismModel(ReferenceFileModel):
 
     def to_fits(self):
         raise NotImplementedError("FITS format is not supported for this file.")
+
+
+class MiriLRSSpecwcsModel(ReferenceFileModel):
+    """
+    A model for a reference file of type "specwcs" for MIRI LRS Slit.
+    The model is for the specwcs for LRS Fixed Slit and LRSSlitless
+    Parameters
+    ----------
+    x_ref : float
+         x coordinate of reference position of fixed slit aperture
+    y_ref : float
+        y coordinate of reference position of fixed slit aperture
+    x_ref_slitless : float
+         x coordinate of reference position of slitless aperture
+    y_ref_slitless : float
+        y coordinate of reference position of slitless aperture
+    v2vert1 : float
+        slit vertex 1 in V2 frame
+    v2vert2 : float
+        slit vertex 2 in V2 frame
+    v2vert3 : float
+        slit vertex 3 in V2 frame
+    v2vert4 : float
+        slit vertex 4 in V2 frames
+    v3vert1 : float
+        slit vertex 1 in V3 frames
+    v3vert2 : float
+        slit vertex 2 in V3 frames
+    v3vert3 : float
+        slit vertex 3 in V3 frames
+    v3vert4 : float
+        slit vertex 4 in V3 frames
+    wavetable : numpy  2-D array
+        For each row in the slit hold  wavelength, and 
+        x center, ycenter, x and y box region cooresponding to the wavelength
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
+    reftype = "specwcs"
+
+    def __init__(self, init=None,
+                 wavetable=None,
+                 x_ref=None,
+                 y_ref=None,
+                 x_ref_slitless=None,
+                 y_ref_slitless=None,
+                 v2_vert1=None,
+                 v2_vert2=None,
+                 v2_vert3=None,
+                 v2_vert4=None,
+                 v3_vert1=None,
+                 v3_vert2=None,
+                 v3_vert3=None,
+                 v3_vert4=None,
+                 **kwargs):
+        super().__init__(init=init, **kwargs)
+
+        if init is None:
+            self.populate_meta()
+        if wavetable is not None:
+            self.wavetable = wavetable
+        if x_ref is not None:
+            self.meta.x_ref = x_ref
+        if y_ref is not None:
+            self.meta.y_ref = y_ref
+        if x_ref_slitless is not None:
+            self.meta.x_ref_slitless = x_ref_slitless
+        if y_ref_slitless is not None:
+            self.meta.y_ref_slitless = y_ref_slitless
+        if v2_vert1 is not None:
+            self.meta.v2_vert1 = v2_vert1
+        if v2_vert2 is not None:
+            self.meta.v2_vert2 = v2_vert2
+        if v2_vert3 is not None:
+            self.meta.v2_vert3 = v2_vert3
+        if v2_vert4 is not None:
+            self.meta.v2_vert4 = v2_vert4
+        if v3_vert1 is not None:
+            self.meta.v3_vert1 = v3_vert1
+        if v3_vert2 is not None:
+            self.meta.v3_vert2 = v3_vert2
+        if v3_vert3 is not None:
+            self.meta.v3_vert3 = v3_vert3
+        if v3_vert4 is not None:
+            self.meta.v3_vert4 = v3_vert4
+
+    def populate_meta(self):
+        self.meta.instrument.name = "MIRI"
+        self.meta.instrument.detector = "MIRIMAGE"
+        self.meta.reftype = self.reftype
+
+    def validate(self):
+        super(MiriLRSSpecwcsModel, self).validate()
+        try:
+            assert self.meta.instrument.name == "MIRI"
+            assert self.meta.instrument.detector == "MIRIMAGE"
+            assert self.meta.reftype == self.reftype
+        except AssertionError:
+            if self._strict_validation:
+                raise
+            else:
+                warnings.warn(traceback.format_exc(), ValidationWarning)
 
 
 class RegionsModel(ReferenceFileModel):

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -29,7 +29,7 @@ __all__ = [
     "NIRCAMGrismModel",
     "NIRISSGrismModel",
     "WaveCorrModel",
-    "MiriLRSSpecwcsModel"
+    "MiriLRSSpecwcsModel",
 ]
 
 
@@ -430,27 +430,31 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
     v3vert4 : float
         slit vertex 4 in V3 frames
     wavetable : numpy  2-D array
-        For each row in the slit hold  wavelength, and 
-        x center, ycenter, x and y box region cooresponding to the wavelength
+        For each row in the slit hold  wavelength, and
+        x center, ycenter, x and y box region corresponding to the wavelength
     """
+
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
     reftype = "specwcs"
 
-    def __init__(self, init=None,
-                 wavetable=None,
-                 x_ref=None,
-                 y_ref=None,
-                 x_ref_slitless=None,
-                 y_ref_slitless=None,
-                 v2_vert1=None,
-                 v2_vert2=None,
-                 v2_vert3=None,
-                 v2_vert4=None,
-                 v3_vert1=None,
-                 v3_vert2=None,
-                 v3_vert3=None,
-                 v3_vert4=None,
-                 **kwargs):
+    def __init__(
+        self,
+        init=None,
+        wavetable=None,
+        x_ref=None,
+        y_ref=None,
+        x_ref_slitless=None,
+        y_ref_slitless=None,
+        v2_vert1=None,
+        v2_vert2=None,
+        v2_vert3=None,
+        v2_vert4=None,
+        v3_vert1=None,
+        v3_vert2=None,
+        v3_vert3=None,
+        v3_vert4=None,
+        **kwargs,
+    ):
         super().__init__(init=init, **kwargs)
 
         if init is None:
@@ -486,6 +490,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
         self.meta.instrument.name = "MIRI"
         self.meta.instrument.detector = "MIRIMAGE"
         self.meta.reftype = self.reftype
+        self.meta.instrument.filter = "P750L"
 
     def validate(self):
         super(MiriLRSSpecwcsModel, self).validate()
@@ -497,7 +502,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
             if self._strict_validation:
                 raise
             else:
-                warnings.warn(traceback.format_exc(), ValidationWarning)
+                warnings.warn(traceback.format_exc(), ValidationWarning, stacklevel=2)
 
 
 class RegionsModel(ReferenceFileModel):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Helps Resolve [JP-3848](https://jira.stsci.edu/browse/JP-3848)


This PR replaces #382. There we too many conflicts to resolve easily after the code style changes were made. 

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->

Corresponding jwst PR: https://github.com/spacetelescope/jwst/pull/9193


This PR adds a datamodel of the reference file, specwcs, for MIRI LRS data. It can be used for fixed slit or slitless data. The reference file for fixed slit contains the V2,V3 corners of the slit. These values are not in the slitless reference file and default to None when the reference files are read in using the data models

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
