### PR TITLE
Move find_fits_keyword to fits_support

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -929,3 +929,38 @@ def ensure_ascii(s):
     if isinstance(s, bytes):
         s = s.decode("ascii")
     return s
+
+
+def find_fits_keyword(schema, keyword, return_result=False):
+    """
+    Utility function to find a reference to a FITS keyword in a given
+    schema.  This is intended for interactive use, and not for use
+    within library code.
+
+    Parameters
+    ----------
+    schema : JSON schema fragment
+        The schema in which to search.
+
+    keyword : str
+        A FITS keyword name
+
+    Returns
+    -------
+    locations : list of str
+
+    Notes
+    -----
+    return_result is included for backward compatibility and is not used.
+    """
+
+    def find_fits_keyword(subschema, path, combiner, ctx, recurse):
+        if len(path) and path[0] == "extra_fits":
+            return True
+        if subschema.get("fits_keyword") == keyword:
+            results.append(".".join(path))
+
+    results = []
+    mschema.walk_schema(schema, find_fits_keyword, results)
+
+    return results

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -740,9 +740,9 @@ class DataModel(properties.ObjectNode):
             the schema where this FITS keyword is used.  Each element
             is a dot-separated path.
         """
-        from . import schema
+        from . import fits_support
 
-        return schema.find_fits_keyword(self.schema, keyword)
+        return fits_support.find_fits_keyword(self.schema, keyword)
 
     def search_schema(self, substring):
         """

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -3,38 +3,6 @@
 import re
 
 
-# return_result included for backward compatibility
-def find_fits_keyword(schema, keyword, return_result=False):
-    """
-    Utility function to find a reference to a FITS keyword in a given
-    schema.  This is intended for interactive use, and not for use
-    within library code.
-
-    Parameters
-    ----------
-    schema : JSON schema fragment
-        The schema in which to search.
-
-    keyword : str
-        A FITS keyword name
-
-    Returns
-    -------
-    locations : list of str
-    """
-
-    def find_fits_keyword(subschema, path, combiner, ctx, recurse):
-        if len(path) and path[0] == "extra_fits":
-            return True
-        if subschema.get("fits_keyword") == keyword:
-            results.append(".".join(path))
-
-    results = []
-    walk_schema(schema, find_fits_keyword, results)
-
-    return results
-
-
 class SearchSchemaResults(list):
     def __repr__(self):
         import textwrap

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -717,3 +717,8 @@ def test_fitsrec_for_non_schema_data(tmp_path):
     )
     fn = tmp_path / "test.fits"
     m.save(fn)
+
+
+def test_find_fits_keyword():
+    with FitsModel() as x:
+        assert x.find_fits_keyword("TELESCOP") == ["meta.telescope"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,11 +29,6 @@ def test_ad_hoc_attributes(filename, tmp_path):
         assert dm2.meta.foo == {"a": 42, "b": ["a", "b", "c"]}
 
 
-def test_find_fits_keyword():
-    with FitsModel() as x:
-        assert x.find_fits_keyword("TELESCOP") == ["meta.telescope"]
-
-
 def test_search_schema():
     with BasicModel() as x:
         results = x.search_schema("origin")


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #33 

<!-- describe the changes comprising this PR here -->
This PR makes a small reorganization, moving the FITS-format-specific function `find_fits_keyword` out of `schema/` and into `fits_support/`.  Note that `find_fits_keyword` is also a method of a DataModel, and that method is unchanged except that it internally calls from elsewhere in the codebase. 

That is, the documented way to call this function, e.g., `model.find_fits_keyword('DATE-OBS')`, is unchanged.  

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
