### PR TITLE
Validate dimension when instantiating datamodel from shape

### DIFF
--- a/changes/395.bugfix.rst
+++ b/changes/395.bugfix.rst
@@ -1,0 +1,1 @@
+Validate dimension against schema when instantiating datamodel from array shape

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -142,7 +142,7 @@ def test_model_with_nonstandard_primary_array():
         def get_primary_array_name(self):
             return "wavelength"
 
-    m = _NonstandardPrimaryArrayModel((10,))
+    m = _NonstandardPrimaryArrayModel((10, 10))
     assert "wavelength" in list(m.keys())
     assert m.wavelength.sum() == 0
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -180,11 +180,8 @@ def _make_default_array(attr, schema, ctx):
 
     if attr == primary_array_name:
         if ctx.shape is not None:
-            # Ensure that input shape matches schema ndim
-            if (ndim is not None) and (len(ctx.shape) != ndim):
-                msg = f"Array has wrong number of dimensions. Expected {ndim}, got {len(ctx.shape)}"
-                raise ValueError(msg)
             shape = ctx.shape
+            _validate_primary_shape(schema, shape)
         elif ndim is not None:
             shape = tuple([0] * ndim)
         else:
@@ -224,6 +221,34 @@ def _make_default_array(attr, schema, ctx):
     if default is not None:
         array[...] = default
     return array
+
+
+def _validate_primary_shape(schema, shape):
+    """
+    Ensure requested shape is allowed by schema.
+
+    Parameters
+    ----------
+    schema : dict
+        The schema for the primary array.
+    shape : tuple
+        The requested shape of the default array.
+
+    Raises
+    ------
+    ValueError
+        If the requested has dimensions different from the schema's ndim,
+        or larger than the schema's max_ndim.
+    """
+    ndim_requested = len(shape)
+    max_ndim = schema.get("max_ndim", None)
+    ndim = schema.get("ndim", None)
+    if (ndim is not None) and (ndim_requested != ndim):
+        msg = f"Array has wrong number of dimensions. Expected {ndim}, got {ndim_requested}"
+        raise ValueError(msg)
+    if (max_ndim is not None) and (ndim_requested > max_ndim):
+        msg = f"Array has wrong number of dimensions. Expected <= {max_ndim}, got {ndim_requested}"
+        raise ValueError(msg)
 
 
 def _make_default(attr, schema, ctx):

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -180,6 +180,10 @@ def _make_default_array(attr, schema, ctx):
 
     if attr == primary_array_name:
         if ctx.shape is not None:
+            # Ensure that input shape matches schema ndim
+            if (ndim is not None) and (len(ctx.shape) != ndim):
+                msg = f"Array has wrong number of dimensions. Expected {ndim}, got {len(ctx.shape)}"
+                raise ValueError(msg)
             shape = ctx.shape
         elif ndim is not None:
             shape = tuple([0] * ndim)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,9 +99,11 @@ def test_init_with_array2():
         with BasicModel(array) as dm:
             dm.data  # noqa: B018
 
+
 def test_init_invalid_shape():
     with pytest.raises(ValueError):
         BasicModel((50, 50, 50))
+
 
 def test_set_array():
     with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,6 +99,9 @@ def test_init_with_array2():
         with BasicModel(array) as dm:
             dm.data  # noqa: B018
 
+def test_init_invalid_shape():
+    with pytest.raises(ValueError):
+        BasicModel((50, 50, 50))
 
 def test_set_array():
     with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,8 +101,19 @@ def test_init_with_array2():
 
 
 def test_init_invalid_shape():
+    """Requested some number of dimensions unequal to ndim"""
     with pytest.raises(ValueError):
-        BasicModel((50, 50, 50))
+        BasicModel((50,))
+
+
+def test_init_invalid_shape2():
+    """Requested more dimensions than max_ndim"""
+    with BasicModel() as dm:
+        schema = dm._schema
+    schema["properties"]["data"]["max_ndim"] = 1
+    schema["properties"]["data"]["ndim"] = None
+    with pytest.raises(ValueError):
+        BasicModel((50, 50), schema=schema)
 
 
 def test_set_array():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,7 +101,7 @@ def test_init_with_array2():
 
 
 def test_init_invalid_shape():
-    """Requested some number of dimensions unequal to ndim"""
+    """Requested some number of dimensions unequal to ndim, which is set to 2"""
     with pytest.raises(ValueError):
         BasicModel((50,))
 


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #307 

<!-- describe the changes comprising this PR here -->
This PR addresses a bug when instantiating datamodels from an array shape.  The problem is discussed in detail on the issue, but in short, the input shape was not checked against the schema `ndim` attribute when creating a default array

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
