### PR TITLE
Force array validation when initializing a datamodel from another datamodel of different type

### DIFF
--- a/changes/403.bugfix.rst
+++ b/changes/403.bugfix.rst
@@ -1,0 +1,1 @@
+Force array validation when initializing a datamodel from another datamodel of different type

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -27,10 +27,12 @@ from stdatamodels.jwst.datamodels import (
     IFUImageModel,
     ABVegaOffsetModel,
     Level1bModel,
+    CubeModel,
 )
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import _defined_models as defined_models
 from stdatamodels.schema import walk_schema
+from stdatamodels.validate import ValidationWarning
 
 ROOT_DIR = Path(__file__).parent / "data"
 FITS_FILE = ROOT_DIR / "test.fits"
@@ -312,6 +314,13 @@ def test_ifuimage():
 
     im = ImageModel(ifuimage)
     assert type(im) is ImageModel
+
+
+def test_init_incompatible_model():
+    data = np.arange(24).reshape((6, 4))
+    im = ImageModel(data=data, err=data / 2, dq=data)
+    with pytest.raises(ValidationWarning):
+        CubeModel(im)
 
 
 def test_abvega_offset_model():

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -212,7 +212,10 @@ class DataModel(properties.ObjectNode):
             asdffile = None
             self.clone(self, init)
             if not isinstance(init, self.__class__):
+                current_validate_arrays = self._validate_arrays
+                self._validate_arrays = True
                 self.validate()
+                self._validate_arrays = current_validate_arrays
             return
 
         elif isinstance(init, AsdfFile):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from stdatamodels import DataModel
 
-from models import BasicModel, AnyOfModel, TableModel, TransformModel
+from models import BasicModel, AnyOfModel, TableModel, TransformModel, FitsModel
+from stdatamodels.validate import ValidationWarning
 
 
 def test_init_from_pathlib(tmp_path):
@@ -114,6 +115,15 @@ def test_init_invalid_shape2():
     schema["properties"]["data"]["ndim"] = None
     with pytest.raises(ValueError):
         BasicModel((50, 50), schema=schema)
+
+
+def test_init_incompatible_datamodel():
+    """Initialized a model with a different model type that has invalid dimensions"""
+    input_model = FitsModel((50, 50))
+    schema = input_model._schema
+    schema["properties"]["data"]["ndim"] = 3
+    with pytest.raises(ValidationWarning):
+        BasicModel(input_model, schema=schema)
 
 
 def test_set_array():


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #307 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug that allowed initialization of a datamodel from a different datamodel with an incompatible schema.  For example, a CubeModel could be used as input to an ImageModel, e.g., `model = ImageModel(CubeModel(10,10,10))`, leading to a situation where the `ImageModel` contained a 3-D data array that was incompatible with its schema `ndim`.  This PR forces validation of arrays when attempting this kind of assignment.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
