### PR TITLE
Fix bug preventing NirspecQuadFlatModel instantiation from NirspecFlatModel

### DIFF
--- a/changes/401.bugfix.rst
+++ b/changes/401.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug preventing NirspecQuadFlatModel instantiation from NirspecFlatModel

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -118,7 +118,7 @@ class NirspecQuadFlatModel(ReferenceFileModel):
             self.quadrants[0].wavelength = init.wavelength
             self.quadrants[0].flat_table = init.flat_table
             self.quadrants[0].dq_def = init.dq_def
-            self.quadrants[0].dq = dynamic_mask(self.quadrants[0])
+            self.quadrants[0].dq = dynamic_mask(self.quadrants[0], pixel)
             return
 
         super(NirspecQuadFlatModel, self).__init__(init=init, **kwargs)

--- a/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
@@ -10,7 +10,14 @@ def flatmodel():
     rng = np.random.default_rng()
     data = rng.random((100, 100))
     dq = rng.integers(0, 2, (100, 100))
-    return NirspecFlatModel(data, dq=dq)
+    model = NirspecFlatModel(data, dq=dq)
+    model.meta.instrument.name = "NIRSPEC"
+    model.meta.reftype = "FLAT"
+    model.meta.author = "STSCI"
+    model.meta.description = "Test flat field model"
+    model.meta.pedigree = "GROUND"
+    model.meta.useafter = "2025-02-12T00:00:00"
+    return model
 
 
 def test_initialize_quad_from_flat(flatmodel):

--- a/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
@@ -1,0 +1,23 @@
+"""Tests for nirspec flat field models."""
+
+import numpy as np
+import pytest
+from stdatamodels.jwst.datamodels import NirspecFlatModel, NirspecQuadFlatModel
+
+
+@pytest.fixture(scope="module")
+def flatmodel():
+    rng = np.random.default_rng()
+    data = rng.random((100, 100))
+    dq = rng.integers(0, 2, (100, 100))
+    return NirspecFlatModel(data, dq=dq)
+
+
+def test_initialize_quad_from_flat(flatmodel):
+    """
+    Cover a bug where attempting to initialize a quad flat model from a flat model would fail.
+    """
+    quadmodel = NirspecQuadFlatModel(flatmodel)
+    assert isinstance(quadmodel, NirspecQuadFlatModel)
+    assert np.allclose(quadmodel.quadrants[0].data, flatmodel.data)
+    assert np.allclose(quadmodel.quadrants[0].dq, flatmodel.dq)


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #186 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where attempting to initialize a `NirspecQuadFlatModel` from a `NirspecFlatModel` would raise `TypeError: dynamic_mask() missing 1 required positional argument: 'mnemonic_map'`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
