### PR TITLE
increase minimum versions to match jwst

### DIFF
--- a/changes/399.misc.rst
+++ b/changes/399.misc.rst
@@ -1,0 +1,1 @@
+Increase minimum versions of asdf-astropy, asdf and astropy dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "asdf>=3.1.0",
+    "asdf>=3.3.0",
     "asdf-transform-schemas>=0.5.0",
     "asdf-astropy>=0.6.0",
     "numpy>=1.25",
-    "astropy>=5.2",
+    "astropy>=6.1",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     "asdf>=3.1.0",
     "asdf-transform-schemas>=0.5.0",
-    "asdf-astropy>=0.3.0",
+    "asdf-astropy>=0.6.0",
     "numpy>=1.25",
     "astropy>=5.2",
 ]


### PR DESCRIPTION
This PR updates a few dependencies to match those in jwst:

- asdf-astropy to 0.6.0 (pending https://github.com/spacetelescope/jwst/pull/9177)
- asdf to [3.3](https://github.com/spacetelescope/jwst/blob/d8033b3dd52a15c40fb034eededb4684afdd03f3/pyproject.toml#L21)
- astropy to [6.1](https://github.com/spacetelescope/jwst/blob/d8033b3dd52a15c40fb034eededb4684afdd03f3/pyproject.toml#L22)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
