### PR TITLE
Remove deprecated get_fileext() method

### DIFF
--- a/changes/400.removal.rst
+++ b/changes/400.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated DataModel.get_fileext() method

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1007,14 +1007,6 @@ class DataModel(properties.ObjectNode):
     def schema(self):
         return self._schema
 
-    def get_fileext(self):
-        warnings.warn(
-            "get_fileext always returns 'fits' and will be removed in an upcoming release",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return "fits"
-
     @property
     def history(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -341,9 +341,3 @@ def test_garbage_collectable(ModelType, tmp_path):  # noqa: N803
             # many models which would indicate they are difficult to garbage
             # collect.
             assert len(mids) < 2
-
-
-def test_get_fileext_deprecation():
-    m = DataModel()
-    with pytest.warns(DeprecationWarning):
-        assert m.get_fileext() == "fits"


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #16 

<!-- describe the changes comprising this PR here -->
This PR removes the previously-deprecated `DataModel.get_fileext()` method. The method is unused by JWST.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
