### PR TITLE
Allow to_flat_dict to be used as a standalone function

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -3,7 +3,6 @@ Data model class hierarchy
 """
 
 import copy
-import datetime
 import os
 from pathlib import Path, PurePath
 import sys
@@ -12,11 +11,9 @@ import warnings
 import numpy as np
 
 from astropy.io import fits
-from astropy.time import Time
 from astropy.wcs import WCS
 
 import asdf
-from asdf.tags.core import NDArrayType
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
 
@@ -25,7 +22,11 @@ from . import fits_support
 from . import properties
 from . import schema as mschema
 from . import validate
-from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
+from .util import (
+    convert_fitsrec_to_array_in_tree,
+    get_envar_as_boolean,
+    remove_none_from_tree,
+)
 
 from .history import HistoryList
 
@@ -986,22 +987,7 @@ class DataModel(properties.ObjectNode):
             {"meta.observation.date": "2012-04-22T03:22:05.432"}
 
         """
-
-        def convert_val(val):
-            if isinstance(val, datetime.datetime):
-                return val.isoformat()
-            elif isinstance(val, Time):
-                return str(val)
-            return val
-
-        if include_arrays:
-            return {key: convert_val(val) for (key, val) in self.items()}
-        else:
-            return {
-                key: convert_val(val)
-                for (key, val) in self.items()
-                if not isinstance(val, (np.ndarray, NDArrayType))
-            }
+        return mschema.flatten_nested_dict(self._instance, include_arrays=include_arrays)
 
     @property
     def schema(self):


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #131 

<!-- describe the changes comprising this PR here -->
This PR addresses a request for the functionality of `model.to_flat_dict()` to also exist as a standalone function instead of a class method for use in e.g. jdaviz.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
