### PR TITLE
Turn on documentation rules in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,10 @@ repos:
       - id: numpydoc-validation
         exclude: |
           (?x)^(
-          src/stdatamodels/jwst/.* |
           docs/.* |
           tests/.* |
+          .*/tests/.* |
+          .*/_tests/.* |
           src/__init__.py |
           )$
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,18 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
-  # - repo: https://github.com/numpy/numpydoc
-  #   rev: v1.8.0
-  #   hooks:
-  #     - id: numpydoc-validation
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.8.0
+    hooks:
+      - id: numpydoc-validation
+        exclude: |
+          (?x)^(
+          src/stdatamodels/.*\.py |
+          src/stdatamodels/jwst/.* |
+          docs/.* |
+          tests/.* |
+          src/__init__.py |
+          )$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
       - id: numpydoc-validation
         exclude: |
           (?x)^(
-          src/stdatamodels/.*\.py |
           src/stdatamodels/jwst/.* |
           docs/.* |
           tests/.* |

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,6 +9,10 @@ exclude = [
     "dist",
     ".tox",
     ".eggs",
+    "**/tests/test*.py",
+    "**/_tests/test*.py",
+    "**/tests/**/__init__.py",
+    "src/__init__.py",
 ]
 line-length = 100
 target-version = "py311"
@@ -69,3 +73,5 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "**/test_*.py" = ["S101", "SLF001", "B011", "D104"]
 "tests/**" = ["INP001"]
 "src/stdatamodels/jwst/datamodels/darkMIRI.py" = ["N999"]
+"src/stdatamodels/jwst/transforms/converters/jwst_models.py" = ["D"] # all converters have same standard docstrings
+"src/stdatamodels/jwst/datamodels/wcs_ref_models.py" = ["D102"] # all public methods are overriding base class, so are the same

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,7 +23,7 @@ select = [
     "F",      # Pyflakes (part of default flake8)
     "E",      # pycodestyle (part of default flake8)
     "W",      # pycodestyle (part of default flake8)
-    #"D",      # docstrings, see also numpydoc pre-commit action
+    "D",      # docstrings, see also numpydoc_validation pre-commit action
     "N",      # pep8-naming (naming conventions)
     "A",      # flake8-builtins (prevent shadowing of builtins)
     #"ARG",    # flake8-unused-arguments (prevent unused arguments)
@@ -46,6 +46,7 @@ select = [
 ]
 ignore = [
     "D100", # missing docstring in public module
+    "D105", # missing docstring in magic method
     "E741", # ambiguous variable name (O/0, l/I, etc.)
     "UP008", # use super() instead of super(class, self). no harm being explicit
     "UP015", # unnecessary open(file, "r"). no harm being explicit
@@ -65,6 +66,6 @@ convention = "numpy"
 ignore-fully-untyped = true  # Turn of annotation checking for fully untyped code
 
 [lint.per-file-ignores]
-"**/test_*.py" = ["S101", "SLF001", "B011"]
+"**/test_*.py" = ["S101", "SLF001", "B011", "D104"]
 "tests/**" = ["INP001"]
 "src/stdatamodels/jwst/datamodels/darkMIRI.py" = ["N999"]

--- a/changes/406.misc.rst
+++ b/changes/406.misc.rst
@@ -1,0 +1,1 @@
+Add docstring rules to pre-commit hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,19 @@ select = [
     "E722",
 ]
 
+[tool.numpydoc_validation]
+checks = [
+    "all",
+    "EX01", # No examples section found
+    "SA01", # See Also section not found
+    "ES01", # No extended summary found
+    "GL08", # Object does not have a docstring. Ruff catches these, and allows more granular ignores.
+    "PR01", # Parameters not documented. Already caught by ruff.
+    "PR09", # Parameter description should finish with a period
+    "RT02", # First line of return should contain only the type
+    "RT05", # Return value description should finish with a period
+]
+
 [tool.codespell]
 skip = "*.fits, *.asdf, ./build, ./docs/_build, CHANGES.rst, *.schema.yaml"
 ignore-words-list = "indx, delt, Shepard, fo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = [
 
 [tool.numpydoc_validation]
 checks = [
-    "all",
+    "all", # Adds all rules except the ones listed below
     "EX01", # No examples section found
     "SA01", # See Also section not found
     "ES01", # No extended summary found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,11 @@ checks = [
     "RT02", # First line of return should contain only the type
     "RT05", # Return value description should finish with a period
 ]
+exclude = [
+    "shape$", # Exclude shape methods
+    "validate$", # Exclude validate methods
+    "copy$", # Exclude copy methods
+]
 
 [tool.codespell]
 skip = "*.fits, *.asdf, ./build, ./docs/_build, CHANGES.rst, *.schema.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,10 +131,13 @@ checks = [
     "RT02", # First line of return should contain only the type
     "RT05", # Return value description should finish with a period
 ]
-exclude = [
-    "shape$", # Exclude shape methods
-    "validate$", # Exclude validate methods
-    "copy$", # Exclude copy methods
+exclude = [ # exclude the following methods
+    "shape$",
+    "validate$",
+    "copy$",
+    "__call__$",
+    "inverse$",
+    "__str__$",
 ]
 
 [tool.codespell]

--- a/src/stdatamodels/__init__.py
+++ b/src/stdatamodels/__init__.py
@@ -1,3 +1,5 @@
+"""Data models for JWST."""
+
 from .model_base import DataModel
 from . import _version
 

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -8,7 +8,8 @@ __all__ = ["write", "open"]
 
 
 def write(filename, tree, hdulist=None, **kwargs):
-    """Write ASDF data inside a fits file
+    """
+    Write ASDF data inside a fits file.
 
     Parameters
     ----------
@@ -16,10 +17,8 @@ def write(filename, tree, hdulist=None, **kwargs):
         Filename where the resulting fits file containing the ASDF
         data will be saved. This is passed on to
         :func:`astropy.io.fits.HDUList.writeto`
-
     tree : ASDF tree or dict
         ASDF data to save in the fits file
-
     kwargs : variable keyword arguments
         Passed on to :func:`astropy.io.fits.HDUList.writeto`
     """
@@ -28,7 +27,8 @@ def write(filename, tree, hdulist=None, **kwargs):
 
 
 def open(filename_or_hdu, **kwargs):  # noqa: A001
-    """Read ASDF data embedded in a fits file
+    """
+    Read ASDF data embedded in a fits file.
 
     Parameters
     ----------
@@ -36,7 +36,6 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
         Filename of the fits file or an open `astropy.io.fits.HDUList`
         containing the ASDF data. If a filename is provided it
         will be opened with :func:`astropy.io.fits.open`.
-
     kwargs : variable keyword arguments
         Passed on to :func:`asdf.open`
 
@@ -46,7 +45,6 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
         :obj:`asdf.AsdfFile` created from ASDF data embedded in the opened
         fits file.
     """
-
     is_hdu = isinstance(filename_or_hdu, fits.HDUList)
     hdulist = filename_or_hdu if is_hdu else fits.open(filename_or_hdu)
     if "ignore_missing_extensions" not in kwargs:

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -19,7 +19,10 @@ def write(filename, tree, hdulist=None, **kwargs):
         :func:`astropy.io.fits.HDUList.writeto`
     tree : ASDF tree or dict
         ASDF data to save in the fits file
-    kwargs : variable keyword arguments
+    hdulist : `astropy.io.fits.HDUList`
+        Optional HDUList to write the ASDF data to. If not provided,
+        a new HDUList will be created.
+    **kwargs : variable keyword arguments
         Passed on to :func:`astropy.io.fits.HDUList.writeto`
     """
     hdulist = fits_support.to_fits(tree, None, hdulist=hdulist)  # no custom schema
@@ -36,7 +39,7 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
         Filename of the fits file or an open `astropy.io.fits.HDUList`
         containing the ASDF data. If a filename is provided it
         will be opened with :func:`astropy.io.fits.open`.
-    kwargs : variable keyword arguments
+    **kwargs : variable keyword arguments
         Passed on to :func:`asdf.open`
 
     Returns

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -9,7 +9,7 @@ __all__ = ["write", "open"]
 
 def write(filename, tree, hdulist=None, **kwargs):
     """
-    Write ASDF data inside a fits file.
+    Write ASDF data inside a FITS file.
 
     Parameters
     ----------
@@ -22,7 +22,7 @@ def write(filename, tree, hdulist=None, **kwargs):
     hdulist : `astropy.io.fits.HDUList`
         Optional HDUList to write the ASDF data to. If not provided,
         a new HDUList will be created.
-    **kwargs : dict
+    **kwargs
         Additional keyword arguments to pass to :func:`astropy.io.fits.HDUList.writeto`
     """
     hdulist = fits_support.to_fits(tree, None, hdulist=hdulist)  # no custom schema
@@ -36,17 +36,17 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
     Parameters
     ----------
     filename_or_hdu : str, path, `astropy.io.fits.HDUList`
-        Filename of the fits file or an open `astropy.io.fits.HDUList`
+        Filename of the FITS file or an open `astropy.io.fits.HDUList`
         containing the ASDF data. If a filename is provided it
         will be opened with :func:`astropy.io.fits.open`.
-    **kwargs : dict
+    **kwargs
         Additional keyword arguments to pass to :func:`asdf.open`
 
     Returns
     -------
     af : :obj:`asdf.AsdfFile`
         :obj:`asdf.AsdfFile` created from ASDF data embedded in the opened
-        fits file.
+        FITS file.
     """
     is_hdu = isinstance(filename_or_hdu, fits.HDUList)
     hdulist = filename_or_hdu if is_hdu else fits.open(filename_or_hdu)

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -22,8 +22,8 @@ def write(filename, tree, hdulist=None, **kwargs):
     hdulist : `astropy.io.fits.HDUList`
         Optional HDUList to write the ASDF data to. If not provided,
         a new HDUList will be created.
-    **kwargs : variable keyword arguments
-        Passed on to :func:`astropy.io.fits.HDUList.writeto`
+    **kwargs : dict
+        Additional keyword arguments to pass to :func:`astropy.io.fits.HDUList.writeto`
     """
     hdulist = fits_support.to_fits(tree, None, hdulist=hdulist)  # no custom schema
     hdulist.writeto(filename, **kwargs)
@@ -39,8 +39,8 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
         Filename of the fits file or an open `astropy.io.fits.HDUList`
         containing the ASDF data. If a filename is provided it
         will be opened with :func:`astropy.io.fits.open`.
-    **kwargs : variable keyword arguments
-        Passed on to :func:`asdf.open`
+    **kwargs : dict
+        Additional keyword arguments to pass to :func:`asdf.open`
 
     Returns
     -------

--- a/src/stdatamodels/basic_utils.py
+++ b/src/stdatamodels/basic_utils.py
@@ -18,7 +18,7 @@ def multiple_replace(string, rep_dict):
     string : str
         The source string to have replacements done on it.
     rep_dict : dict
-        The replacements were key is the input substring and
+        The replacements, where key is the input substring and
         value is the replacement
 
     Returns

--- a/src/stdatamodels/basic_utils.py
+++ b/src/stdatamodels/basic_utils.py
@@ -5,26 +5,25 @@ __all__ = ["multiple_replace"]
 
 
 def multiple_replace(string, rep_dict):
-    """Single-pass replacement of multiple substrings
+    """
+    Single-pass replacement of multiple substrings.
 
     Similar to `str.replace`, except that a dictionary of replacements
     can be specified.
-
-    The replacements are done in a single-pass. This means that a previous
+    The replacements are done in a single pass. This means that a previous
     replacement will not be replaced by a subsequent match.
 
     Parameters
     ----------
-    string: str
+    string : str
         The source string to have replacements done on it.
-
-    rep_dict: dict
+    rep_dict : dict
         The replacements were key is the input substring and
         value is the replacement
 
     Returns
     -------
-    replaced: str
+    replaced : str
         New string with the replacements done
 
     Examples
@@ -35,8 +34,7 @@ def multiple_replace(string, rep_dict):
 
     >>> multiple_replace("button mutton", {"but": "mut", "mutton": "lamb"})
     'mutton lamb'
-
-    """
+    """  # numpydoc ignore=SS05
     pattern = re.compile(
         "|".join([re.escape(k) for k in sorted(rep_dict, key=len, reverse=True)]), flags=re.DOTALL
     )

--- a/src/stdatamodels/dqflags.py
+++ b/src/stdatamodels/dqflags.py
@@ -1,6 +1,5 @@
 """
-Implementation
---------------
+Interpret JWST data quality flags.
 
 The flags are implemented as "bit flags": Each flag is assigned a bit position
 in a byte, or multi-byte word, of memory. If that bit is set, the flag assigned
@@ -16,9 +15,10 @@ from stdatamodels.basic_utils import multiple_replace
 
 
 def interpret_bit_flags(bit_flags, flip_bits=None, mnemonic_map=None):
-    """Converts input bit flags to a single integer value (bit mask) or `None`.
+    """
+    Convert input bit flags to a single integer value (bit mask) or `None`.
 
-    Wraps `astropy.nddate.bitmask.interpret_bit_flags`, allowing the
+    Wraps `astropy.nddata.bitmask.interpret_bit_flags`, allowing the
     bit mnemonics to be used in place of integers.
 
     Parameters
@@ -54,14 +54,15 @@ def interpret_bit_flags(bit_flags, flip_bits=None, mnemonic_map=None):
 
 
 def dqflags_to_mnemonics(dqflags, mnemonic_map):
-    """Interpret value as bit flags and return the mnemonics
+    """
+    Interpret value as bit flags and return the mnemonics.
 
     Parameters
     ----------
     dqflags : int-like
         The value to interpret as DQ flags
 
-    mnemonic_map: {str: int[,...]}
+    mnemonic_map : {str: int[,...]}
         Dictionary associating the mnemonic string to an integer value
         representing the set bit for that mnemonic.
 

--- a/src/stdatamodels/dqflags.py
+++ b/src/stdatamodels/dqflags.py
@@ -62,13 +62,13 @@ def dqflags_to_mnemonics(dqflags, mnemonic_map):
     dqflags : int-like
         The value to interpret as DQ flags
 
-    mnemonic_map : {str: int[,...]}
+    mnemonic_map : dict
         Dictionary associating the mnemonic string to an integer value
         representing the set bit for that mnemonic.
 
     Returns
     -------
-    mnemonics : {str[,...]}
+    mnemonics : set
         Set of mnemonics represented by the set bit flags
 
     Examples

--- a/src/stdatamodels/dqflags.py
+++ b/src/stdatamodels/dqflags.py
@@ -30,7 +30,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None, mnemonic_map=None):
     flip_bits : bool, None
         See `astropy.nddata.bitmask.interpret_bit_flags`.
 
-    mnemonic_map : {str: int[,...]}
+    mnemonic_map : dict
         Dictionary associating the mnemonic string to an integer value
         representing the set bit for that mnemonic.
 

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -17,10 +17,8 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     ----------
     input_model : ``MaskModel``
         An instance of a Mask model defined in jwst or romancal.
-
     mnemonic_map : dict
         Dictionary of flag names and values.
-
     inv : bool
         If true, compress using the dq_def.  If false, decompress
         using the dq_def.
@@ -30,7 +28,6 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     dqmask : ndarray
         A Numpy array
     """
-
     dq_table = input_model.dq_def
     # Get the DQ array and the flag definitions
     if (

--- a/src/stdatamodels/filetype.py
+++ b/src/stdatamodels/filetype.py
@@ -3,17 +3,17 @@ from pathlib import Path
 
 def check(init):
     """
-    Determine the type of a file and return it as a string
+    Determine the type of a file and return it as a string.
 
     Parameters
     ----------
-
-    init : file path or file object
+    init : str or file-like object
+        The file path or file object
 
     Returns
     -------
-    file_type: a string with the file type ("asdf", "asn", or "fits")
-
+    file_type : str
+        A string representing the file type ("asdf", "asn", or "fits")
     """
     if isinstance(init, str):
         path = Path(init)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -798,7 +798,7 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
 
     Returns
     -------
-    af : asdf.AsdfFile
+    asdf.AsdfFile
         The ASDF file object
     """
     ignore_missing_extensions = kwargs.pop("ignore_missing_extensions")

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -472,6 +472,16 @@ def _normalize_arrays(tree):
     They are written to disk by astropy.io.fits in C-contiguous, and we
     don't want the asdf library to notice the change in memory
     layout and duplicate the array in the embedded ASDF.
+
+    Parameters
+    ----------
+    tree : dict
+        The ASDF tree.
+
+    Returns
+    -------
+    tree : dict
+        The ASDF tree with all arrays converted to C-contiguous.
     """
 
     def normalize_array(node):
@@ -740,8 +750,15 @@ def from_fits(hdulist, schema, context, **kwargs):
         The FITS HDUList
     schema : dict
         The schema defining the ASDF > FITS_KEYWORD, FITS_HDU mapping.
-    context: DataModel
+    context : DataModel
         The `DataModel` to update
+    **kwargs : dict
+        Additional arguments to pass to `from_fits_asdf`
+
+    Returns
+    -------
+    asdf.AsdfFile
+        The ASDF file object
     """
     try:
         ff = from_fits_asdf(hdulist, **kwargs)
@@ -773,11 +790,11 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     ignore_unrecognized_tag : bool
         When `True`, ignore unrecognized tags in the ASDF file.
         When `False`, raise an error when an unrecognized tag is found.
-    ignore_missing_extensions : bool
-        When `True`, ignore missing extensions in the ASDF file.
-        When `False`, raise an error when an extension is missing.
     **kwargs : dict
         Additional arguments to pass to `asdf.open`
+        - ignore_missing_extensions : bool
+          When `True`, ignore missing extensions in the ASDF file.
+          When `False`, raise an error when an extension is missing.
 
     Returns
     -------

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -80,7 +80,7 @@ _builtin_regex = re.compile("|".join(f"(^{x}$)" for x in _builtin_regexes))
 
 def is_builtin_fits_keyword(key):
     """
-    Check if key is a fits builtin.
+    Check if key is a FITS builtin.
 
     Builtins are those managed by ``astropy.io.fits``, and we don't
     want to propagate those through the `_extra_fits` mechanism.
@@ -158,7 +158,7 @@ def get_hdu(hdulist, hdu_name, index=None, _cache=None):
 
     Parameters
     ----------
-    hdulist : weakref.ReferenceType
+    hdulist : astropy.io.fits.hdu.hdulist.HDUList
         A FITS HDUList
     hdu_name : str
         The name of the HDU to retrieve
@@ -292,7 +292,7 @@ def _fits_element_writer(fits_context, validator, fits_keyword, instance, schema
         hdu.header.append((" ", ""), end=True)
     fits_context.comment_stack = []
 
-    comment = get_short_doc(schema)
+    comment = _get_short_doc(schema)
 
     if fits_keyword in ("COMMENT", "HISTORY"):
         for item in instance:
@@ -781,7 +781,7 @@ def from_fits(hdulist, schema, context, **kwargs):
 
 def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     """
-    Wrap asdf call to extract optional arguments.
+    Open the ASDF extension from a FITS hdulist.
 
     Parameters
     ----------
@@ -961,20 +961,7 @@ def fits_hash(hdulist):
     return fits_hash.hexdigest()
 
 
-def get_short_doc(schema):
-    """
-    Get the short description from the schema.
-
-    Parameters
-    ----------
-    schema : dict
-        The schema to extract the description
-
-    Returns
-    -------
-    description : str
-        The short description
-    """
+def _get_short_doc(schema):
     title = schema.get("title", None)
     description = schema.get("description", None)
     if description is None:

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -80,9 +80,20 @@ _builtin_regex = re.compile("|".join(f"(^{x}$)" for x in _builtin_regexes))
 
 def is_builtin_fits_keyword(key):
     """
-    Returns `True` if the given `key` is a built-in FITS keyword, i.e.
-    a keyword that is managed by ``astropy.io.fits`` and we wouldn't
-    want to propagate through the `_extra_fits` mechanism.
+    Check if key is a fits builtin.
+
+    Builtins are those managed by ``astropy.io.fits``, and we don't
+    want to propagate those through the `_extra_fits` mechanism.
+
+    Parameters
+    ----------
+    key : str
+        The keyword to check.
+
+    Returns
+    -------
+    bool
+        `True` if the keyword is a built-in FITS keyword.
     """
     return _builtin_regex.match(key) is not None
 
@@ -142,6 +153,25 @@ def _get_hdu_pair(hdu_name, index=None):
 
 
 def get_hdu(hdulist, hdu_name, index=None, _cache=None):
+    """
+    Retrieve an HDU from an hdulist.
+
+    Parameters
+    ----------
+    hdulist : weakref.ReferenceType
+        A FITS HDUList
+    hdu_name : str
+        The name of the HDU to retrieve
+    index : int, optional
+        The index of the HDU to retrieve
+    _cache : dict, optional
+        Cache of HDUs
+
+    Returns
+    -------
+    hdu : astropy.io.fits.hdu.base._BaseHDU
+        The HDU as represented by astropy.io.fits
+    """
     pair = _get_hdu_pair(hdu_name, index=index)
     if _cache is not None and pair in _cache:
         return _cache[pair]
@@ -437,8 +467,9 @@ def _create_tagged_dict_for_fits_array(hdu, hdu_index):
 
 def _normalize_arrays(tree):
     """
-    Convert arrays in the tree to C-contiguous, since that is
-    how they are written to disk by astropy.io.fits and we
+    Convert arrays in the tree to C-contiguous.
+
+    They are written to disk by astropy.io.fits in C-contiguous, and we
     don't want the asdf library to notice the change in memory
     layout and duplicate the array in the embedded ASDF.
     """
@@ -490,7 +521,23 @@ def _save_history(hdulist, tree):
 
 
 def to_fits(tree, schema, hdulist=None):
-    """Create hdulist and modified ASDF tree"""
+    """
+    Create hdulist and modified ASDF tree.
+
+    Parameters
+    ----------
+    tree : dict
+        The ASDF tree to convert to FITS.
+    schema : dict
+        The schema for the ASDF tree.
+    hdulist : astropy.io.fits.HDUList, optional
+        The HDU list to append to. If not provided, a new HDU list will be created.
+
+    Returns
+    -------
+    hdulist : astropy.io.fits.HDUList
+        The HDU list.
+    """
     if hdulist is None:
         hdulist = fits.HDUList()
         hdulist.append(fits.PrimaryHDU())
@@ -684,19 +731,17 @@ def _load_history(hdulist, tree):
 
 
 def from_fits(hdulist, schema, context, **kwargs):
-    """Read model information from a FITS HDU list
+    """
+    Read model information from a FITS HDU list.
 
     Parameters
     ----------
     hdulist : astropy.io.fits.HDUList
         The FITS HDUList
-
     schema : dict
         The schema defining the ASDF > FITS_KEYWORD, FITS_HDU mapping.
-
     context: DataModel
         The `DataModel` to update
-
     """
     try:
         ff = from_fits_asdf(hdulist, **kwargs)
@@ -719,7 +764,25 @@ def from_fits(hdulist, schema, context, **kwargs):
 
 def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     """
-    Wrap asdf call to extract optional arguments
+    Wrap asdf call to extract optional arguments.
+
+    Parameters
+    ----------
+    hdulist : astropy.io.fits.HDUList
+        The FITS HDUList
+    ignore_unrecognized_tag : bool
+        When `True`, ignore unrecognized tags in the ASDF file.
+        When `False`, raise an error when an unrecognized tag is found.
+    ignore_missing_extensions : bool
+        When `True`, ignore missing extensions in the ASDF file.
+        When `False`, raise an error when an extension is missing.
+    **kwargs : dict
+        Additional arguments to pass to `asdf.open`
+
+    Returns
+    -------
+    af : asdf.AsdfFile
+        The ASDF file object
     """
     ignore_missing_extensions = kwargs.pop("ignore_missing_extensions")
 
@@ -777,7 +840,19 @@ def _map_hdulist_to_arrays(hdulist, af):
 
 def from_fits_hdu(hdu, schema):
     """
-    Read the data from a fits hdu into a numpy ndarray
+    Read the data from a fits hdu into a numpy ndarray.
+
+    Parameters
+    ----------
+    hdu : astropy.io.fits.hdu.base._BaseHDU
+        The FITS HDU
+    schema : dict
+        The schema for the data
+
+    Returns
+    -------
+    data : numpy.ndarray
+        The data from the FITS HDU
     """
     data = hdu.data
 
@@ -798,7 +873,8 @@ def from_fits_hdu(hdu, schema):
 
 
 def _can_skip_fits_update(hdulist, asdf_struct, context):
-    """Ensure all conditions for skipping FITS updating are true
+    """
+    Ensure all conditions for skipping FITS updating are true.
 
     Returns True if either 1) the FITS hash in the asdf structure matches the input
     FITS structure. Or 2) skipping has been explicitly asked for in `skip_fits_update`.
@@ -807,10 +883,8 @@ def _can_skip_fits_update(hdulist, asdf_struct, context):
     ----------
     hdulist : astropy.io.fits.HDUList
         The input FITS information
-
     asdf_struct : asdf.ASDFFile
         The associated ASDF structure
-
     context : DataModel
         The DataModel being built.
 
@@ -845,7 +919,8 @@ def _can_skip_fits_update(hdulist, asdf_struct, context):
 
 
 def fits_hash(hdulist):
-    """Calculate a hash based on all HDU headers
+    """
+    Calculate a hash based on all HDU headers.
 
     Uses basic SHA-256 hash to calculate.
 
@@ -870,6 +945,19 @@ def fits_hash(hdulist):
 
 
 def get_short_doc(schema):
+    """
+    Get the short description from the schema.
+
+    Parameters
+    ----------
+    schema : dict
+        The schema to extract the description
+
+    Returns
+    -------
+    description : str
+        The short description
+    """
     title = schema.get("title", None)
     description = schema.get("description", None)
     if description is None:

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -571,7 +571,7 @@ def to_fits(tree, schema, hdulist=None):
 def _create_asdf_hdu(tree):
     buffer = io.BytesIO()
     # convert all FITS_rec instances to numpy arrays, this is needed as
-    # some arrays loaded from the fits data for old files may not be defined
+    # some arrays loaded from the FITS data for old files may not be defined
     # in the current schemas. These will be loaded as FITS_rec instances but
     # not linked back (and safely converted) on write if they are removed
     # from the schema.
@@ -752,7 +752,7 @@ def from_fits(hdulist, schema, context, **kwargs):
         The schema defining the ASDF > FITS_KEYWORD, FITS_HDU mapping.
     context : DataModel
         The `DataModel` to update
-    **kwargs : dict
+    **kwargs
         Additional arguments to pass to `from_fits_asdf`
 
     Returns
@@ -781,7 +781,7 @@ def from_fits(hdulist, schema, context, **kwargs):
 
 def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     """
-    Open the ASDF extension from a FITS hdulist.
+    Open the ASDF extension from a FITS HDUlist.
 
     Parameters
     ----------
@@ -790,7 +790,7 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     ignore_unrecognized_tag : bool
         When `True`, ignore unrecognized tags in the ASDF file.
         When `False`, raise an error when an unrecognized tag is found.
-    **kwargs : dict
+    **kwargs
         Additional arguments to pass to `asdf.open`
         - ignore_missing_extensions : bool
           When `True`, ignore missing extensions in the ASDF file.
@@ -857,7 +857,7 @@ def _map_hdulist_to_arrays(hdulist, af):
 
 def from_fits_hdu(hdu, schema):
     """
-    Read the data from a fits hdu into a numpy ndarray.
+    Read the data from a FITS HDU into a numpy ndarray.
 
     Parameters
     ----------

--- a/src/stdatamodels/history.py
+++ b/src/stdatamodels/history.py
@@ -10,6 +10,7 @@ def _iterable(values):
 class HistoryList:
     """
     A list that coerces a new value into a HistoryEntry.
+
     Only a subset of the list interface is implemented.
     """
 
@@ -64,16 +65,16 @@ class HistoryList:
                         return False
         return True
 
-    def append(self, value):
+    def append(self, value):  # noqa: D102
         if isinstance(value, HistoryEntry):
             self._entries.append(value)
         else:
             self._context.add_history_entry(value)
 
-    def clear(self):
+    def clear(self):  # noqa: D102
         self._entries.clear()
 
-    def extend(self, values):
+    def extend(self, values):  # noqa: D102
         values = _iterable(values)
         for value in values:
             self.append(value)

--- a/src/stdatamodels/jwst/__init__.py
+++ b/src/stdatamodels/jwst/__init__.py
@@ -1,0 +1,1 @@
+"""Datamodels for JWST and architecture to support them."""

--- a/src/stdatamodels/jwst/_kwtool/_tests/conftest.py
+++ b/src/stdatamodels/jwst/_kwtool/_tests/conftest.py
@@ -140,7 +140,5 @@ def limit_dmd_models():
 
 @pytest.fixture(scope="module")
 def fake_dmd(limit_dmd_models):
-    """
-    A fake datamodel dictionary that includes only 1 datamodel: ImageModel
-    """
+    """Make a fake datamodel dictionary that includes only 1 datamodel: ImageModel."""
     return dmd.load()

--- a/src/stdatamodels/jwst/_kwtool/kwd.py
+++ b/src/stdatamodels/jwst/_kwtool/kwd.py
@@ -1,5 +1,6 @@
 """
 Since these aren't jsonschemas the usual tools won't work.
+
 - Start with a "top" schema
 - Traverse (keeping track of path, ignore combiners, properties, etc)
 - When we hit 'fits_keyword'...

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -1,3 +1,5 @@
+"""Datamodels for JWST pipeline."""
+
 from .model_base import JwstDataModel
 from .abvega_offset import ABVegaOffsetModel
 from .amilg import AmiLgModel

--- a/src/stdatamodels/jwst/datamodels/abvega_offset.py
+++ b/src/stdatamodels/jwst/datamodels/abvega_offset.py
@@ -8,10 +8,9 @@ __all__ = ["ABVegaOffsetModel"]
 
 class ABVegaOffsetModel(ReferenceFileModel):
     """
-    A data model containing offsets to convert from AB to Vega
-    magnitudes.
+    A data model containing offsets to convert from AB to Vega magnitudes.
 
-    Parameters
+    Attributes
     ----------
     abvega_offset : `astropy.table.Table`
         An astropy table containing offsets to convert from AB to Vega
@@ -41,7 +40,7 @@ class ABVegaOffsetModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/abvegaoffset.schema"
 
-    def validate(self):
+    def validate(self):  # noqa: D102
         super(ABVegaOffsetModel, self).validate()
         try:
             assert len(self.abvega_offset) > 0

--- a/src/stdatamodels/jwst/datamodels/amilg.py
+++ b/src/stdatamodels/jwst/datamodels/amilg.py
@@ -8,41 +8,27 @@ class AmiLgModel(JwstDataModel):
     """
     A data model for AMI LG analysis results.
 
-    Parameters
+    Attributes
     ----------
-
     fit_image : numpy float32 array
          Fitted image
-
     resid_image : numpy float32 array
          Residual image
-
     closure_amp_table : numpy table
          Closure amplitudes table
-
     closure_phase_table : numpy table
          Closure phases table
-
     fringe_amp_table : numpy table
          Fringe amplitudes table
-
     fringe_phase_table : numpy table
          Fringe phases table
-
     pupil_phase_table : numpy table
          Pupil phases table
-
     solns_table : numpy table
          Solutions table
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/amilg.schema"
 
-    def get_primary_array_name(self):
-        """
-        Returns the name "primary" array for this model, which
-        controls the size of other arrays that are implicitly created.
-        This is intended to be overridden in the subclasses if the
-        primary array's name is not "data".
-        """
+    def get_primary_array_name(self):  # noqa: D102
         return "fit_image"

--- a/src/stdatamodels/jwst/datamodels/amilgfitmodel.py
+++ b/src/stdatamodels/jwst/datamodels/amilgfitmodel.py
@@ -8,9 +8,8 @@ class AmiLgFitModel(JwstDataModel):
     """
     A data model for AMI LG analysis results.
 
-    Parameters
+    Attributes
     ----------
-
     centered_image : numpy float32 array
         Centered image
     norm_centered_image : numpy float32 array
@@ -29,11 +28,5 @@ class AmiLgFitModel(JwstDataModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/amilgfitmodel.schema"
 
-    def get_primary_array_name(self):
-        """
-        Returns the name "primary" array for this model, which
-        controls the size of other arrays that are implicitly created.
-        This is intended to be overridden in the subclasses if the
-        primary array's name is not "data".
-        """
+    def get_primary_array_name(self):  # noqa: D102
         return "fit_image"

--- a/src/stdatamodels/jwst/datamodels/amioi.py
+++ b/src/stdatamodels/jwst/datamodels/amioi.py
@@ -5,16 +5,16 @@ __all__ = ["AmiOIModel"]
 
 class AmiOIModel(JwstDataModel):
     """
-    TODO
+    TODO.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     TODO
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/amioi.schema"
 
-    def get_primary_array_name(self):
+    def get_primary_array_name(self):  # noqa: D102
         # for the example file OI_T3 is the largest array
         return "t3"
 
@@ -75,11 +75,11 @@ class AmiOIModel(JwstDataModel):
         if self.meta.oifits.derived.array.z is None:
             self.meta.oifits.derived.array.z = 0.0
 
-    def on_save(self, path=None):
+    def on_save(self, path=None):  # noqa: D102
         super().on_save(path)
         self._map_oifits_keywords()
 
-    def validate(self):
+    def validate(self):  # noqa: D102
         # map the JWST to OIFITS keywords prior to validate
         self._map_oifits_keywords()
         super().validate()

--- a/src/stdatamodels/jwst/datamodels/amioi.py
+++ b/src/stdatamodels/jwst/datamodels/amioi.py
@@ -4,13 +4,7 @@ __all__ = ["AmiOIModel"]
 
 
 class AmiOIModel(JwstDataModel):
-    """
-    TODO.
-
-    Attributes
-    ----------
-    TODO
-    """
+    """Class containing AMI interferometric observables."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/amioi.schema"
 

--- a/src/stdatamodels/jwst/datamodels/apcorr.py
+++ b/src/stdatamodels/jwst/datamodels/apcorr.py
@@ -19,8 +19,8 @@ class FgsImgApcorrModel(ReferenceFileModel):
     """
     A data model for FGS imaging apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -32,7 +32,6 @@ class FgsImgApcorrModel(ReferenceFileModel):
         - apcorr: float32
         - skyin: float32
         - skyout: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fgsimg_apcorr.schema"
@@ -42,8 +41,8 @@ class MirImgApcorrModel(ReferenceFileModel):
     """
     A data model for MIRI imaging apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -57,7 +56,6 @@ class MirImgApcorrModel(ReferenceFileModel):
         - apcorr: float32
         - skyin: float32
         - skyout: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_apcorr.schema"
@@ -67,8 +65,8 @@ class MirLrsApcorrModel(ReferenceFileModel):
     """
     A data model for MIRI LRS apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -82,7 +80,6 @@ class MirLrsApcorrModel(ReferenceFileModel):
         - nelem_size: int16
         - apcorr: float32 2D array
         - apcorr_err: float32 2D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_apcorr.schema"
@@ -92,8 +89,8 @@ class MirMrsApcorrModel(ReferenceFileModel):
     """
     A data model for MIRI MRS apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -104,7 +101,6 @@ class MirMrsApcorrModel(ReferenceFileModel):
         - radius: float32 2D array
         - apcorr: float32 2D array
         - apcorr_err: float32 2D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_apcorr.schema"
@@ -114,8 +110,8 @@ class NrcImgApcorrModel(ReferenceFileModel):
     """
     A data model for NIRCam imaging apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -129,7 +125,6 @@ class NrcImgApcorrModel(ReferenceFileModel):
         - apcorr: float32
         - skyin: float32
         - skyout: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_apcorr.schema"
@@ -139,8 +134,8 @@ class NrcWfssApcorrModel(ReferenceFileModel):
     """
     A data model for NIRCam WFSS apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -155,7 +150,6 @@ class NrcWfssApcorrModel(ReferenceFileModel):
         - nelem_size: int16
         - apcorr: float32 2D array
         - apcorr_err: float32 2D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_apcorr.schema"
@@ -165,8 +159,8 @@ class NisImgApcorrModel(ReferenceFileModel):
     """
     A data model for NIRISS imaging apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -180,7 +174,6 @@ class NisImgApcorrModel(ReferenceFileModel):
         - apcorr: float32
         - skyin: float32
         - skyout: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nisimg_apcorr.schema"
@@ -190,8 +183,8 @@ class NisWfssApcorrModel(ReferenceFileModel):
     """
     A data model for NIRISS WFSS apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -206,7 +199,6 @@ class NisWfssApcorrModel(ReferenceFileModel):
         - nelem_size: int16
         - apcorr: float32 2D array
         - apcorr_err: float32 2D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/niswfss_apcorr.schema"
@@ -216,8 +208,8 @@ class NrsMosApcorrModel(ReferenceFileModel):
     """
     A data model for NIRSpec MOS apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -233,7 +225,6 @@ class NrsMosApcorrModel(ReferenceFileModel):
         - pixphase: float32 1D array
         - apcorr: float32 3D array
         - apcorr_err: float32 3D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsmos_apcorr.schema"
@@ -243,8 +234,8 @@ class NrsIfuApcorrModel(ReferenceFileModel):
     """
     A data model for NIRSpec IFU apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -257,7 +248,6 @@ class NrsIfuApcorrModel(ReferenceFileModel):
         - radius: float32 3D array
         - apcorr: float32 3D array
         - apcorr_err: float32 3D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsifu_apcorr.schema"
@@ -267,8 +257,8 @@ class NrsFsApcorrModel(ReferenceFileModel):
     """
     A data model for NIRSpec Fixed-Slit apcorr reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apcorr_table : numpy table
         Aperture correction factors table
         A table-like object containing row selection criteria made up
@@ -285,7 +275,6 @@ class NrsFsApcorrModel(ReferenceFileModel):
         - pixphase: float32 1D array
         - apcorr: float32 3D array
         - apcorr_err: float32 3D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsfs_apcorr.schema"

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -7,9 +7,7 @@ __all__ = ["AsnModel"]
 
 
 class AsnModel(JwstDataModel):
-    """
-    A data model for association tables.
-    """
+    """A data model for association tables."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/asn.schema"
     supported_formats = ["yaml", "json", "fits"]
@@ -21,6 +19,7 @@ class AsnModel(JwstDataModel):
         self.parse_table()
 
     def parse_table(self):
+        """Parse the association table to identify the output product and inputs."""
         self.output = None
         self.output_rootname = None
         self.inputs = []

--- a/src/stdatamodels/jwst/datamodels/barshadow.py
+++ b/src/stdatamodels/jwst/datamodels/barshadow.py
@@ -7,17 +7,14 @@ class BarshadowModel(ReferenceFileModel):
     """
     A data model for Bar Shadow correction information.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data1x1 : numpy float32 array
          Bar Shadow 1x1 data array
-
     var1x1 : numpy float32 array
          Bar Shadow 1x1 correction variance
-
     data1x3 : numpy float32 array
          Bar Shadow 1x3 data array
-
     var1x3 : numpy float32 array
          Bar Shadow 1x3 correction variance
     """

--- a/src/stdatamodels/jwst/datamodels/combinedspec.py
+++ b/src/stdatamodels/jwst/datamodels/combinedspec.py
@@ -8,8 +8,8 @@ class CombinedSpecModel(JwstDataModel):
     """
     A data model for combined 1D spectra.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     spec_table : numpy table
          Combined, extracted spectral data table
     """

--- a/src/stdatamodels/jwst/datamodels/conftest.py
+++ b/src/stdatamodels/jwst/datamodels/conftest.py
@@ -4,7 +4,7 @@ import os
 
 @pytest.fixture
 def jail_environ():
-    """Lock changes to the environment"""
+    """Lock changes to the environment."""
     original = os.environ.copy()
     try:
         yield

--- a/src/stdatamodels/jwst/datamodels/contrast.py
+++ b/src/stdatamodels/jwst/datamodels/contrast.py
@@ -8,8 +8,8 @@ class ContrastModel(JwstDataModel):
     """
     A data model for coronagraphic contrast curve files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     contrast_table : numpy table
          Contrast curve table
     """

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -8,32 +8,24 @@ class CubeModel(JwstDataModel):
     """
     A data model for 3D image cubes.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     zeroframe : numpy float32 array
          Zero frame array
-
     area : numpy float32 array
          Pixel area map array
-
     int_times : numpy table
          table of times for each integration
-
     wavelength : numpy float32 array
          Wavelength array
-
     var_poisson : numpy float32 array
          Integration-specific variances of slope due to Poisson noise
-
     var_rnoise : numpy float32 array
          Integration-specific variances of slope due to read noise
     """

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -10,17 +10,14 @@ class DarkModel(ReferenceFileModel):
     """
     A data model for dark reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Dark current array
-
     dq : numpy uint32 array
          2-D data quality array for all planes
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/darkMIRI.py
+++ b/src/stdatamodels/jwst/datamodels/darkMIRI.py
@@ -10,17 +10,14 @@ class DarkMIRIModel(ReferenceFileModel):
     """
     A data model for dark MIRI reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Dark current array
-
     dq : numpy uint32 array
          2-D data quality array for all planes
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -1,4 +1,5 @@
-"""JWST Data Quality Flags
+"""
+JWST Data Quality Flags.
 
 The definitions are documented in the JWST RTD:
 

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -5,10 +5,6 @@ The definitions are documented in the JWST RTD:
 
 https://jwst-pipeline.readthedocs.io/en/latest/jwst/references_general/references_general.html#data-quality-flags
 
-
-Implementation
--------------
-
 The flags are implemented as "bit flags": Each flag is assigned a bit position
 in a byte, or multi-byte word, of memory. If that bit is set, the flag assigned
 to that bit is interpreted as being set or active.

--- a/src/stdatamodels/jwst/datamodels/emi.py
+++ b/src/stdatamodels/jwst/datamodels/emi.py
@@ -8,8 +8,8 @@ class EmiModel(ReferenceFileModel):
     """
     A data model to correct MIRI images for EMI contamination.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy table
         The reference waves to correct for MIRI EMI.
         A table-like object containing phase amplitude values
@@ -28,9 +28,9 @@ class EmiModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(EmiModel, self).__init__(init=init, **kwargs)
 
-    def on_save(self, path=None):
+    def on_save(self, path=None):  # noqa: D102
         self.meta.reftype = self.reftype
         self.meta.instrument.name = "MIRI"
 
-    def validate(self):
+    def validate(self):  # noqa: D102
         super(EmiModel, self).validate()

--- a/src/stdatamodels/jwst/datamodels/extract1d_spec.py
+++ b/src/stdatamodels/jwst/datamodels/extract1d_spec.py
@@ -7,8 +7,8 @@ class Extract1dIFUModel(ReferenceFileModel):
     """
     A data model for IFU MIRI and NIRSpec extract 1d reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     extract1d_params : numpy table
         Basic extract 1D parameters
         - region_type: ascii
@@ -25,7 +25,6 @@ class Extract1dIFUModel(ReferenceFileModel):
         - outer_bkg: float32 1D array
         - axis_ratio: float32 1D array
         - axis_pa: float32 1D array
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/extract1difu.schema"

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -10,17 +10,14 @@ class FlatModel(ReferenceFileModel):
     """
     A data model for 2D flat-field images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -10,17 +10,14 @@ class FringeModel(ReferenceFileModel):
     """
     A data model for 2D fringe correction images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/fringefreq.py
+++ b/src/stdatamodels/jwst/datamodels/fringefreq.py
@@ -7,8 +7,8 @@ class FringeFreqModel(ReferenceFileModel):
     """
     A data model for 2D fringe correction images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     rfc_freq_short : numpy table
     rfc_freq_medium : numpy table
     rfc_freq_long : numpy table

--- a/src/stdatamodels/jwst/datamodels/gain.py
+++ b/src/stdatamodels/jwst/datamodels/gain.py
@@ -8,8 +8,8 @@ class GainModel(ReferenceFileModel):
     """
     A data model for 2D gain.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The gain
     """

--- a/src/stdatamodels/jwst/datamodels/gls_rampfit.py
+++ b/src/stdatamodels/jwst/datamodels/gls_rampfit.py
@@ -6,23 +6,18 @@ __all__ = ["GLS_RampFitModel"]
 
 class GLS_RampFitModel(JwstDataModel):  # noqa: N801
     """
-    A data model for the optional output of the ramp fitting step
-    for the GLS algorithm.
+    Data model for the optional output of the ramp fitting step for the GLS algorithm.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     yint : numpy float32 array
          Y-intercept
-
     sigyint : numpy float32 array
          Sigma for Y-intercept
-
     pedestal : numpy float32 array
          Pedestal
-
     crmag : numpy float32 array
          CR magnitudes
-
     sigcrmag : numpy float32 array
          Sigma for CR magnitudes
     """

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -6,31 +6,24 @@ __all__ = ["GuiderRawModel", "GuiderCalModel"]
 
 class GuiderRawModel(JwstDataModel):
     """
-    A data model for Guide Star pipeline raw data files
+    A data model for Guide Star pipeline raw data files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     err : numpy float32 array
          Error array
-
     dq : numpy uint32 array
          Data quality array
-
     planned_star_table : numpy table
          Planned reference star table
-
     flight_star_table : numpy table
          Flight reference star table
-
     pointing_table : numpy table
          Pointing table
-
     centroid_table : numpy table
          Centroid packet table
-
     track_sub_table : numpy table
          Track subarray data table
     """
@@ -47,31 +40,24 @@ class GuiderRawModel(JwstDataModel):
 
 class GuiderCalModel(JwstDataModel):
     """
-    A data model for Guide Star pipeline calibrated files
+    A data model for Guide Star pipeline calibrated files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     err : numpy float32 array
          Error array
-
     dq : numpy uint32 array
          Data quality array
-
     planned_star_table : numpy table
          Planned reference star table
-
     flight_star_table : numpy table
          Flight reference star table
-
     pointing_table : numpy table
          Pointing table
-
     centroid_table : numpy table
          Centroid packet table
-
     track_sub_table : numpy table
          Track subarray data table
     """

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -8,20 +8,16 @@ class IFUCubeModel(JwstDataModel):
     """
     A data model for 3D IFU  cubes.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     weightmap : numpy float32 array
          Weight map of coverage
-
     wavetable : numpy table
          Wavelength value for slices
     """

--- a/src/stdatamodels/jwst/datamodels/ifucubepars.py
+++ b/src/stdatamodels/jwst/datamodels/ifucubepars.py
@@ -7,41 +7,30 @@ class NirspecIFUCubeParsModel(ReferenceFileModel):
     """
     A data model for Nirspec ifucubepars reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     ifucubepars_table : numpy table
          default IFU cube  parameters table
-
     ifucubepars_msm_table : numpy table
          default IFU cube msm parameters table
-
     ifucubepars_prism_msm_wavetable : numpy table
          default IFU cube prism msm wavetable
-
     ifucubepars_med_msm_wavetable : numpy table
          default IFU cube med resolution msm  wavetable
-
     ifucubepars_high_msm_wavetable : numpy table
          default IFU cube high resolution msm wavetable
-
     ifucubepars_emsm_table : numpy table
          default IFU cube emsm parameters table
-
     ifucubepars_prism_emsm_wavetable : numpy table
          default IFU cube prism emsm wavetable
-
     ifucubepars_med_emsm_wavetable : numpy table
          default IFU cube med resolution emsm wavetable
-
     ifucubepars_high_emsm_wavetable : numpy table
          default IFU cube high resolution emsm  wavetable
-
     ifucubepars_prism_driz_wavetable : numpy float32 array
          default IFU cube prism drizzle wavetable
-
     ifucubepars_med_driz_wavetable : numpy float32 array
          default IFU cube med resolution drizzle wavetable
-
     ifucubepars_high_driz_wavetable : numpy float32 array
          default IFU cube high resolution drizzle wavetable
     """
@@ -53,26 +42,20 @@ class MiriIFUCubeParsModel(ReferenceFileModel):
     """
     A data model for MIRI mrs ifucubepars reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     ifucubepars_table : numpy table
          default IFU cube  parameters table
-
     ifucubepars_msm_table : numpy table
          default IFU cube msm parameters table
-
     ifucubepars_multichannel_msm_wavetable : numpy table
          default IFU cube msm wavetable
-
     ifucubepars_emsm_table : numpy table
          default IFU cube emsm parameters table
-
     ifucubepars_multichannel_emsm_wavetable : numpy table
          default IFU cube emsm wavetable
-
     ifucubepars_multichannel_driz_wavetable : numpy float32 array
          default IFU cube driz wavetable
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/miri_ifucubepars.schema"

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -9,35 +9,26 @@ class IFUImageModel(JwstDataModel):
     """
     A data model for 2D IFU images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     zeroframe : numpy float32 array
          Zeroframe array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
-
     var_rnoise : numpy float32 array
          variance due to read noise
-
     wavelength : numpy float32 array
          wavelength
-
     pathloss_point : numpy float32 array
          pathloss correction for point source
-
     pathloss_uniform : numpy float32 array
          pathloss correction for uniform source
-
     area : numpy float32 array
          Pixel area map array
     """

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -8,32 +8,24 @@ class ImageModel(JwstDataModel):
     """
     A data model for 2D images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     zeroframe : numpy float32 array
          Zeroframe array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
-
     var_rnoise : numpy float32 array
          variance due to read noise
-
     area : numpy float32 array
          Pixel area map array
-
     pathloss_point : numpy float32 array
          Pathloss correction for point source
-
     pathloss_uniform : numpy float32 array
          Pathloss correction for uniform source
     """

--- a/src/stdatamodels/jwst/datamodels/integration.py
+++ b/src/stdatamodels/jwst/datamodels/integration.py
@@ -1,6 +1,4 @@
-"""
-This module supports the entry points for ASDF support for the `jwst.datamodels`.
-"""
+"""Create the entry points for ASDF support for the `jwst.datamodels`."""
 
 import importlib.resources
 
@@ -18,8 +16,8 @@ def get_resource_mappings():
 
     Returns
     -------
-    list of the `asdf.resource.ResourceMapping` instances containing the `jwst.datamodels`
-    schemas.
+    list of `asdf.resource.ResourceMapping` instances
+        List containing the `jwst.datamodels` schemas.
     """
     resources_root = importlib.resources.files(datamodels)
     if not resources_root.is_dir():

--- a/src/stdatamodels/jwst/datamodels/ipc.py
+++ b/src/stdatamodels/jwst/datamodels/ipc.py
@@ -7,8 +7,8 @@ class IPCModel(ReferenceFileModel):
     """
     A data model for IPC kernel checking information.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          IPC deconvolution kernel
     """

--- a/src/stdatamodels/jwst/datamodels/irs2.py
+++ b/src/stdatamodels/jwst/datamodels/irs2.py
@@ -8,15 +8,14 @@ class IRS2Model(ReferenceFileModel):
     """
     A data model for the IRS2 refpix reference file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     irs2_table : numpy table
         Table for IRS2 refpix correction.
         A table with 8 columns and 2916352 (2048 * 712 * 2) rows.  All
         values are float, but these are interpreted as alternating real
         and imaginary parts (real, imag, real, imag, ...) of complex
         values.  There are four columns for ALPHA and four for BETA.
-
     dq_table : data quality info table
         Table for identifying bad reference pixels.
         A table with three columns (OUTPUT, ODD_EVEN, and MASK) and

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -10,17 +10,14 @@ class LastFrameModel(ReferenceFileModel):
     """
     A data model for Last frame correction reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Last Frame Correction array
-
     dq : numpy uint32 array
          2-D data quality array
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -14,6 +14,16 @@ def _migrate_moving_target_table(hdulist):
     stdatamodels>=2.1.0 will encounter validation errors due to the
     missing columns. This function adds NaN-filled columns where needed
     to pass validation.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        The input HDUList
+
+    Returns
+    -------
+    hdulist : HDUList
+        The modified HDUList
     """
     for ext in hdulist:
         if ext.name != "MOVING_TARGET_POSITION":

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -6,7 +6,8 @@ __all__ = ["Level1bModel"]
 
 
 def _migrate_moving_target_table(hdulist):
-    """Add missing columns to prevent validation issues for `jwst` 1.16.0
+    """
+    Add missing columns to prevent validation issues for `jwst` 1.16.0.
 
     Files produced prior to Build 11.1 will not have columns `mt_v2` or
     `mt_v3` in the moving_target_table; loading these old files with
@@ -32,23 +33,18 @@ class Level1bModel(JwstDataModel):
     """
     A data model for raw 4D ramps level-1b products.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy uint16 array
          The science data
-
     zeroframe : numpy uint16 array
          Zeroframe array
-
     refout : numpy uint16 array
          Reference Output
-
     group : numpy table
          group parameters table
-
     int_times : numpy table
          table of times for each integration
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/level1b.schema"

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -30,13 +30,5 @@ class LinearityModel(ReferenceFileModel):
         # Implicitly create arrays
         self.dq = self.dq
 
-    def get_primary_array_name(self):
-        """
-        Return the name "primary" array for this model.
-
-        Returns
-        -------
-        str
-            The name of the primary array.
-        """
+    def get_primary_array_name(self):  # noqa: D102
         return "coeffs"

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -10,14 +10,12 @@ class LinearityModel(ReferenceFileModel):
     """
     A data model for linearity correction information.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     coeffs : numpy float32 array
          Linearity coefficients
-
     dq : numpy uint32 array
          Data quality flags
-
     dq_def : numpy table
          DQ flag definitions
     """
@@ -34,9 +32,11 @@ class LinearityModel(ReferenceFileModel):
 
     def get_primary_array_name(self):
         """
-        Returns the name "primary" array for this model, which
-        controls the size of other arrays that are implicitly created.
-        This is intended to be overridden in the subclasses if the
-        primary array's name is not "data".
+        Return the name "primary" array for this model.
+
+        Returns
+        -------
+        str
+            The name of the primary array.
         """
         return "coeffs"

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -9,11 +9,10 @@ class MaskModel(ReferenceFileModel):
     """
     A data model for 2D masks.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     dq : numpy uint32 array
          The mask
-
     dq_def : numpy table
          DQ flag definitions
     """
@@ -29,11 +28,5 @@ class MaskModel(ReferenceFileModel):
         # Implicitly create arrays
         self.dq = self.dq
 
-    def get_primary_array_name(self):
-        """
-        Returns the name "primary" array for this model, which
-        controls the size of other arrays that are implicitly created.
-        This is intended to be overridden in the subclasses if the
-        primary array's name is not "data".
-        """
+    def get_primary_array_name(self):  # noqa: D102
         return "dq"

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -19,6 +19,7 @@ class JwstDataModel(_DataModel):
         Returns
         -------
         str
+            The observatory code.
         """
         return "jwst"
 
@@ -29,6 +30,7 @@ class JwstDataModel(_DataModel):
         Returns
         -------
         dict
+            Dictionary of CRDS parameters
         """
         return {
             key: val

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -40,7 +40,7 @@ class JwstDataModel(_DataModel):
 
     def on_init(self, init):
         """
-        Run before returning a newly created model instance.
+        Run a hook before returning a newly created model instance.
 
         Parameters
         ----------
@@ -54,7 +54,7 @@ class JwstDataModel(_DataModel):
 
     def on_save(self, init):
         """
-        Run before writing a model to a file (FITS or ASDF).
+        Run a hook before writing a model to a file (FITS or ASDF).
 
         Parameters
         ----------

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -7,6 +7,8 @@ __all__ = ["JwstDataModel"]
 
 
 class JwstDataModel(_DataModel):
+    """Base class for JWST data models."""
+
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/core.schema"
 
     @property
@@ -36,8 +38,12 @@ class JwstDataModel(_DataModel):
 
     def on_init(self, init):
         """
-        Hook invoked by the base class before returning a newly
-        created model instance.
+        Run before returning a newly created model instance.
+
+        Parameters
+        ----------
+        init : object
+            First argument to __init__.
         """
         super().on_init(init)
 
@@ -46,8 +52,12 @@ class JwstDataModel(_DataModel):
 
     def on_save(self, init):
         """
-        Hook invoked by the base class before writing a model
-        to a file (FITS or ASDF).
+        Run before writing a model to a file (FITS or ASDF).
+
+        Parameters
+        ----------
+        init : str
+            The path to the file that we're about to save to.
         """
         super().on_save(init)
 

--- a/src/stdatamodels/jwst/datamodels/mrsptcorr.py
+++ b/src/stdatamodels/jwst/datamodels/mrsptcorr.py
@@ -7,26 +7,20 @@ class MirMrsPtCorrModel(ReferenceFileModel):
     """
     A data model for MIRI mrs IFU across-slice corrections file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     init : any
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
-
     leakcor_table : numpy table
          IFU spectral leak correction (fractional, Jy to Jy)
-
     tracor_table : numpy table
          IFU across slice transmission correction
-
     wavcorr_optical_table : numpy table
          IFU across slice wavelength offset table 1
-
     wavcorr_xslice_table : numpy table
          IFU across slice wavelength offset table 2
-
     wavcorr_shift_table : numpy table
          IFU across slice wavelength offset table 3
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/miri_mrsptcorr.schema"

--- a/src/stdatamodels/jwst/datamodels/mrsxartcorr.py
+++ b/src/stdatamodels/jwst/datamodels/mrsxartcorr.py
@@ -7,47 +7,34 @@ class MirMrsXArtCorrModel(ReferenceFileModel):
     """
     A data model for MIRI MRS cross-artifact corrections file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     init : any
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
-
     ch1a_table : numpy table
          Cross artifact correction parameters for Channel 1A
-
     ch1b_table : numpy table
          Cross artifact correction parameters for Channel 1B
-
     ch1c_table : numpy table
          Cross artifact correction parameters for Channel 1C
-
     ch2a_table : numpy table
          Cross artifact correction parameters for Channel 2A
-
     ch2b_table : numpy table
          Cross artifact correction parameters for Channel 2B
-
     ch2c_table : numpy table
          Cross artifact correction parameters for Channel 2C
-
     ch3a_table : numpy table
          Cross artifact correction parameters for Channel 3A
-
     ch3b_table : numpy table
          Cross artifact correction parameters for Channel 3B
-
     ch3c_table : numpy table
          Cross artifact correction parameters for Channel 3C
-
     ch4a_table : numpy table
          Cross artifact correction parameters for Channel 4A
-
     ch4b_table : numpy table
          Cross artifact correction parameters for Channel 4B
-
     ch4c_table : numpy table
          Cross artifact correction parameters for Channel 4C
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/miri_mrsxartcorr.schema"

--- a/src/stdatamodels/jwst/datamodels/multicombinedspec.py
+++ b/src/stdatamodels/jwst/datamodels/multicombinedspec.py
@@ -24,14 +24,12 @@ class MultiCombinedSpecModel(JwstDataModel):
     the first element of `spec`.  `CombinedSpecModel` objects can be appended
     to the `spec` attribute by using its `append` method.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     int_times : numpy table
          table of times for each integration
-
     spec.items.spec_table : numpy table
          Extracted spectral data table
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/multicombinedspec.schema"

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -105,7 +105,7 @@ class MultiExposureModel(JwstDataModel):
 
 # Utilities
 def set_hdu(obj, hdu_id="EXP"):
-    """Add fits_hdu specification to fits-connected properties."""
+    """Add fits_hdu specification to FITS-connected properties."""
     try:
         if "fits_keyword" in obj.keys():
             obj["fits_hdu"] = hdu_id

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -13,8 +13,9 @@ __all__ = ["MultiExposureModel", "set_hdu", "remove_fits"]
 
 class MultiExposureModel(JwstDataModel):
     """
-    A data model for multi-slit images derived from
-    numerous exposures. The intent is that all slits
+    A data model for multi-slit images derived from numerous exposures.
+
+    The intent is that all slits
     in this model are of the same source, with each slit
     representing a separate exposure of that source.
 
@@ -34,8 +35,8 @@ class MultiExposureModel(JwstDataModel):
     models. This is part of the Level 3 processing of multi-objection
     observations.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     exposures.items.data : numpy float32 array
 
     exposures.items.dq : numpy uint32 array
@@ -97,7 +98,7 @@ class MultiExposureModel(JwstDataModel):
 
 # Utilities
 def set_hdu(obj, hdu_id="EXP"):
-    """Add fits_hdu specification to fits-connected properties"""
+    """Add fits_hdu specification to fits-connected properties."""
     try:
         if "fits_keyword" in obj.keys():
             obj["fits_hdu"] = hdu_id
@@ -106,6 +107,7 @@ def set_hdu(obj, hdu_id="EXP"):
 
 
 def remove_fits(obj):
+    """Remove fits_keyword and fits_hdu from schema."""
     try:
         obj.pop("fits_keyword", None)
     except (AttributeError, KeyError, TypeError):

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -77,7 +77,14 @@ class MultiExposureModel(JwstDataModel):
         super(MultiExposureModel, self).__init__(init=init, schema=schema, **kwargs)
 
     def _build_schema(self):
-        """Build the schema, incorporating the core."""
+        """
+        Build the schema, incorporating the core.
+
+        Returns
+        -------
+        schema : dict
+            The schema for the model.
+        """
         # Get the schemas
         schema = asdf_schema.load_schema(self.schema_url, resolve_references=True)
         core_schema = asdf_schema.load_schema(self.core_schema_url, resolve_references=True)

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -27,7 +27,7 @@ class MultiSlitModel(JwstDataModel):
 
     Attributes
     ----------
-    slits : SlitModel
+    slits : list of SlitModel
         The slits in the model; see SlitModel for details.
     """
 

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -27,34 +27,8 @@ class MultiSlitModel(JwstDataModel):
 
     Attributes
     ----------
-    slits.items.data : numpy float32 array
-        The science data
-    slits.items.dq : numpy uint32 array
-        Data quality array
-    slits.items.err : numpy float32 array
-        Error array
-    slits.items.var_poisson : numpy float32 array
-        variance due to poisson noise
-    slits.items.var_rnoise : numpy float32 array
-        variance due to read noise
-    slits.items.wavelength : numpy float32 array
-        Wavelength array, corrected for zero-point
-    slits.items.barshadow : numpy float32 array
-        Bar shadow correction
-    slits.items.flatfield_point : numpy float32 array
-        flatfield array for point source
-    slits.items.flatfield_uniform : numpy float32 array
-        flatfield array for uniform source
-    slits.items.pathloss_point : numpy float32 array
-        pathloss array for point source
-    slits.items.pathloss_uniform : numpy float32 array
-        pathloss array for uniform source
-    slits.items.photom_point : numpy float32 array
-        photom array for point source
-    slits.items.photom_uniform : numpy float32 array
-        photom array for uniform source
-    slits.items.area : numpy float32 array
-        Pixel area map array
+    slits : SlitModel
+        The slits in the model; see SlitModel for details.
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/multislit.schema"

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -13,11 +13,11 @@ class MultiSlitModel(JwstDataModel):
     This model has a special member `slits` that can be used to
     deal with an entire slit at a time.  It behaves like a list::
 
-       >>> from stdatamodels.jwst.datamodels import SlitModel
-       >>> multislit_model = MultiSlitModel()
-       >>> multislit_model.slits.append(SlitModel())
-       >>> multislit_model[0]
-       <SlitModel>
+        >>> from stdatamodels.jwst.datamodels import SlitModel
+        >>> multislit_model = MultiSlitModel()
+        >>> multislit_model.slits.append(SlitModel())
+        >>> multislit_model[0]
+        <SlitModel>
 
     If ``init`` is a file name or an ``ImageModel`` or a ``SlitModel``instance,
     an empty ``SlitModel`` will be created and assigned to attribute ``slits[0]``,
@@ -25,49 +25,36 @@ class MultiSlitModel(JwstDataModel):
     attributes from the input file or model will be copied to the
     first element of ``slits``.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     slits.items.data : numpy float32 array
-         The science data
-
+        The science data
     slits.items.dq : numpy uint32 array
-         Data quality array
-
+        Data quality array
     slits.items.err : numpy float32 array
-         Error array
-
+        Error array
     slits.items.var_poisson : numpy float32 array
-         variance due to poisson noise
-
+        variance due to poisson noise
     slits.items.var_rnoise : numpy float32 array
-         variance due to read noise
-
+        variance due to read noise
     slits.items.wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
-
+        Wavelength array, corrected for zero-point
     slits.items.barshadow : numpy float32 array
-         Bar shadow correction
-
+        Bar shadow correction
     slits.items.flatfield_point : numpy float32 array
-         flatfield array for point source
-
+        flatfield array for point source
     slits.items.flatfield_uniform : numpy float32 array
-         flatfield array for uniform source
-
+        flatfield array for uniform source
     slits.items.pathloss_point : numpy float32 array
-         pathloss array for point source
-
+        pathloss array for point source
     slits.items.pathloss_uniform : numpy float32 array
-         pathloss array for uniform source
-
+        pathloss array for uniform source
     slits.items.photom_point : numpy float32 array
-         photom array for point source
-
+        photom array for point source
     slits.items.photom_uniform : numpy float32 array
-         photom array for uniform source
-
+        photom array for uniform source
     slits.items.area : numpy float32 array
-         Pixel area map array
+        Pixel area map array
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/multislit.schema"
@@ -84,8 +71,17 @@ class MultiSlitModel(JwstDataModel):
 
     def __getitem__(self, key):
         """
-        Returns a metadata value using a dotted name or
-        a ``SlitModel``.
+        Return a metadata value using a dotted name or a ``SlitModel``.
+
+        Parameters
+        ----------
+        key : str or int
+        A dotted name identifying a metadata field or a slit number.
+
+        Returns
+        -------
+        value : any
+        The value of the metadata field or the ``SlitModel`` instance.
         """
         if isinstance(key, str) and key.split(".")[0] == "meta":
             res = super(MultiSlitModel, self).__getitem__(key)

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -76,12 +76,12 @@ class MultiSlitModel(JwstDataModel):
         Parameters
         ----------
         key : str or int
-        A dotted name identifying a metadata field or a slit number.
+            A dotted name identifying a metadata field or a slit number.
 
         Returns
         -------
         value : any
-        The value of the metadata field or the ``SlitModel`` instance.
+            The value of the metadata field or the ``SlitModel`` instance.
         """
         if isinstance(key, str) and key.split(".")[0] == "meta":
             res = super(MultiSlitModel, self).__getitem__(key)

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -24,11 +24,10 @@ class MultiSpecModel(JwstDataModel):
     the first element of `spec`.  `SpecModel` objects can be appended
     to the `spec` attribute by using its `append` method.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     int_times : numpy table
          table of times for each integration
-
     spec.items.spec_table : numpy table
          Extracted spectral data table
 

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -36,25 +36,21 @@ def _migrate_fast_variation_table(hdulist):
 
 
 class NirspecFlatModel(ReferenceFileModel):
-    """A data model for NIRSpec flat-field reference files.
+    """
+    A data model for NIRSpec flat-field reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          NIRSpec flat-field reference data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error estimate
-
     wavelength : numpy table
          Table of wavelengths for image planes
-
     flat_table : numpy table
          Table for quickly varying component of flat field
-
     dq_def : numpy table
          DQ flag definitions
     """
@@ -79,18 +75,16 @@ class NirspecFlatModel(ReferenceFileModel):
 
 
 class NirspecQuadFlatModel(ReferenceFileModel):
-    """A data model for NIRSpec flat-field files that differ by quadrant.
+    """
+    A data model for NIRSpec flat-field files that differ by quadrant.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     quadrants.items.data : numpy float32 array
-
 
     quadrants.items.dq : numpy uint32 array
 
-
     quadrants.items.err : numpy float32 array
-
 
     quadrants.items.wavelength : numpy table
          Table of wavelengths for image planes

--- a/src/stdatamodels/jwst/datamodels/nrm.py
+++ b/src/stdatamodels/jwst/datamodels/nrm.py
@@ -8,8 +8,8 @@ class NRMModel(ReferenceFileModel):
     """
     A data model for Non-Redundant Mask.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     nrm : numpy float32 array
          Non-Redundant Mask
     """

--- a/src/stdatamodels/jwst/datamodels/outlierifuoutput.py
+++ b/src/stdatamodels/jwst/datamodels/outlierifuoutput.py
@@ -11,21 +11,16 @@ class OutlierIFUOutputModel(JwstDataModel):
     In the parameter definitions below, `n` is the number of
     exposures,  `ny` and `nx` are the height and width of the image.
 
-    Parameters
-    __________
-
+    Attributes
+    ----------
     diffarr : numpy float32 array (n, ny, nx)
         Minimum difference array for all the data
-
     minarr : numpy float32 array (ny, nx)
         Final combined minimum difference array
-
     normarr : numpy float32 array (ny, nx)
         Normalized minarr
-
     minnorm : numpy float32 array (ny, nx)
         minarr/normarr
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/outlierifuoutput.schema"

--- a/src/stdatamodels/jwst/datamodels/pastasossmodel.py
+++ b/src/stdatamodels/jwst/datamodels/pastasossmodel.py
@@ -7,11 +7,12 @@ __all__ = ["PastasossModel"]
 class PastasossModel(ReferenceFileModel):
     """
     A data model to hold NIRISS SOSS wavelength grids.
+
     This 1-D array of wavelengths can be saved from a processing run
     and applied to future input products.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     wavegrid : numpy float32 array
         1-D array of the wavelengths corresponding to the ATOCA fit.
     """

--- a/src/stdatamodels/jwst/datamodels/pathloss.py
+++ b/src/stdatamodels/jwst/datamodels/pathloss.py
@@ -8,17 +8,14 @@ class PathlossModel(ReferenceFileModel):
     """
     A data model for pathloss correction information.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     apertures.items.pointsource_data : numpy float32 array
          Point source pathloss
-
     apertures.items.pointsource_err : numpy float32 array
          Point source pathloss variance
-
     apertures.items.uniform_data : numpy float32 array
          Uniform source pathloss
-
     apertures.items.uniform_err : numpy float32 array
          Uniform source pathloss variance
     """
@@ -27,11 +24,6 @@ class PathlossModel(ReferenceFileModel):
 
 
 class MirLrsPathlossModel(ReferenceFileModel):
-    """
-    A data model for MIRI LRS pathloss correction information.
-
-    Parameters
-    __________
-    """
+    """A data model for MIRI LRS pathloss correction information."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_pathloss.schema"

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -10,14 +10,12 @@ class PersistenceSatModel(ReferenceFileModel):
     """
     A data model for the persistence saturation value (full well).
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Persistence saturation threshold
-
     dq : numpy uint32 array
          data quality array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -22,8 +22,8 @@ class FgsImgPhotomModel(ReferenceFileModel):
     """
     A data model for FGS photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -32,7 +32,6 @@ class FgsImgPhotomModel(ReferenceFileModel):
 
         - photmjsr: float32
         - uncertainty: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fgsimg_photom.schema"
@@ -42,8 +41,8 @@ class MirImgPhotomModel(ReferenceFileModel):
     """
     A data model for MIRI imaging photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -61,7 +60,6 @@ class MirImgPhotomModel(ReferenceFileModel):
        - amplitude: float32
        - tau: float32
        - t0: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirimg_photom.schema"
@@ -74,8 +72,8 @@ class MirLrsPhotomModel(ReferenceFileModel):
     """
     A data model for MIRI LRS photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -100,46 +98,36 @@ class MirMrsPhotomModel(ReferenceFileModel):
     """
     A data model for MIRI MRS photom reference files.
 
-    Parameters
+    Attributes
     ----------
     init : any
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
-
     data : numpy array
         An array-like object containing the pixel-by-pixel conversion values
         in units of (MJy / pixel) / (DN / sec).
-
     err : numpy array
         An array-like object containing the uncertainties in the conversion
         values, in the same units as the data array.
-
     dq : numpy array
         An array-like object containing bit-encoded data quality flags,
         indicating problem conditions for values in the data array.
-
     dq_def : numpy array
         A table-like object containing the data quality definitions table.
-
     pixsiz : numpy array
         An array-like object containing pixel-by-pixel size values, in units of
         square arcseconds (arcsec^2).
-
     timecoeff_ch1 : numpy table
         A table of time and wavelength dependent throughput corrections
         for channel 1
-
     timecoeff_ch2 : numpy table
         A table of time and wavelength dependent throughput corrections
         for channel 2
-
     timecoeff_ch3 : numpy table
         A table of time and wavelength dependent throughput corrections
         for channel 3
-
     timecoeff_ch4 : numpy table
         A table of time and wavelength dependent throughput corrections
         for channel 4
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_photom.schema"
@@ -154,8 +142,8 @@ class NrcImgPhotomModel(ReferenceFileModel):
     """
     A data model for NIRCam imaging photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -166,7 +154,6 @@ class NrcImgPhotomModel(ReferenceFileModel):
         - pupil: str[12]
         - photmjsr: float32
         - uncertainty: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_photom.schema"
@@ -176,8 +163,8 @@ class NrcWfssPhotomModel(ReferenceFileModel):
     """
     A data model for NIRCam WFSS photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -193,7 +180,6 @@ class NrcWfssPhotomModel(ReferenceFileModel):
         - wavelength: float32[*]
         - relresponse: float32[*]
         - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcwfss_photom.schema"
@@ -203,8 +189,8 @@ class NisImgPhotomModel(ReferenceFileModel):
     """
     A data model for NIRISS imaging photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -215,7 +201,6 @@ class NisImgPhotomModel(ReferenceFileModel):
         - pupil: str[12]
         - photmjsr: float32
         - uncertainty: float32
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nisimg_photom.schema"
@@ -225,8 +210,8 @@ class NisWfssPhotomModel(ReferenceFileModel):
     """
     A data model for NIRISS WFSS photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -242,7 +227,6 @@ class NisWfssPhotomModel(ReferenceFileModel):
         - wavelength: float32[*]
         - relresponse: float32[*]
         - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/niswfss_photom.schema"
@@ -252,8 +236,8 @@ class NisSossPhotomModel(ReferenceFileModel):
     """
     A data model for NIRISS SOSS photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -269,7 +253,6 @@ class NisSossPhotomModel(ReferenceFileModel):
         - wavelength: float32[*]
         - relresponse: float32[*]
         - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nissoss_photom.schema"
@@ -279,8 +262,8 @@ class NrsFsPhotomModel(ReferenceFileModel):
     """
     A data model for NIRSpec Fixed-Slit photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -296,7 +279,6 @@ class NrsFsPhotomModel(ReferenceFileModel):
         - wavelength: float32[*]
         - relresponse: float32[*]
         - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsfs_photom.schema"
@@ -306,8 +288,8 @@ class NrsMosPhotomModel(ReferenceFileModel):
     """
     A data model for NIRSpec MOS and IFU photom reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     phot_table : numpy table
         Photometric flux conversion factors table
         A table-like object containing row selection criteria made up
@@ -322,7 +304,6 @@ class NrsMosPhotomModel(ReferenceFileModel):
         - wavelength: float32[*]
         - relresponse: float32[*]
         - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrsmos_photom.schema"

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -88,7 +88,6 @@ class MirLrsPhotomModel(ReferenceFileModel):
        - wavelength: float32[*]
        - relresponse: float32[*]
        - reluncertainty: float32[*]
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"

--- a/src/stdatamodels/jwst/datamodels/pixelarea.py
+++ b/src/stdatamodels/jwst/datamodels/pixelarea.py
@@ -6,10 +6,10 @@ __all__ = ["PixelAreaModel", "NirspecSlitAreaModel", "NirspecMosAreaModel", "Nir
 
 class PixelAreaModel(ReferenceFileModel):
     """
-    A data model for the pixel area map
+    A data model for the pixel area map.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The pixel area array
     """
@@ -19,10 +19,10 @@ class PixelAreaModel(ReferenceFileModel):
 
 class NirspecSlitAreaModel(ReferenceFileModel):
     """
-    A data model for the NIRSpec fixed-slit pixel area reference file
+    A data model for the NIRSpec fixed-slit pixel area reference file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     area_table : numpy table
          NIRSpec fixed-slit pixel area table
          A table-like object containing row selection criteria made up
@@ -38,10 +38,10 @@ class NirspecSlitAreaModel(ReferenceFileModel):
 
 class NirspecMosAreaModel(ReferenceFileModel):
     """
-    A data model for the NIRSpec MOS pixel area reference file
+    A data model for the NIRSpec MOS pixel area reference file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     area_table : numpy table
          NIRSpec MOS pixel area table
          A table-like object containing row selection criteria made up
@@ -59,10 +59,10 @@ class NirspecMosAreaModel(ReferenceFileModel):
 
 class NirspecIfuAreaModel(ReferenceFileModel):
     """
-    A data model for the NIRSpec IFU pixel area reference file
+    A data model for the NIRSpec IFU pixel area reference file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     area_table : numpy table
          NIRSpec IFU pixel area table
          A table-like object containing row selection criteria made up

--- a/src/stdatamodels/jwst/datamodels/psfmask.py
+++ b/src/stdatamodels/jwst/datamodels/psfmask.py
@@ -6,10 +6,10 @@ __all__ = ["PsfMaskModel"]
 
 class PsfMaskModel(ReferenceFileModel):
     """
-    A data model for coronagraphic 2D PSF mask reference files
+    A data model for coronagraphic 2D PSF mask reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The PSF mask
     """

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -8,14 +8,12 @@ class QuadModel(JwstDataModel):
     """
     A data model for 4D image arrays.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
     """

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -8,26 +8,20 @@ class RampModel(JwstDataModel):
     """
     A data model for 4D ramps.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     pixeldq : numpy uint32 array
          2-D data quality array for all planes
-
     groupdq : numpy uint8 array
          4-D data quality array for each plane
-
     zeroframe : numpy float32 array
          Zeroframe array
-
     group : numpy table
          group parameters table
-
     int_times : numpy table
          table of times for each integration
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"

--- a/src/stdatamodels/jwst/datamodels/rampfitoutput.py
+++ b/src/stdatamodels/jwst/datamodels/rampfitoutput.py
@@ -13,33 +13,24 @@ class RampFitOutputModel(JwstDataModel):
     were fit, `nreads` is the number of reads in an integration, and
     `ny` and `nx` are the height and width of the image.
 
-    Parameters
-    __________
-
+    Attributes
+    ----------
     slope : numpy float32 array (n_int, max_seg, ny, nx)
         Segment-specific slope
-
     sigslope : numpy float32 array (n_int, max_seg, ny, nx)
         Sigma for segment-specific slope
-
     var_poisson : numpy float32 array (n_int, max_seg, ny, nx)
         Variance due to poisson noise for segment-specific slope
-
     var_rnoise : numpy float32 array (n_int, max_seg, ny, nx)
         Variance due to read noise for segment-specific slope
-
     yint : numpy float32 array (n_int, max_seg, ny, nx)
         Segment-specific y-intercept
-
     sigyint : numpy float32 array (n_int, max_seg, ny, nx)
         Sigma for segment-specific y-intercept
-
     pedestal : numpy float32 array (n_int, max_seg, ny, nx)
         Pedestal array
-
     weights : numpy float32 array (n_int, max_seg, ny, nx)
         Weights for segment-specific fits
-
     crmag : numpy float32 array (n_int, max_seg, ny, nx)
         Approximate CR magnitudes
     """

--- a/src/stdatamodels/jwst/datamodels/readnoise.py
+++ b/src/stdatamodels/jwst/datamodels/readnoise.py
@@ -8,8 +8,8 @@ class ReadnoiseModel(ReferenceFileModel):
     """
     A data model for 2D readnoise.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Read noise
     """

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -47,6 +47,11 @@ class ReferenceFileModel(JwstDataModel):
             The path to the directory containing the file
         *args, **kwargs
             Any additional arguments to pass to the save method of JwstDataModel
+
+        Returns
+        -------
+        output_path : str
+            The path to the saved file
         """
         if (
             self.hasattr("dq_def")
@@ -84,17 +89,12 @@ class ReferenceImageModel(ReferenceFileModel):
     """
     A data model for 2D reference images.
 
-    Reference image data model.
-
-    Parameters
+    Attributes
     ----------
-    __________
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
     """

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -11,10 +11,7 @@ __all__ = ["ReferenceFileModel", "ReferenceImageModel", "ReferenceCubeModel", "R
 
 
 class ReferenceFileModel(JwstDataModel):
-    """
-    A data model for reference tables
-
-    """
+    """A data model for reference tables."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencefile.schema"
 
@@ -24,10 +21,7 @@ class ReferenceFileModel(JwstDataModel):
         self.meta.telescope = "JWST"
 
     def validate(self):
-        """
-        Convenience function to be run when files are created.
-        Checks that required reference file keywords are set.
-        """
+        """Check that required reference file keywords are set."""
         to_fix = []
         to_check = ["description", "reftype", "author", "pedigree", "useafter"]
         for field in to_check:
@@ -43,8 +37,16 @@ class ReferenceFileModel(JwstDataModel):
 
     def save(self, path, dir_path=None, *args, **kwargs):
         """
-        Save data model.  If the 'dq' and 'dq_def' exist they need special
-        handling.
+        Save the model, handling 'dq' and 'dq_def' separately if they exist.
+
+        Parameters
+        ----------
+        path : str
+            The path to the file
+        dir_path : str
+            The path to the directory containing the file
+        *args, **kwargs
+            Any additional arguments to pass to the save method of JwstDataModel
         """
         if (
             self.hasattr("dq_def")
@@ -64,6 +66,14 @@ class ReferenceFileModel(JwstDataModel):
         return output_path
 
     def print_err(self, message):
+        """
+        Raise error or warn, depending on strict_validation attribute.
+
+        Parameters
+        ----------
+        message : str
+            The message to print
+        """
         if self._strict_validation:
             raise ValueError(message)
         else:
@@ -77,6 +87,7 @@ class ReferenceImageModel(ReferenceFileModel):
     Reference image data model.
 
     Parameters
+    ----------
     __________
     data : numpy float32 array
          The science data
@@ -103,16 +114,14 @@ class ReferenceImageModel(ReferenceFileModel):
 
 class ReferenceCubeModel(ReferenceFileModel):
     """
-    A data model for 3D reference images
+    A data model for 3D reference images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
     """
@@ -129,16 +138,14 @@ class ReferenceCubeModel(ReferenceFileModel):
 
 class ReferenceQuadModel(ReferenceFileModel):
     """
-    A data model for 4D reference images
+    A data model for 4D reference images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
     """

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -10,17 +10,14 @@ class ResetModel(ReferenceFileModel):
     """
     A data model for reset correction reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Reset Correction array
-
     dq : numpy uint32 array
          2-D data quality array for each integration
-
     err : numpy float32 array
          Error array
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/resolution.py
+++ b/src/stdatamodels/jwst/datamodels/resolution.py
@@ -7,8 +7,8 @@ class ResolutionModel(ReferenceFileModel):
     """
     A data model for Spectral Resolution  parameters reference tables.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
         Resolving Power table
     """
@@ -20,15 +20,14 @@ class MiriResolutionModel(ResolutionModel):
     """
     A data model for MIRI Resolution reference files.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy table
         Resolving Power table
         A table containing resolving power of the MRS. THe table consist of 11
         columns and 12 rows. Each row corresponds to a band. The columns give the
         name of band, central wavelength, and polynomial coefficients (a,b,c)
         needed to obtain the limits and average value of the spectral resolution.
-
     psf_fwhm_alpha_table : table
         PSF FWHM Alpha
         A table with 5 columns. Column 1 gives the cutoff wavelength where the
@@ -37,7 +36,6 @@ class MiriResolutionModel(ResolutionModel):
         shorter than cutoff. Columns 4 and 5 give the polynomial
         coefficients (a,b) describing alpha FWHM for wavelengths longer than the
         cutoff.
-
     psf_fwhm_beta_table : table
         PSF FWHM Beta
         A table with 5 columns. Column 1 gives the cutoff wavelength where the

--- a/src/stdatamodels/jwst/datamodels/rscd.py
+++ b/src/stdatamodels/jwst/datamodels/rscd.py
@@ -8,33 +8,28 @@ class RSCDModel(ReferenceFileModel):
     """
     A data model for the RSCD reference file.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     rscd_group_skip_table : numpy table
         Reference table for RSCD correction baseline correction
         A table with 3 columns that set the number of groups to skip for each
         subarray and readpatt
-
     rscd_gen_table : numpy table
         Reference table for RSCD correction enhanced correction
         A table with 5 columns that sets up general parameters for the enhanced
         correction
-
     rscd_int1_table : numpy table
         Reference table for RSCD correction enhanced correction
         A table with 7 columns that sets up correction parameters for the enhanced
         correction for integration 1 based on subarray, readpatt, even or odd row
-
     rscd_int2_table : numpy table
         Reference table for RSCD correction enhanced correction
         A table with 7 columns that sets up correction parameters for the enhanced
         correction for integration 2 based on subarray, readpatt, even or odd row
-
     rscd_int3_table : numpy table
         Reference table for RSCD correction enhanced correction
         A table with 7 columns that sets up correction parameters for the enhanced
         correction for integration 3 based on subarray, readpatt, even or odd row
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/rscd.schema"

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -10,14 +10,12 @@ class SaturationModel(ReferenceFileModel):
     """
     A data model for saturation checking information.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          Saturation threshold
-
     dq : numpy uint32 array
          2-D data quality array for all planes
-
     dq_def : numpy table
          DQ flag definitions
     """

--- a/src/stdatamodels/jwst/datamodels/schemas/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schemas for JWST datamodels."""

--- a/src/stdatamodels/jwst/datamodels/segmap.py
+++ b/src/stdatamodels/jwst/datamodels/segmap.py
@@ -6,10 +6,10 @@ __all__ = ["SegmentationMapModel"]
 
 class SegmentationMapModel(JwstDataModel):
     """
-    A data model for 2D segmentation maps
+    A data model for 2D segmentation maps.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy uint32 array
          The segmentation map
     """

--- a/src/stdatamodels/jwst/datamodels/sirs_kernel.py
+++ b/src/stdatamodels/jwst/datamodels/sirs_kernel.py
@@ -6,11 +6,12 @@ __all__ = ["SIRSKernelModel"]
 
 class SIRSKernelModel(ReferenceFileModel):
     """
-    A data model for the NIR Optimized Convolution Kernel Fourier Coefficients,
-    also called Simple Improved Reference Subtraction (SIRS).
+    A data model for the NIR Optimized Convolution Kernel Fourier Coefficients.
 
-    Parameters
-    __________
+    Also called Simple Improved Reference Subtraction (SIRS).
+
+    Attributes
+    ----------
     data : numpy table
         The reference waves to correct for 1/f at the REFPIX step for NIR data.
         A table-like object containing the Fourier Coefficients for the
@@ -26,8 +27,8 @@ class SIRSKernelModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(SIRSKernelModel, self).__init__(init=init, **kwargs)
 
-    def on_save(self, path=None):
+    def on_save(self, path=None):  # noqa: D102
         self.meta.reftype = self.reftype
 
-    def validate(self):
+    def validate(self):  # noqa: D102
         super(SIRSKernelModel, self).validate()

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -12,35 +12,35 @@ class SlitDataModel(JwstDataModel):
     Attributes
     ----------
     data : numpy float32 array
-         The science data
+        The science data
     dq : numpy uint32 array
-         Data quality array
+        Data quality array
     err : numpy float32 array
-         Error array
+        Error array
     var_poisson : numpy float32 array
-         variance due to poisson noise
+        variance due to poisson noise
     var_rnoise : numpy float32 array
-         variance due to read noise
+        variance due to read noise
     var_flat : numpy float32 array
-         variance due to flat
+        variance due to flat
     wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
+        Wavelength array, corrected for zero-point
     barshadow : numpy float32 array
-         Bar shadow correction
+        Bar shadow correction
     flatfield_point : numpy float32 array
-         flatfield array for point source
+        flatfield array for point source
     flatfield_uniform : numpy float32 array
-         flatfield array for uniform source
+        flatfield array for uniform source
     pathloss_point : numpy float32 array
-         pathloss array for point source
+        pathloss array for point source
     pathloss_uniform : numpy float32 array
-         pathloss array for uniform source
+        pathloss array for uniform source
     photom_point : numpy float32 array
-         photom array for point source
+        photom array for point source
     photom_uniform : numpy float32 array
-         photom array for uniform source
+        photom array for uniform source
     area : numpy float32 array
-         Pixel area map array
+        Pixel area map array
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
@@ -81,37 +81,37 @@ class SlitModel(JwstDataModel):
     Attributes
     ----------
     data : numpy float32 array
-         The science data
+        The science data
     dq : numpy uint32 array
-         Data quality array
+        Data quality array
     err : numpy float32 array
-         Error array
+        Error array
     var_poisson : numpy float32 array
-         variance due to poisson noise
+        Variance due to poisson noise
     var_rnoise : numpy float32 array
-         variance due to read noise
+        Variance due to read noise
     var_flat : numpy float32 array
-         variance due to flat
+        Variance due to flat
     wavelength : numpy float32 array
-         Wavelength array, corrected for zero-point
+        Wavelength array, corrected for zero-point
     barshadow : numpy float32 array
-         Bar shadow correction
+        Bar shadow correction
     flatfield_point : numpy float32 array
-         flatfield array for point source
+        Flatfield array for point source
     flatfield_uniform : numpy float32 array
-         flatfield array for uniform source
+        Flatfield array for uniform source
     pathloss_point : numpy float32 array
-         pathloss array for point source
+        Pathloss array for point source
     pathloss_uniform : numpy float32 array
-         pathloss array for uniform source
+        Pathloss array for uniform source
     photom_point : numpy float32 array
-         photom array for point source
+        Photom array for point source
     photom_uniform : numpy float32 array
-         photom array for uniform source
+        Photom array for uniform source
     area : numpy float32 array
-         Pixel area map array
+        Pixel area map array
     int_times : numpy table
-         table of times for each integration
+        Table of times for each integration
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slit.schema"

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -9,50 +9,36 @@ class SlitDataModel(JwstDataModel):
     """
     A data model for 2D slit images.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
-
     var_rnoise : numpy float32 array
          variance due to read noise
-
     var_flat : numpy float32 array
          variance due to flat
-
     wavelength : numpy float32 array
          Wavelength array, corrected for zero-point
-
     barshadow : numpy float32 array
          Bar shadow correction
-
     flatfield_point : numpy float32 array
          flatfield array for point source
-
     flatfield_uniform : numpy float32 array
          flatfield array for uniform source
-
     pathloss_point : numpy float32 array
          pathloss array for point source
-
     pathloss_uniform : numpy float32 array
          pathloss array for uniform source
-
     photom_point : numpy float32 array
          photom array for point source
-
     photom_uniform : numpy float32 array
          photom array for uniform source
-
     area : numpy float32 array
          Pixel area map array
     """
@@ -93,6 +79,7 @@ class SlitModel(JwstDataModel):
     A data model for 2D images.
 
     Parameters
+    ----------
     __________
     data : numpy float32 array
          The science data

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -78,54 +78,38 @@ class SlitModel(JwstDataModel):
     """
     A data model for 2D images.
 
-    Parameters
+    Attributes
     ----------
-    __________
     data : numpy float32 array
          The science data
-
     dq : numpy uint32 array
          Data quality array
-
     err : numpy float32 array
          Error array
-
     var_poisson : numpy float32 array
          variance due to poisson noise
-
     var_rnoise : numpy float32 array
          variance due to read noise
-
     var_flat : numpy float32 array
          variance due to flat
-
     wavelength : numpy float32 array
          Wavelength array, corrected for zero-point
-
     barshadow : numpy float32 array
          Bar shadow correction
-
     flatfield_point : numpy float32 array
          flatfield array for point source
-
     flatfield_uniform : numpy float32 array
          flatfield array for uniform source
-
     pathloss_point : numpy float32 array
          pathloss array for point source
-
     pathloss_uniform : numpy float32 array
          pathloss array for uniform source
-
     photom_point : numpy float32 array
          photom array for point source
-
     photom_uniform : numpy float32 array
          photom array for uniform source
-
     area : numpy float32 array
          Pixel area map array
-
     int_times : numpy table
          table of times for each integration
     """

--- a/src/stdatamodels/jwst/datamodels/sossextractmodel.py
+++ b/src/stdatamodels/jwst/datamodels/sossextractmodel.py
@@ -6,33 +6,29 @@ __all__ = ["SossExtractModel"]
 class SossExtractModel(JwstDataModel):
     """
     A data model to hold NIRISS SOSS extraction model arrays.
+
     For each order, stores the model trace per integration and
     aperture pixel weights for each order extraction.
 
     This model is written to explicitly handle each of the three orders.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     order1 : numpy float32 array
         3-D array of the 2-D model trace for each integration,
         for spectral order 1
-
     order2 : numpy float32 array
         3-D array of the 2-D model trace for each integration,
         for spectral order 2
-
     order3 : numpy float32 array
         3-D array of the 2-D model trace for each integration,
         for spectral order 3
-
     aperture1 : numpy float32 array
         2-D array storing the pixel weights for box-extracting
         spectral order 1
-
     aperture2 : numpy float32 array
         2-D array storing the pixel weights for box-extracting
         spectral order 2
-
     aperture3 : numpy float32 array
         2-D array storing the pixel weights for box-extracting
         spectral order 3

--- a/src/stdatamodels/jwst/datamodels/sosswavegrid.py
+++ b/src/stdatamodels/jwst/datamodels/sosswavegrid.py
@@ -6,11 +6,12 @@ __all__ = ["SossWaveGridModel"]
 class SossWaveGridModel(JwstDataModel):
     """
     A data model to hold NIRISS SOSS wavelength grids.
+
     This 1-D array of wavelengths can be saved from a processing run
     and applied to future input products.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     wavegrid : numpy float32 array
         1-D array of the wavelengths corresponding to the ATOCA fit.
     """

--- a/src/stdatamodels/jwst/datamodels/spec.py
+++ b/src/stdatamodels/jwst/datamodels/spec.py
@@ -8,8 +8,8 @@ class SpecModel(JwstDataModel):
     """
     A data model for 1D spectra.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     spec_table : numpy table
         Extracted spectral data table.
         A table with at least four columns:  wavelength, flux, an error
@@ -23,8 +23,8 @@ class MRSSpecModel(SpecModel):
     """
     A data model for MIRI MRS 1D spectra with residual fringe corrections.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     spec_table : numpy table
         Extracted spectral data table.
         A table with the standard spectral columns plus three extra

--- a/src/stdatamodels/jwst/datamodels/speckernel.py
+++ b/src/stdatamodels/jwst/datamodels/speckernel.py
@@ -8,8 +8,8 @@ class SpecKernelModel(ReferenceFileModel):
     """
     A data model for 2D spectral kernels.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     wavelengths : numpy float32 array
          Wavelengths
 

--- a/src/stdatamodels/jwst/datamodels/specprofile.py
+++ b/src/stdatamodels/jwst/datamodels/specprofile.py
@@ -23,11 +23,10 @@ class SpecProfileModel(ReferenceFileModel):
     the first element of `profile`.  `SpecProfileSingleModel` objects can be appended
     to the `profile` attribute by using its `append` method.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     profile.items.data : numpy array
          Spectral profile data
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specprofile.schema"
@@ -47,6 +46,7 @@ class SpecProfileSingleModel(ReferenceFileModel):
     A data model for NIRISS SOSS spectral profile data.
 
     Parameters
+    ----------
     __________
     data : numpy float32 array
          Spectral profile values

--- a/src/stdatamodels/jwst/datamodels/specprofile.py
+++ b/src/stdatamodels/jwst/datamodels/specprofile.py
@@ -45,9 +45,8 @@ class SpecProfileSingleModel(ReferenceFileModel):
     """
     A data model for NIRISS SOSS spectral profile data.
 
-    Parameters
+    Attributes
     ----------
-    __________
     data : numpy float32 array
          Spectral profile values
     """

--- a/src/stdatamodels/jwst/datamodels/specpsf.py
+++ b/src/stdatamodels/jwst/datamodels/specpsf.py
@@ -6,16 +6,14 @@ __all__ = ["SpecPsfModel"]
 
 class SpecPsfModel(ReferenceFileModel):
     """
-    A data model for spectral PSF reference data
+    A data model for spectral PSF reference data.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
          The PSF image
-
     wave : numpy float32 array
          Wavelength image
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specpsf.schema"

--- a/src/stdatamodels/jwst/datamodels/spectrace.py
+++ b/src/stdatamodels/jwst/datamodels/spectrace.py
@@ -45,9 +45,8 @@ class SpecTraceSingleModel(ReferenceFileModel):
     """
     A data model for NIRISS SOSS spectral trace data.
 
-    Parameters
+    Attributes
     ----------
-    __________
     data : numpy table
          Trace values
     """

--- a/src/stdatamodels/jwst/datamodels/spectrace.py
+++ b/src/stdatamodels/jwst/datamodels/spectrace.py
@@ -23,11 +23,10 @@ class SpecTraceModel(ReferenceFileModel):
     the first element of `trace`.  `SpecTraceSingleModel` objects can be appended
     to the `trace` attribute by using its `append` method.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     trace.items.data : numpy table
          Spectral trace data
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/spectrace.schema"
@@ -47,6 +46,7 @@ class SpecTraceSingleModel(ReferenceFileModel):
     A data model for NIRISS SOSS spectral trace data.
 
     Parameters
+    ----------
     __________
     data : numpy table
          Trace values

--- a/src/stdatamodels/jwst/datamodels/straylight.py
+++ b/src/stdatamodels/jwst/datamodels/straylight.py
@@ -8,8 +8,8 @@ class StrayLightModel(ReferenceFileModel):
     """
     A data model for 2D straylight mask.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy uint8 array
          Straylight mask
     """

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -7,23 +7,7 @@ __all__ = ["SuperBiasModel"]
 
 
 class SuperBiasModel(ReferenceFileModel):
-    """
-    A data model for 2D super-bias images.
-
-    Parameters
-    __________
-    data : numpy float32 array
-         The science data
-
-    dq : numpy uint32 array
-         Data quality array
-
-    err : numpy float32 array
-         Error array
-
-    dq_def : numpy table
-         DQ flag definitions
-    """
+    """A data model for 2D super-bias images."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -13,13 +13,13 @@ class SuperBiasModel(ReferenceFileModel):
     Attributes
     ----------
     data : numpy float32 array
-         The science data
+        The science data
     dq : numpy uint32 array
-         Data quality array
+        Data quality array
     err : numpy float32 array
-         Error array
+        Error array
     dq_def : numpy table
-         DQ flag definitions
+        DQ flag definitions
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -7,7 +7,20 @@ __all__ = ["SuperBiasModel"]
 
 
 class SuperBiasModel(ReferenceFileModel):
-    """A data model for 2D super-bias images."""
+    """
+    A data model for 2D super-bias images.
+
+    Attributes
+    ----------
+    data : numpy float32 array
+         The science data
+    dq : numpy uint32 array
+         Data quality array
+    err : numpy float32 array
+         Error array
+    dq_def : numpy table
+         DQ flag definitions
+    """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"
 

--- a/src/stdatamodels/jwst/datamodels/throughput.py
+++ b/src/stdatamodels/jwst/datamodels/throughput.py
@@ -8,8 +8,8 @@ class ThroughputModel(ReferenceFileModel):
     """
     A data model for filter throughput.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     filter_table : numpy table
          Filter throughput table
     """

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -7,7 +7,18 @@ __all__ = ["TrapDensityModel"]
 
 
 class TrapDensityModel(ReferenceFileModel):
-    """A data model for the trap density of a detector, for persistence."""
+    """
+    A data model for the trap density of a detector, for persistence.
+
+    Attributes
+    ----------
+    data : numpy float32 array
+         Trap density
+    dq : numpy uint32 array
+         data quality array
+    dq_def : numpy table
+         DQ flag definitions
+    """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/trapdensity.schema"
 

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -7,20 +7,7 @@ __all__ = ["TrapDensityModel"]
 
 
 class TrapDensityModel(ReferenceFileModel):
-    """
-    A data model for the trap density of a detector, for persistence.
-
-    Parameters
-    __________
-    data : numpy float32 array
-         Trap density
-
-    dq : numpy uint32 array
-         data quality array
-
-    dq_def : numpy table
-         DQ flag definitions
-    """
+    """A data model for the trap density of a detector, for persistence."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/trapdensity.schema"
 

--- a/src/stdatamodels/jwst/datamodels/trappars.py
+++ b/src/stdatamodels/jwst/datamodels/trappars.py
@@ -8,8 +8,8 @@ class TrapParsModel(ReferenceFileModel):
     """
     A data model for trap capture and decay parameters.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     trappars_table : numpy table
          Trap capture and decay parameters
          A table with three columns for trap-capture parameters and one

--- a/src/stdatamodels/jwst/datamodels/trapsfilled.py
+++ b/src/stdatamodels/jwst/datamodels/trapsfilled.py
@@ -6,11 +6,10 @@ __all__ = ["TrapsFilledModel"]
 
 class TrapsFilledModel(JwstDataModel):
     """
-    A data model for the number of traps filled for a detector, for
-    persistence.
+    A data model for the number of traps filled for a detector, for persistence.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     data : numpy float32 array
         Traps filled
         The map of the number of traps filled over the detector, with

--- a/src/stdatamodels/jwst/datamodels/tsophot.py
+++ b/src/stdatamodels/jwst/datamodels/tsophot.py
@@ -24,10 +24,10 @@ class TsoPhotModel(ReferenceFileModel):
         ----------
         init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
             The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+            is supported by DataModel.
         radii : list, optional
             List of one or more dictionaries, each with keys 'pupil', 'radius',
-            'radius_inner', and 'radius_outer', by default None.
+            'radius_inner', and 'radius_outer'.
         **kwargs
             Additional keyword arguments passed to ReferenceFileModel.
         """

--- a/src/stdatamodels/jwst/datamodels/tsophot.py
+++ b/src/stdatamodels/jwst/datamodels/tsophot.py
@@ -26,7 +26,8 @@ class TsoPhotModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
         radii : list, optional
-            ADD HERE, by default None
+            List of one or more dictionaries, each with keys 'pupil', 'radius',
+            'radius_inner', and 'radius_outer', by default None.
         **kwargs
             Additional keyword arguments passed to ReferenceFileModel.
         """

--- a/src/stdatamodels/jwst/datamodels/tsophot.py
+++ b/src/stdatamodels/jwst/datamodels/tsophot.py
@@ -11,25 +11,36 @@ __all__ = ["TsoPhotModel"]
 
 
 class TsoPhotModel(ReferenceFileModel):
-    """
-    A model for a reference file of type "tsophot".
-    """
+    """A model for a reference file of type "tsophot"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/tsophot.schema"
     reftype = "tsophot"
 
     def __init__(self, init=None, radii=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        radii : list, optional
+            ADD HERE, by default None
+        **kwargs
+            Additional keyword arguments passed to ReferenceFileModel.
+        """
         super(TsoPhotModel, self).__init__(init=init, **kwargs)
         if radii is not None:
             self.radii = radii
 
-    def on_save(self, path=None):
+    def on_save(self, path=None):  # noqa: D102
         self.meta.reftype = self.reftype
 
-    def to_fits(self):
+    def to_fits(self):  # noqa: D102
         raise NotImplementedError("FITS format is not supported for this file.")
 
-    def validate(self):
+    def validate(self):  # noqa: D102
         super(TsoPhotModel, self).validate()
         try:
             assert len(self.radii) > 0

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -1,6 +1,4 @@
-"""
-Various utility functions and data types
-"""
+"""Various utility functions and data types."""
 
 from collections.abc import Sequence
 import sys
@@ -26,7 +24,7 @@ log.addHandler(logging.NullHandler())
 
 def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
     """
-    Creates a DataModel from a number of different types
+    Create a DataModel from a number of different types.
 
     Parameters
     ----------
@@ -52,10 +50,8 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
     guess : bool
         Guess as to the model type if the model type is not specifically known from the file.
         If not guess and the model type is not explicit, raise a TypeError.
-
     memmap : bool
         Turn memmap of file on or off.  (default: False).
-
     kwargs : dict
         Additional keyword arguments passed to the DataModel constructor.  Some arguments
         are general, others are file format-specific.  Arguments of note are:
@@ -68,9 +64,9 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
 
     Returns
     -------
-    model : DataModel instance
+    DataModel
+        A new model instance.
     """
-
     from . import model_base
 
     # Initialize variables used to select model class
@@ -238,15 +234,17 @@ def _handle_missing_model_type(model, file_name):
 
 def _class_from_model_type(init):
     """
-    Get the model type from the primary header, lookup to get class
+    Get the model type from the primary header, lookup to get class.
 
     Parameter
     ---------
     init: AsdfFile or HDUList
+        The input metadata
 
     Return
     ------
     new_class: str or None
+        The class name.
     """
     from . import _defined_models as defined_models
 
@@ -272,7 +270,19 @@ def _class_from_model_type(init):
 
 def _class_from_ramp_type(hdulist, shape):
     """
-    Special check to see if file is ramp file
+    Check to see if file is ramp file.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        The HDUList object
+    shape : tuple
+        The shape of the data
+
+    Returns
+    -------
+    RampModel
+        The model class to use
     """
     if not hdulist:
         new_class = None
@@ -294,7 +304,19 @@ def _class_from_ramp_type(hdulist, shape):
 
 def _class_from_reftype(hdulist, shape):
     """
-    Get the class name from the reftype and other header keywords
+    Get the class name from the reftype and other header keywords.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        The HDUList object
+    shape : tuple
+        The shape of the data
+
+    Returns
+    -------
+    ReferenceDataModel
+        The model class to use
     """
     if not hdulist:
         new_class = None
@@ -324,7 +346,19 @@ def _class_from_reftype(hdulist, shape):
 
 def _class_from_shape(hdulist, shape):
     """
-    Get the class name from the shape
+    Get the class name from the shape.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        The HDUList object
+    shape : tuple
+        The shape of the data
+
+    Returns
+    -------
+    DataModel
+        The model class to use
     """
     if len(shape) == 0:
         from . import model_base
@@ -359,7 +393,17 @@ def _class_from_shape(hdulist, shape):
 
 def is_association(asn_data):
     """
-    Test if an object is an association by checking for required fields
+    Test if an object is an association by checking for required fields.
+
+    Parameters
+    ----------
+    asn_data : object
+        The object to test
+
+    Returns
+    -------
+    bool
+        True if `asn_data` is an association
     """
     if isinstance(asn_data, dict):
         if "asn_id" in asn_data and "asn_pool" in asn_data:

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -51,8 +51,8 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
         Guess as to the model type if the model type is not specifically known from the file.
         If not guess and the model type is not explicit, raise a TypeError.
     memmap : bool
-        Turn memmap of file on or off.  (default: False).
-    **kwargs : dict
+        Turn memmap of file on or off.
+    **kwargs
         Additional keyword arguments passed to the DataModel constructor.  Some arguments
         are general, others are file format-specific.  Arguments of note are:
 

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -52,7 +52,7 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
         If not guess and the model type is not explicit, raise a TypeError.
     memmap : bool
         Turn memmap of file on or off.  (default: False).
-    kwargs : dict
+    **kwargs : dict
         Additional keyword arguments passed to the DataModel constructor.  Some arguments
         are general, others are file format-specific.  Arguments of note are:
 
@@ -236,14 +236,14 @@ def _class_from_model_type(init):
     """
     Get the model type from the primary header, lookup to get class.
 
-    Parameter
-    ---------
-    init: AsdfFile or HDUList
+    Parameters
+    ----------
+    init : AsdfFile or HDUList
         The input metadata
 
-    Return
-    ------
-    new_class: str or None
+    Returns
+    -------
+    new_class : str or None
         The class name.
     """
     from . import _defined_models as defined_models

--- a/src/stdatamodels/jwst/datamodels/wavemap.py
+++ b/src/stdatamodels/jwst/datamodels/wavemap.py
@@ -23,11 +23,10 @@ class WaveMapModel(ReferenceFileModel):
     the first element of `map`.  `WaveMapSingleModel` objects can be appended
     to the `map` attribute by using its `append` method.
 
-    Parameters
-    __________
+    Attributes
+    ----------
     map.items.data : numpy data array
          Wavelength map data
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavemap.schema"
@@ -47,6 +46,7 @@ class WaveMapSingleModel(ReferenceFileModel):
     A data model for NIRISS SOSS wavelength map data.
 
     Parameters
+    ----------
     __________
     data : numpy float32 array
          Wavelength values

--- a/src/stdatamodels/jwst/datamodels/wavemap.py
+++ b/src/stdatamodels/jwst/datamodels/wavemap.py
@@ -45,9 +45,8 @@ class WaveMapSingleModel(ReferenceFileModel):
     """
     A data model for NIRISS SOSS wavelength map data.
 
-    Parameters
+    Attributes
     ----------
-    __________
     data : numpy float32 array
          Wavelength values
     """

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -460,36 +460,8 @@ class NIRISSGrismModel(ReferenceFileModel):
 class MiriLRSSpecwcsModel(ReferenceFileModel):
     """
     A model for a reference file of type "specwcs" for MIRI LRS Slit.
-    The model is for the specwcs for LRS Fixed Slit and LRSSlitless
-    Parameters
-    ----------
-    x_ref : float
-         x coordinate of reference position of fixed slit aperture
-    y_ref : float
-        y coordinate of reference position of fixed slit aperture
-    x_ref_slitless : float
-         x coordinate of reference position of slitless aperture
-    y_ref_slitless : float
-        y coordinate of reference position of slitless aperture
-    v2vert1 : float
-        slit vertex 1 in V2 frame
-    v2vert2 : float
-        slit vertex 2 in V2 frame
-    v2vert3 : float
-        slit vertex 3 in V2 frame
-    v2vert4 : float
-        slit vertex 4 in V2 frames
-    v3vert1 : float
-        slit vertex 1 in V3 frames
-    v3vert2 : float
-        slit vertex 2 in V3 frames
-    v3vert3 : float
-        slit vertex 3 in V3 frames
-    v3vert4 : float
-        slit vertex 4 in V3 frames
-    wavetable : numpy  2-D array
-        For each row in the slit hold  wavelength, and
-        x center, ycenter, x and y box region corresponding to the wavelength
+
+    The model is for the specwcs for LRS Fixed Slit and LRS Slitless data.
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_miri_lrs.schema"
@@ -513,6 +485,44 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
         v3_vert4=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        wavetable : numpy  2-D array
+            For each row in the slit hold  wavelength, and
+            x center, ycenter, x and y box region corresponding to the wavelength
+        x_ref : float
+            X-coordinate of reference position of fixed slit aperture
+        y_ref : float
+            Y-coordinate of reference position of fixed slit aperture
+        x_ref_slitless : float
+            X-coordinate of reference position of slitless aperture
+        y_ref_slitless : float
+            Y-coordinate of reference position of slitless aperture
+        v2_vert1 : float
+            Slit vertex 1 in V2 frame
+        v2_vert2 : float
+            Slit vertex 2 in V2 frame
+        v2_vert3 : float
+            Slit vertex 3 in V2 frame
+        v2_vert4 : float
+            Slit vertex 4 in V2 frames
+        v3_vert1 : float
+            Slit vertex 1 in V3 frames
+        v3_vert2 : float
+            Slit vertex 2 in V3 frames
+        v3_vert3 : float
+            Slit vertex 3 in V3 frames
+        v3_vert4 : float
+            Slit vertex 4 in V3 frames
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel.
+        """
         super().__init__(init=init, **kwargs)
 
         if init is None:

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -314,7 +314,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
         init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
-        displ: `~astropy.modeling.Model`
+        displ : `~astropy.modeling.Model`
             Nircam Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
             Nircam Grism row dispersion model
@@ -399,7 +399,7 @@ class NIRISSGrismModel(ReferenceFileModel):
         init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
-        displ: `~astropy.modeling.Model`
+        displ : `~astropy.modeling.Model`
             NIRISS Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
             NIRISS Grism row dispersion model
@@ -407,10 +407,6 @@ class NIRISSGrismModel(ReferenceFileModel):
             NIRISS Grism column dispersion model
         invdispl : `~astropy.modeling.Model`
             NIRISS Grism inverse wavelength dispersion model
-        invdispx : `~astropy.modeling.Model`
-            NIRISS Grism inverse row dispersion model
-        invdispy : `~astropy.modeling.Model`
-            NIRISS Grism inverse column dispersion model
         orders : `~astropy.modeling.Model`
             NIRISS Grism orders, matched to the array locations of the
             dispersion models

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -164,17 +164,17 @@ class DistortionMRSModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
         x_model : `astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         y_model : `astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         alpha_model : `astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         beta_model : `astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         bzero : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         bdel : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         input_units : str or `~astropy.units.NamedUnit`, optional
             The units of the input, by default None
         output_units : str or `~astropy.units.NamedUnit`, optional
@@ -579,7 +579,7 @@ class RegionsModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
         regions : np.ndarray, optional
-            ADD HERE, by default None
+            TODO, by default None
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel
         """
@@ -735,9 +735,9 @@ class FPAModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
         nrs1_model : `~astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         nrs2_model : `~astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         """
         super().__init__(init=init, **kwargs)
         if nrs1_model is not None:
@@ -844,9 +844,9 @@ class IFUSlicerModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
         model : `~astropy.modeling.core.Model`, optional
-            ADD HERE, by default None
+            TODO, by default None
         data : np.ndarray, optional
-            ADD HERE, by default None
+            TODO, by default None
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -890,9 +890,9 @@ class MSAModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
         models : dict, optional
-            ADD HERE, by default None
+            TODO, by default None
         data : dict, optional
-            ADD HERE, by default None
+            TODO, by default None
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -956,29 +956,29 @@ class DisperserModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
         angle : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         gwa_tiltx : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         gwa_tilty : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         kcoef : list, optional
-            ADD HERE, by default None
+            TODO, by default None
         lcoef : list, optional
-            ADD HERE, by default None
+            TODO, by default None
         tcoef : list, optional
-            ADD HERE, by default None
+            TODO, by default None
         pref : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         tref : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         theta_x : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         theta_y : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         theta_z : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         groovedensity : float, optional
-            ADD HERE, by default None
+            TODO, by default None
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -1064,7 +1064,7 @@ class FilteroffsetModel(ReferenceFileModel):
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
         filters : dict, optional
-            ADD HERE, by default None
+            TODO, by default None
         instrument : str, optional
             The instrument for which the filter offsets are defined, by default None
         **kwargs : dict
@@ -1226,8 +1226,8 @@ class WaveCorrModel(ReferenceFileModel):
         init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None
-        apertures : ADD HERE, optional
-            ADD HERE, by default None
+        apertures : TODO, optional
+            TODO, by default None
         """
         super().__init__(init, **kwargs)
         if apertures is not None:

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -34,14 +34,27 @@ __all__ = [
 
 
 class _SimpleModel(ReferenceFileModel):
-    """
-    A model for a reference file of type "distortion".
-    """
+    """A DataModel for a reference file that includes an astropy.modeling.Model."""
 
     schema_url = None
     reftype = None
 
     def __init__(self, init=None, model=None, input_units=None, output_units=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        model : `astropy.modeling.core.Model` or list[Model], optional
+            The transform as an astropy Model, by default None
+        input_units : str or `~astropy.units.NamedUnit`, optional
+            The units of the input, by default None
+        output_units : str or `~astropy.units.NamedUnit`, optional
+            The units of the output, by default None
+        """
         super(_SimpleModel, self).__init__(init=init, **kwargs)
         if model is not None:
             self.model = model
@@ -56,18 +69,33 @@ class _SimpleModel(ReferenceFileModel):
                 pass
 
     def on_save(self, path=None):
+        """
+        Modify the model.meta.reftype attribute before saving to disk.
+
+        Also implicitly turns off other DataModel on_save functionality, which is
+        not relevant for this type of model.
+
+        Parameters
+        ----------
+        path : str, optional
+            Not used, only here to match the signature of the parent class, by default None.
+        """
         self.meta.reftype = self.reftype
 
     def populate_meta(self):
         """
-        Subclasses can overwrite this to populate specific meta keywords.
+        Populate specific meta keywords.
+
+        Should be overwritten by subclasses if needed.
         """
         raise NotImplementedError
 
     def to_fits(self):
+        """Override base class to specify that reference files are not writable to fits."""
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
+        """Run additional validations beyond schema validation for these model types."""
         super().validate()
         try:
             assert isinstance(self.model, Model) or all(isinstance(m, Model) for m in self.model)
@@ -87,9 +115,7 @@ class _SimpleModel(ReferenceFileModel):
 
 
 class DistortionModel(_SimpleModel):
-    """
-    A model for a reference file of type "distortion".
-    """
+    """A model for a reference file of type "distortion"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/distortion.schema"
     reftype = "distortion"
@@ -111,9 +137,7 @@ class DistortionModel(_SimpleModel):
 
 
 class DistortionMRSModel(ReferenceFileModel):
-    """
-    A model for a reference file of type "distortion" for the MIRI MRS.
-    """
+    """A model for a reference file of type "distortion" for the MIRI MRS."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/distortion_mrs.schema"
     reftype = "distortion"
@@ -131,6 +155,31 @@ class DistortionMRSModel(ReferenceFileModel):
         output_units=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        x_model : `astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        y_model : `astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        alpha_model : `astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        beta_model : `astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        bzero : float, optional
+            ADD HERE, by default None
+        bdel : float, optional
+            ADD HERE, by default None
+        input_units : str or `~astropy.units.NamedUnit`, optional
+            The units of the input, by default None
+        output_units : str or `~astropy.units.NamedUnit`, optional
+            The units of the output, by default None
+        """
         super().__init__(init=init, **kwargs)
 
         if x_model is not None:
@@ -240,25 +289,6 @@ class NIRCAMGrismModel(ReferenceFileModel):
 
     This reference file contains the models for wave, x, and y polynomial
     solutions that describe dispersion through the grism.
-
-    Parameters
-    ----------
-    displ: `~astropy.modeling.Model`
-          Nircam Grism wavelength dispersion model
-    dispx : `~astropy.modeling.Model`
-          Nircam Grism row dispersion model
-    dispy : `~astropy.modeling.Model`
-          Nircam Grism column dispersion model
-    invdispl : `~astropy.modeling.Model`
-          Nircam Grism inverse wavelength dispersion model
-    invdispx : `~astropy.modeling.Model`
-          Nircam Grism inverse row dispersion model
-    invdispy : `~astropy.modeling.Model`
-          Nircam Grism inverse column dispersion model
-    orders : `~astropy.modeling.Model`
-          NIRCAM Grism orders, matched to the array locations of the
-          dispersion models
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_nircam_grism.schema"
@@ -276,6 +306,32 @@ class NIRCAMGrismModel(ReferenceFileModel):
         orders=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        displ: `~astropy.modeling.Model`
+            Nircam Grism wavelength dispersion model
+        dispx : `~astropy.modeling.Model`
+            Nircam Grism row dispersion model
+        dispy : `~astropy.modeling.Model`
+            Nircam Grism column dispersion model
+        invdispl : `~astropy.modeling.Model`
+            Nircam Grism inverse wavelength dispersion model
+        invdispx : `~astropy.modeling.Model`
+            Nircam Grism inverse row dispersion model
+        invdispy : `~astropy.modeling.Model`
+            Nircam Grism inverse column dispersion model
+        orders : `~astropy.modeling.Model`
+            NIRCAM Grism orders, matched to the array locations of the
+            dispersion models
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel
+        """
         super().__init__(init=init, **kwargs)
 
         if init is None:
@@ -319,29 +375,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
 
 
 class NIRISSGrismModel(ReferenceFileModel):
-    """
-    A model for a reference file of type "specwcs" for NIRISS grisms.
-
-    Parameters
-    ----------
-    displ: `~astropy.modeling.Model`
-          NIRISS Grism wavelength dispersion model
-    dispx : `~astropy.modeling.Model`
-          NIRISS Grism row dispersion model
-    dispy : `~astropy.modeling.Model`
-          NIRISS Grism column dispersion model
-    invdispl : `~astropy.modeling.Model`
-          NIRISS Grism inverse wavelength dispersion model
-    invdispx : `~astropy.modeling.Model`
-          NIRISS Grism inverse row dispersion model
-    invdispy : `~astropy.modeling.Model`
-          NIRISS Grism inverse column dispersion model
-    orders : `~astropy.modeling.Model`
-          NIRISS Grism orders, matched to the array locations of the
-          dispersion models
-    fwcpos_ref : float
-        The reference value for the filter wheel position
-    """
+    """A model for a reference file of type "specwcs" for NIRISS grisms."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_niriss_grism.schema"
     reftype = "specwcs"
@@ -357,6 +391,34 @@ class NIRISSGrismModel(ReferenceFileModel):
         fwcpos_ref=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        displ: `~astropy.modeling.Model`
+            NIRISS Grism wavelength dispersion model
+        dispx : `~astropy.modeling.Model`
+            NIRISS Grism row dispersion model
+        dispy : `~astropy.modeling.Model`
+            NIRISS Grism column dispersion model
+        invdispl : `~astropy.modeling.Model`
+            NIRISS Grism inverse wavelength dispersion model
+        invdispx : `~astropy.modeling.Model`
+            NIRISS Grism inverse row dispersion model
+        invdispy : `~astropy.modeling.Model`
+            NIRISS Grism inverse column dispersion model
+        orders : `~astropy.modeling.Model`
+            NIRISS Grism orders, matched to the array locations of the
+            dispersion models
+        fwcpos_ref : float
+            The reference value for the filter wheel position
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel
+        """
         super().__init__(init=init, **kwargs)
 
         if init is None:
@@ -506,14 +568,25 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
 
 
 class RegionsModel(ReferenceFileModel):
-    """
-    A model for a reference file of type "regions".
-    """
+    """A model for a reference file of type "regions"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/regions.schema"
     reftype = "regions"
 
     def __init__(self, init=None, regions=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        regions : np.ndarray, optional
+            ADD HERE, by default None
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel
+        """
         super().__init__(init=init, **kwargs)
         if regions is not None:
             self.regions = regions
@@ -561,19 +634,6 @@ class WavelengthrangeModel(ReferenceFileModel):
     A model for a reference file of type "wavelengthrange".
 
     The model is used by MIRI, NIRSPEC, NIRCAM, and NIRISS.
-
-
-    Parameters
-    ----------
-    wrange : list
-        Contains a list of [order, filter, min wave, max wave]
-    order : list
-        A list of orders that are available and described in the file
-    extract_orders : list
-        A list of filters and the orders that should be extracted by default
-    wunits : `~astropy.units`
-        The units for the wavelength data
-
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavelengthrange.schema"
@@ -589,6 +649,25 @@ class WavelengthrangeModel(ReferenceFileModel):
         wunits=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None.
+        wrange : list
+            Contains a list of [order, filter, min wave, max wave]
+        order : list
+            A list of orders that are available and described in the file
+        extract_orders : list
+            A list of filters and the orders that should be extracted by default
+        wunits : `~astropy.units`
+            The units for the wavelength data
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel
+        """
         super().__init__(init=init, **kwargs)
         if wrange_selector is not None:
             self.waverange_selector = wrange_selector
@@ -618,7 +697,8 @@ class WavelengthrangeModel(ReferenceFileModel):
                 warnings.warn(traceback.format_exc(), ValidationWarning, stacklevel=2)
 
     def get_wfss_wavelength_range(self, filter_name, orders):
-        """Retrieve the wavelength range for a WFSS observation.
+        """
+        Retrieve the wavelength range for a WFSS observation.
 
         Parameters
         ----------
@@ -644,14 +724,25 @@ class WavelengthrangeModel(ReferenceFileModel):
 
 
 class FPAModel(ReferenceFileModel):
-    """
-    A model for a NIRSPEC reference file of type "fpa".
-    """
+    """A model for a NIRSPEC reference file of type "fpa"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fpa.schema"
     reftype = "fpa"
 
     def __init__(self, init=None, nrs1_model=None, nrs2_model=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        nrs1_model : `~astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        nrs2_model : `~astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        """
         super().__init__(init=init, **kwargs)
         if nrs1_model is not None:
             self.nrs1_model = nrs1_model
@@ -687,28 +778,34 @@ class FPAModel(ReferenceFileModel):
 
 
 class IFUPostModel(ReferenceFileModel):
-    """
-    A model for a NIRSPEC reference file of type "ifupost".
-
-    Parameters
-    ----------
-    init : str
-        A file name.
-    slice_models : dict
-        A dictionary with slice transforms with the following entries
-        {"slice_N": {'linear': astropy.modeling.Model,
-        ...         'xpoly': astropy.modeling.Model,
-        ...         'xpoly_distortion': astropy.modeling.Model,
-        ...         'ypoly': astropy.modeling.Model,
-        ...         'ypoly_distortion': astropy.modeling.Model,
-        ...         }}
-
-    """
+    """A model for a NIRSPEC reference file of type "ifupost"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifupost.schema"
     reftype = "ifupost"
 
     def __init__(self, init=None, slice_models=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        slice_models : dict
+            A dictionary with slice transforms with the following entries
+            {"slice_N": {'linear': astropy.modeling.Model,
+            ...         'xpoly': astropy.modeling.Model,
+            ...         'xpoly_distortion': astropy.modeling.Model,
+            ...         'ypoly': astropy.modeling.Model,
+            ...         'ypoly_distortion': astropy.modeling.Model,
+            ...         }}
+
+        Raises
+        ------
+        ValueError
+            If the number of slice models is not 30.
+        """
         super().__init__(init=init, **kwargs)
         if slice_models is not None:
             if len(slice_models) != 30:
@@ -736,14 +833,27 @@ class IFUPostModel(ReferenceFileModel):
 
 
 class IFUSlicerModel(ReferenceFileModel):
-    """
-    A model for a NIRSPEC reference file of type "ifuslicer".
-    """
+    """A model for a NIRSPEC reference file of type "ifuslicer"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuslicer.schema"
     reftype = "ifuslicer"
 
     def __init__(self, init=None, model=None, data=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        model : `~astropy.modeling.core.Model`, optional
+            ADD HERE, by default None
+        data : np.ndarray, optional
+            ADD HERE, by default None
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel.
+        """
         super().__init__(init=init, **kwargs)
         if model is not None:
             self.model = model
@@ -769,14 +879,27 @@ class IFUSlicerModel(ReferenceFileModel):
 
 
 class MSAModel(ReferenceFileModel):
-    """
-    A model for a NIRSPEC reference file of type "msa".
-    """
+    """A model for a NIRSPEC reference file of type "msa"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/msa.schema"
     reftype = "msa"
 
     def __init__(self, init=None, models=None, data=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        models : dict, optional
+            ADD HERE, by default None
+        data : dict, optional
+            ADD HERE, by default None
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel.
+        """
         super().__init__(init=init, **kwargs)
         if models is not None and data is not None:
             self.Q1 = {"model": models["Q1"], "data": data["Q1"]}
@@ -806,9 +929,7 @@ class MSAModel(ReferenceFileModel):
 
 
 class DisperserModel(ReferenceFileModel):
-    """
-    A model for a NIRSPEC reference file of type "disperser".
-    """
+    """A model for a NIRSPEC reference file of type "disperser"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/disperser.schema"
     reftype = "disperser"
@@ -830,6 +951,41 @@ class DisperserModel(ReferenceFileModel):
         groovedensity=None,
         **kwargs,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        angle : float, optional
+            ADD HERE, by default None
+        gwa_tiltx : float, optional
+            ADD HERE, by default None
+        gwa_tilty : float, optional
+            ADD HERE, by default None
+        kcoef : list, optional
+            ADD HERE, by default None
+        lcoef : list, optional
+            ADD HERE, by default None
+        tcoef : list, optional
+            ADD HERE, by default None
+        pref : float, optional
+            ADD HERE, by default None
+        tref : float, optional
+            ADD HERE, by default None
+        theta_x : float, optional
+            ADD HERE, by default None
+        theta_y : float, optional
+            ADD HERE, by default None
+        theta_z : float, optional
+            ADD HERE, by default None
+        groovedensity : float, optional
+            ADD HERE, by default None
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel.
+        """
         super().__init__(init=init, **kwargs)
         if groovedensity is not None:
             self.groovedensity = groovedensity
@@ -897,14 +1053,27 @@ class DisperserModel(ReferenceFileModel):
 
 
 class FilteroffsetModel(ReferenceFileModel):
-    """
-    A model for filter-dependent boresight offsets.
-    """
+    """A model for filter-dependent boresight offsets."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/filteroffset.schema"
     reftype = "filteroffset"
 
     def __init__(self, init=None, filters=None, instrument=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        filters : dict, optional
+            ADD HERE, by default None
+        instrument : str, optional
+            The instrument for which the filter offsets are defined, by default None
+        **kwargs : dict
+            Additional keyword arguments to pass to ReferenceFileModel.
+        """
         super().__init__(init, **kwargs)
         if filters is not None:
             self.filters = filters
@@ -953,9 +1122,7 @@ class FilteroffsetModel(ReferenceFileModel):
 
 
 class IFUFOREModel(_SimpleModel):
-    """
-    A model for a NIRSPEC reference file of type "ifufore".
-    """
+    """A model for a NIRSPEC reference file of type "ifufore"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifufore.schema"
     reftype = "ifufore"
@@ -968,9 +1135,7 @@ class IFUFOREModel(_SimpleModel):
 
 
 class CameraModel(_SimpleModel):
-    """
-    A model for a reference file of type "camera".
-    """
+    """A model for a reference file of type "camera"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/camera.schema"
     reftype = "camera"
@@ -985,9 +1150,7 @@ class CameraModel(_SimpleModel):
 
 
 class CollimatorModel(_SimpleModel):
-    """
-    A model for a reference file of type "collimator".
-    """
+    """A model for a reference file of type "collimator"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/collimator.schema"
     reftype = "collimator"
@@ -1002,9 +1165,7 @@ class CollimatorModel(_SimpleModel):
 
 
 class OTEModel(_SimpleModel):
-    """
-    A model for a reference file of type "ote".
-    """
+    """A model for a reference file of type "ote"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ote.schema"
     reftype = "ote"
@@ -1019,9 +1180,7 @@ class OTEModel(_SimpleModel):
 
 
 class FOREModel(_SimpleModel):
-    """
-    A model for a reference file of type "fore".
-    """
+    """A model for a reference file of type "fore"."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fore.schema"
     reftype = "fore"
@@ -1057,10 +1216,23 @@ class FOREModel(_SimpleModel):
 
 
 class WaveCorrModel(ReferenceFileModel):
+    """Model for the reference file for the wavecorr step."""
+
     reftype = "wavecorr"
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavecorr.schema"
 
     def __init__(self, init=None, apertures=None, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+            The data from which to initialize the model. Can be of any type that
+            is supported by DataModel, by default None
+        apertures : ADD HERE, optional
+            ADD HERE, by default None
+        """
         super().__init__(init, **kwargs)
         if apertures is not None:
             self.apertures = apertures
@@ -1069,6 +1241,14 @@ class WaveCorrModel(ReferenceFileModel):
 
     @property
     def aperture_names(self):
+        """
+        Return the names of the apertures.
+
+        Returns
+        -------
+        list
+            A list of aperture names
+        """
         return [getattr(ap, "aperture_name") for ap in self.apertures]  # noqa: B009
 
     def populate_meta(self):

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -45,7 +45,7 @@ class _SimpleModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
+        init : str, None, optional
             The data from which to initialize the model. Can be of any type that
             is supported by DataModel, by default None.
         model : `astropy.modeling.core.Model` or list[Model], optional
@@ -160,21 +160,24 @@ class DistortionMRSModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         x_model : `astropy.modeling.core.Model`, optional
-            TODO, by default None
+            Transform between the 'detector' frame and the frame associated with
+            the local channel cube 'alpha', by default None.
         y_model : `astropy.modeling.core.Model`, optional
-            TODO, by default None
+            Transform between the 'detector' frame and the frame associated with
+            the local channel cube 'beta', by default None.
         alpha_model : `astropy.modeling.core.Model`, optional
-            TODO, by default None
+            Transform between the local channel frame and the global instrument frame
+            on the sky, by default None.
         beta_model : `astropy.modeling.core.Model`, optional
-            TODO, by default None
+            Transform between the local channel frame and the global instrument frame
+            on the sky, by default None.
         bzero : float, optional
-            TODO, by default None
+            Center of each slice in the local channel frame.
         bdel : float, optional
-            TODO, by default None
+            Slice width in the local channel frame.
         input_units : str or `~astropy.units.NamedUnit`, optional
             The units of the input, by default None
         output_units : str or `~astropy.units.NamedUnit`, optional
@@ -311,9 +314,8 @@ class NIRCAMGrismModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         displ : `~astropy.modeling.Model`
             Nircam Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
@@ -396,9 +398,8 @@ class NIRISSGrismModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         displ : `~astropy.modeling.Model`
             NIRISS Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
@@ -490,9 +491,8 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         wavetable : numpy  2-D array
             For each row in the slit hold  wavelength, and
             x center, ycenter, x and y box region corresponding to the wavelength
@@ -585,11 +585,10 @@ class RegionsModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         regions : np.ndarray, optional
-            TODO, by default None
+            An array mapping pixels to slices, by default None.
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel
         """
@@ -660,9 +659,8 @@ class WavelengthrangeModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         wrange : list
             Contains a list of [order, filter, min wave, max wave]
         order : list
@@ -741,13 +739,14 @@ class FPAModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         nrs1_model : `~astropy.modeling.core.Model`, optional
-            TODO, by default None
+            The transform from the NIRSpec focal plane array (FPA) to the camera
+            for the NRS1 detector, by default None.
         nrs2_model : `~astropy.modeling.core.Model`, optional
-            TODO, by default None
+            The transform from the NIRSpec focal plane array (FPA) to the camera
+            for the NRS2 detector, by default None.
         """
         super().__init__(init=init, **kwargs)
         if nrs1_model is not None:
@@ -795,9 +794,8 @@ class IFUPostModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         slice_models : dict
             A dictionary with slice transforms with the following entries
             {"slice_N": {'linear': astropy.modeling.Model,
@@ -806,6 +804,7 @@ class IFUPostModel(ReferenceFileModel):
             ...         'ypoly': astropy.modeling.Model,
             ...         'ypoly_distortion': astropy.modeling.Model,
             ...         }}
+            These are the transforms from the IFU slicer plane to the MSA frame.
 
         Raises
         ------
@@ -850,13 +849,14 @@ class IFUSlicerModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         model : `~astropy.modeling.core.Model`, optional
-            TODO, by default None
+            Transform from relative positions of each slice to
+            absolute positions within the exit plane of the slicer, by default None.
         data : np.ndarray, optional
-            TODO, by default None
+            Relative positions and sizes of each slice in the slicer frame,
+            by default None.
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -896,13 +896,14 @@ class MSAModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         models : dict, optional
-            TODO, by default None
+            Transform from relative positions of each shutter within the MSA plane
+            to absolute positions within the MSA, by default None.
         data : dict, optional
-            TODO, by default None
+            Relative positions and sizes of each shutter within the MSA plane,
+            by default None.
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -962,33 +963,34 @@ class DisperserModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
         angle : float, optional
-            TODO, by default None
-        gwa_tiltx : float, optional
-            TODO, by default None
-        gwa_tilty : float, optional
-            TODO, by default None
+            Angle between the front surface and back surface of the prism in degrees,
+            by default None.
+        gwa_tiltx, gwa_tilty : float, optional
+            Angles in x, y between the grating surface and the reference surface (MIRROR)
+            in degrees, by default None.
         kcoef : list, optional
-            TODO, by default None
+            Coefficients K1, K2, and K3 to describe the material of the prism,
+            by default None.
         lcoef : list, optional
-            TODO, by default None
+            Coefficients L1, L2, and L3 to describe the material of the prism,
+            by default None.
         tcoef : list, optional
-            TODO, by default None
+            Six constants (D0, D1, D2, E0, E1 and lambdak) to describe
+            the thermal behavior of the glass, by default None.
         pref : float, optional
-            TODO, by default None
+            Pressure (in atm) to compute the change in temperature relative to
+            the reference temperature of the prism glass, by default None.
         tref : float, optional
-            TODO, by default None
-        theta_x : float, optional
-            TODO, by default None
-        theta_y : float, optional
-            TODO, by default None
-        theta_z : float, optional
-            TODO, by default None
+            Temperature (in Kelvin) to compute the change in temperature relative to
+            the reference temperature of the prism glass, by default None.
+        theta_x, theta_y, theta_z : float, optional
+            Element alignment angles in the x-, y-, and z-axes in arcseconds,
+            by default None.
         groovedensity : float, optional
-            TODO, by default None
+            Number of grooves per meter, by default None
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -1070,13 +1072,12 @@ class FilteroffsetModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
-        filters : dict, optional
-            TODO, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
+        filters : list[dict], optional
+            Column and row offsets for each filter in pixels, by default None.
         instrument : str, optional
-            The instrument for which the filter offsets are defined, by default None
+            The instrument for which the filter offsets are defined, by default None.
         **kwargs : dict
             Additional keyword arguments to pass to ReferenceFileModel.
         """
@@ -1128,7 +1129,13 @@ class FilteroffsetModel(ReferenceFileModel):
 
 
 class IFUFOREModel(_SimpleModel):
-    """A model for a NIRSPEC reference file of type "ifufore"."""
+    """
+    A model for a NIRSPEC reference file of type "ifufore".
+
+    This model provides the parameters (Paraxial and distortions coefficients)
+    for the coordinate transforms from the MSA plane (in)
+    to the plane of the IFU slicer.
+    """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifufore.schema"
     reftype = "ifufore"
@@ -1141,7 +1148,7 @@ class IFUFOREModel(_SimpleModel):
 
 
 class CameraModel(_SimpleModel):
-    """A model for a reference file of type "camera"."""
+    """Stores the transforms from the NIRSpec camera to the GWA."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/camera.schema"
     reftype = "camera"
@@ -1156,7 +1163,7 @@ class CameraModel(_SimpleModel):
 
 
 class CollimatorModel(_SimpleModel):
-    """A model for a reference file of type "collimator"."""
+    """Stores the transform through the NIRSpec collimator."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/collimator.schema"
     reftype = "collimator"
@@ -1171,7 +1178,7 @@ class CollimatorModel(_SimpleModel):
 
 
 class OTEModel(_SimpleModel):
-    """A model for a reference file of type "ote"."""
+    """Stores the transform from the Filter Wheel to the Optical Telescope Element."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ote.schema"
     reftype = "ote"
@@ -1186,7 +1193,7 @@ class OTEModel(_SimpleModel):
 
 
 class FOREModel(_SimpleModel):
-    """A model for a reference file of type "fore"."""
+    """Stores the transform from the MSA plane to the Filter Wheel."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fore.schema"
     reftype = "fore"
@@ -1222,7 +1229,7 @@ class FOREModel(_SimpleModel):
 
 
 class WaveCorrModel(ReferenceFileModel):
-    """Model for the reference file for the wavecorr step."""
+    """Wavelength zero-point correction for the position of a point source in a NIRSpec slit."""
 
     reftype = "wavecorr"
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wavecorr.schema"
@@ -1233,11 +1240,15 @@ class WaveCorrModel(ReferenceFileModel):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None, optional
-            The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None
-        apertures : TODO, optional
-            TODO, by default None
+        init : str, None, optional
+            Input file name in ASDF format from which to initialize the model.
+        apertures : list[dict], optional
+            Each aperture is a dict with keys:
+            * aperture_name : str, the name of the aperture.
+            * width : float, the aperture or pitch width in meters.
+            * zero_point_offset : astropy.Tabular2D model,
+              a lookup table for the wavelength correction.
+            * variance : the variance of the correction.
         """
         super().__init__(init, **kwargs)
         if apertures is not None:

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -47,13 +47,13 @@ class _SimpleModel(ReferenceFileModel):
         ----------
         init : str, None, optional
             The data from which to initialize the model. Can be of any type that
-            is supported by DataModel, by default None.
+            is supported by DataModel.
         model : `astropy.modeling.core.Model` or list[Model], optional
-            The transform as an astropy Model, by default None
+            The transform as an astropy Model
         input_units : str or `~astropy.units.NamedUnit`, optional
-            The units of the input, by default None
+            The units of the input
         output_units : str or `~astropy.units.NamedUnit`, optional
-            The units of the output, by default None
+            The units of the output
         """
         super(_SimpleModel, self).__init__(init=init, **kwargs)
         if model is not None:
@@ -78,7 +78,7 @@ class _SimpleModel(ReferenceFileModel):
         Parameters
         ----------
         path : str, optional
-            Not used, only here to match the signature of the parent class, by default None.
+            Not used, only here to match the signature of the parent class
         """
         self.meta.reftype = self.reftype
 
@@ -91,7 +91,7 @@ class _SimpleModel(ReferenceFileModel):
         raise NotImplementedError
 
     def to_fits(self):
-        """Override base class to specify that reference files are not writable to fits."""
+        """Override base class to specify that reference files are not writable to FITS."""
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -161,27 +161,27 @@ class DistortionMRSModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         x_model : `astropy.modeling.core.Model`, optional
             Transform between the 'detector' frame and the frame associated with
-            the local channel cube 'alpha', by default None.
+            the local channel cube 'alpha'
         y_model : `astropy.modeling.core.Model`, optional
             Transform between the 'detector' frame and the frame associated with
-            the local channel cube 'beta', by default None.
+            the local channel cube 'beta'
         alpha_model : `astropy.modeling.core.Model`, optional
             Transform between the local channel frame and the global instrument frame
-            on the sky, by default None.
+            on the sky
         beta_model : `astropy.modeling.core.Model`, optional
             Transform between the local channel frame and the global instrument frame
-            on the sky, by default None.
+            on the sky
         bzero : float, optional
             Center of each slice in the local channel frame.
         bdel : float, optional
             Slice width in the local channel frame.
         input_units : str or `~astropy.units.NamedUnit`, optional
-            The units of the input, by default None
+            The units of the input
         output_units : str or `~astropy.units.NamedUnit`, optional
-            The units of the output, by default None
+            The units of the output
         """
         super().__init__(init=init, **kwargs)
 
@@ -315,7 +315,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         displ : `~astropy.modeling.Model`
             Nircam Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
@@ -331,7 +331,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
         orders : `~astropy.modeling.Model`
             NIRCAM Grism orders, matched to the array locations of the
             dispersion models
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel
         """
         super().__init__(init=init, **kwargs)
@@ -399,7 +399,7 @@ class NIRISSGrismModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         displ : `~astropy.modeling.Model`
             NIRISS Grism wavelength dispersion model
         dispx : `~astropy.modeling.Model`
@@ -413,7 +413,7 @@ class NIRISSGrismModel(ReferenceFileModel):
             dispersion models
         fwcpos_ref : float
             The reference value for the filter wheel position
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel
         """
         super().__init__(init=init, **kwargs)
@@ -492,7 +492,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         wavetable : numpy  2-D array
             For each row in the slit hold  wavelength, and
             x center, ycenter, x and y box region corresponding to the wavelength
@@ -520,7 +520,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
             Slit vertex 3 in V3 frames
         v3_vert4 : float
             Slit vertex 4 in V3 frames
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel.
         """
         super().__init__(init=init, **kwargs)
@@ -586,10 +586,10 @@ class RegionsModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         regions : np.ndarray, optional
-            An array mapping pixels to slices, by default None.
-        **kwargs : dict
+            An array mapping pixels to slices
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel
         """
         super().__init__(init=init, **kwargs)
@@ -660,7 +660,7 @@ class WavelengthrangeModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         wrange : list
             Contains a list of [order, filter, min wave, max wave]
         order : list
@@ -669,7 +669,7 @@ class WavelengthrangeModel(ReferenceFileModel):
             A list of filters and the orders that should be extracted by default
         wunits : `~astropy.units`
             The units for the wavelength data
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel
         """
         super().__init__(init=init, **kwargs)
@@ -740,13 +740,13 @@ class FPAModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         nrs1_model : `~astropy.modeling.core.Model`, optional
             The transform from the NIRSpec focal plane array (FPA) to the camera
-            for the NRS1 detector, by default None.
+            for the NRS1 detector
         nrs2_model : `~astropy.modeling.core.Model`, optional
             The transform from the NIRSpec focal plane array (FPA) to the camera
-            for the NRS2 detector, by default None.
+            for the NRS2 detector
         """
         super().__init__(init=init, **kwargs)
         if nrs1_model is not None:
@@ -795,7 +795,7 @@ class IFUPostModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         slice_models : dict
             A dictionary with slice transforms with the following entries
             {"slice_N": {'linear': astropy.modeling.Model,
@@ -850,14 +850,13 @@ class IFUSlicerModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         model : `~astropy.modeling.core.Model`, optional
             Transform from relative positions of each slice to
-            absolute positions within the exit plane of the slicer, by default None.
+            absolute positions within the exit plane of the slicer
         data : np.ndarray, optional
-            Relative positions and sizes of each slice in the slicer frame,
-            by default None.
-        **kwargs : dict
+            Relative positions and sizes of each slice in the slicer frame
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel.
         """
         super().__init__(init=init, **kwargs)
@@ -897,14 +896,13 @@ class MSAModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         models : dict, optional
             Transform from relative positions of each shutter within the MSA plane
-            to absolute positions within the MSA, by default None.
+            to absolute positions within the MSA
         data : dict, optional
-            Relative positions and sizes of each shutter within the MSA plane,
-            by default None.
-        **kwargs : dict
+            Relative positions and sizes of each shutter within the MSA plane
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel.
         """
         super().__init__(init=init, **kwargs)
@@ -964,34 +962,30 @@ class DisperserModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         angle : float, optional
-            Angle between the front surface and back surface of the prism in degrees,
-            by default None.
+            Angle between the front surface and back surface of the prism in degrees
         gwa_tiltx, gwa_tilty : float, optional
             Angles in x, y between the grating surface and the reference surface (MIRROR)
-            in degrees, by default None.
+            in degrees
         kcoef : list, optional
-            Coefficients K1, K2, and K3 to describe the material of the prism,
-            by default None.
+            Coefficients K1, K2, and K3 to describe the material of the prism
         lcoef : list, optional
-            Coefficients L1, L2, and L3 to describe the material of the prism,
-            by default None.
+            Coefficients L1, L2, and L3 to describe the material of the prism
         tcoef : list, optional
-            Six constants (D0, D1, D2, E0, E1 and lambdak) to describe
-            the thermal behavior of the glass, by default None.
+            Six constants (D0, D1, D2, E0, E1 and lambda_k) to describe
+            the thermal behavior of the glass
         pref : float, optional
             Pressure (in atm) to compute the change in temperature relative to
-            the reference temperature of the prism glass, by default None.
+            the reference temperature of the prism glass
         tref : float, optional
             Temperature (in Kelvin) to compute the change in temperature relative to
-            the reference temperature of the prism glass, by default None.
+            the reference temperature of the prism glass
         theta_x, theta_y, theta_z : float, optional
-            Element alignment angles in the x-, y-, and z-axes in arcseconds,
-            by default None.
+            Element alignment angles in the x-, y-, and z-axes in arcseconds
         groovedensity : float, optional
-            Number of grooves per meter, by default None
-        **kwargs : dict
+            Number of grooves per meter
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel.
         """
         super().__init__(init=init, **kwargs)
@@ -1073,12 +1067,12 @@ class FilteroffsetModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         filters : list[dict], optional
-            Column and row offsets for each filter in pixels, by default None.
+            Column and row offsets for each filter in pixels
         instrument : str, optional
-            The instrument for which the filter offsets are defined, by default None.
-        **kwargs : dict
+            The instrument for which the filter offsets are defined
+        **kwargs
             Additional keyword arguments to pass to ReferenceFileModel.
         """
         super().__init__(init, **kwargs)
@@ -1132,7 +1126,7 @@ class IFUFOREModel(_SimpleModel):
     """
     A model for a NIRSPEC reference file of type "ifufore".
 
-    This model provides the parameters (Paraxial and distortions coefficients)
+    This model provides the parameters (paraxial and distortion coefficients)
     for the coordinate transforms from the MSA plane (in)
     to the plane of the IFU slicer.
     """
@@ -1241,7 +1235,7 @@ class WaveCorrModel(ReferenceFileModel):
         Parameters
         ----------
         init : str, None, optional
-            Input file name in ASDF format from which to initialize the model.
+            File name for input file in ASDF format from which to initialize the model.
         apertures : list[dict], optional
             Each aperture is a dict with keys:
             * aperture_name : str, the name of the aperture.

--- a/src/stdatamodels/jwst/datamodels/wfssbkg.py
+++ b/src/stdatamodels/jwst/datamodels/wfssbkg.py
@@ -7,23 +7,7 @@ __all__ = ["WfssBkgModel"]
 
 
 class WfssBkgModel(ReferenceFileModel):
-    """
-    A data model for 2D WFSS master background reference files.
-
-    Parameters
-    __________
-    data : numpy float32 array
-         The science data
-
-    dq : numpy uint32 array
-         Data quality array
-
-    err : numpy float32 array
-         Error array
-
-    dq_def : numpy table
-         DQ flag definitions
-    """
+    """A data model for 2D WFSS master background reference files."""
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wfssbkg.schema"
 

--- a/src/stdatamodels/jwst/datamodels/wfssbkg.py
+++ b/src/stdatamodels/jwst/datamodels/wfssbkg.py
@@ -7,7 +7,20 @@ __all__ = ["WfssBkgModel"]
 
 
 class WfssBkgModel(ReferenceFileModel):
-    """A data model for 2D WFSS master background reference files."""
+    """
+    A data model for 2D WFSS master background reference files.
+
+    Attributes
+    ----------
+    data : numpy float32 array
+         The science data
+    dq : numpy uint32 array
+         Data quality array
+    err : numpy float32 array
+         Error array
+    dq_def : numpy table
+         DQ flag definitions
+    """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wfssbkg.schema"
 

--- a/src/stdatamodels/jwst/transforms/__init__.py
+++ b/src/stdatamodels/jwst/transforms/__init__.py
@@ -1,1 +1,2 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Custom Astropy modeling transforms for JWST."""

--- a/src/stdatamodels/jwst/transforms/converters/__init__.py
+++ b/src/stdatamodels/jwst/transforms/converters/__init__.py
@@ -1,3 +1,4 @@
+"""Convert models to and from YAML tree structures."""
 # from .jwst_models import (Gwa2SlitConverter, Slit2MsaConverter, LogicalConverter,
 #                           NirissSOSSConverter, RefractionIndexConverter,
 #                           MIRI_AB2SliceConverter, NIRCAMGrismDispersionConverter,

--- a/src/stdatamodels/jwst/transforms/integration.py
+++ b/src/stdatamodels/jwst/transforms/integration.py
@@ -1,6 +1,4 @@
-"""
-This module supports the entry points for ASDF support for the `jwst.transforms`.
-"""
+"""Create the entry points for ASDF support for the `jwst.transforms`."""
 
 import importlib.resources
 
@@ -40,11 +38,13 @@ def get_resource_mappings():
 def get_extensions():
     """
     Get the jwst.transforms extension.
+
     This method is registered with the asdf.extensions entry point.
 
     Returns
     -------
     list of asdf.extension.Extension
+        The jwst.transforms extensions.
     """
     from . import extensions
 

--- a/src/stdatamodels/jwst/transforms/integration.py
+++ b/src/stdatamodels/jwst/transforms/integration.py
@@ -16,8 +16,8 @@ def get_resource_mappings():
 
     Returns
     -------
-    list of the `asdf.resource.ResourceMapping` instances containing the `jwst.transforms`
-    schemas.
+    list
+        The `asdf.resource.ResourceMapping` instances containing the `jwst.transforms` schemas.
     """
     resources_root = importlib.resources.files(transforms) / "resources"
     if not resources_root.is_dir():

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -256,7 +256,7 @@ class MIRI_AB2Slice(Model):  # noqa: N801
             Slice width.
         channel : int
             MIRI MRS channel number. Valid values are 1, 2, 3, 4.
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to Model.
         """
         super().__init__(beta_zero=beta_zero, beta_del=beta_del, channel=channel, **kwargs)
@@ -310,7 +310,7 @@ class RefractionIndexFromPrism(Model):
         prism_angle : float
             Prism angle in degrees.
         name : str, optional
-            Name of the model, by default None
+            Name of the model
         """
         super(RefractionIndexFromPrism, self).__init__(prism_angle=prism_angle, name=name)
         self.inputs = (
@@ -636,7 +636,7 @@ class Logical(Model):
             same shape.
         value : float, ndarray
             Value to substitute where condition is True.
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to Model.
         """
         self.condition = condition.upper()
@@ -648,7 +648,7 @@ class Logical(Model):
 
     def evaluate(self, x):
         """
-        Compare x to compareto and substitute value where condition is True.
+        Compare x to ``compareto`` and substitute value where condition is True.
 
         Parameters
         ----------
@@ -682,7 +682,7 @@ class IdealToV2V3(Model):
 
     The two systems have the same origin: V2_REF, V3_REF.
 
-    Note that this model has no schema implemented - add schema if needed.
+    Note that this model has no schema implemented.
     """
 
     _separable = False
@@ -740,7 +740,7 @@ class V2V3ToIdeal(Model):
 
     The two systems have the same origin - V2_REF, V3_REF.
 
-    Note that this model has no schema implemented - add if needed.
+    Note that this model has no schema implemented.
     """
 
     _separable = False
@@ -878,7 +878,7 @@ class NIRCAMForwardRowGrismDispersion(Model):
         inv_ymodels : list [astropy.modeling.Model]
             List of models which will be used if inverse ymodels cannot be analytically derived
         name : str, optional
-            Name of the model, by default None
+            Name of the model
         meta : dict, optional
             Unused
         """
@@ -903,9 +903,9 @@ class NIRCAMForwardRowGrismDispersion(Model):
 
         Parameters
         ----------
-        x, y :  int,float,list
+        x, y :  int, float, list
             Input x, y location
-        x0, y0 : int,float,list
+        x0, y0 : int, float, list
             Source object x-center, y-center
         order : int
             Input spectral order
@@ -1052,7 +1052,7 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         inv_ymodels : list [astropy.modeling.Model]
             List of models which will be used if inverse ymodels cannot be analytically derived
         name : str, optional
-            Name of the model, by default None
+            Name of the model
         meta : dict, optional
             Unused
         """
@@ -1077,9 +1077,9 @@ class NIRCAMForwardColumnGrismDispersion(Model):
 
         Parameters
         ----------
-        x, y :  int,float,list
+        x, y :  int, float, list
             Input x, y location
-        x0, y0 : int,float,list
+        x0, y0 : int, float, list
             Source object x-center, y-center
         order : int
             Input spectral order
@@ -1231,7 +1231,7 @@ class NIRCAMBackwardGrismDispersion(Model):
             List of models which will be used if inverse ymodels
             cannot be analytically derived
         name : str, optional
-            Name of the model, by default None.
+            Name of the model
         meta : dict
             Unused
         """
@@ -1375,7 +1375,7 @@ class NIRISSBackwardGrismDispersion(Model):
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str, optional
-            Name of the model, by default None.
+            Name of the model
         meta : dict
             Unused
         """
@@ -1483,7 +1483,7 @@ class NIRISSForwardRowGrismDispersion(Model):
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str, optional
-            Name of the model, by default None.
+            Name of the model
         meta : dict
             Unused
         """
@@ -1507,9 +1507,9 @@ class NIRISSForwardRowGrismDispersion(Model):
 
         Parameters
         ----------
-        x, y :  int,float,list
+        x, y :  int, float, list
             Input x, y location
-        x0, y0 : int,float,list
+        x0, y0 : int, float, list
             Source object x-center, y-center
         order : int
             Input spectral order
@@ -1604,7 +1604,7 @@ class NIRISSForwardColumnGrismDispersion(Model):
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str
-            The name of the model, by default None.
+            The name of the model
         meta : dict
             Unused.
         """
@@ -1628,9 +1628,9 @@ class NIRISSForwardColumnGrismDispersion(Model):
 
         Parameters
         ----------
-        x, y :  int,float
+        x, y :  int, float
             Input x,y location
-        x0, y0 : int,float
+        x0, y0 : int, float
             Source object x-center, y-center
         order : int
             Input spectral order
@@ -1774,7 +1774,7 @@ class Rotation3DToGWA(Model):
 
 
 class Snell(Model):
-    """Apply transforms, including Snell law, through the NIRSpec prism."""
+    """Apply transforms, including Snell's law, through the NIRSpec prism."""
 
     standard_broadcasting = False
     _separable = False
@@ -1805,7 +1805,7 @@ class Snell(Model):
         pressure : float
             System pressure during observation in ATM.
         name : str, optional
-            Name of the model, by default None.
+            Name of the model
         """
         self.prism_angle = angle
         self.kcoef = np.array(kcoef, dtype=float)
@@ -1977,7 +1977,7 @@ class AngleFromGratingEquation(Model):
             Grating ruling density.
         order : int
             Spectral order.
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to Model base class.
         """
         super().__init__(groove_density=groove_density, order=order, **kwargs)
@@ -2041,7 +2041,7 @@ class WavelengthFromGratingEquation(Model):
             Grating ruling density.
         order : int
             Spectral order.
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments to pass to Model base class.
         """
         super().__init__(groove_density=groove_density, order=order, **kwargs)
@@ -2112,7 +2112,7 @@ class Rotation3D(Model):
             axis of rotation and matching the order in ``angles``.
             The axes are "zyxyz".
         name : str, optional
-            The name of the transform, by default None.
+            The name of the transform
         """
         self.axes = ["x", "y", "z"]
         unrecognized = set(axes_order).difference(self.axes)
@@ -2243,7 +2243,7 @@ class V23ToSky(Rotation3D):
             axis of rotation and matching the order in ``angles``.
             The axes are "zyxyz".
         name : str, optional
-            The name of the transform, by default None.
+            The name of the transform
         """
         super(V23ToSky, self).__init__(angles, axes_order=axes_order, name=name)
         self._inputs = ("v2", "v3")

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -119,37 +119,8 @@ class GrismObject(
         rename=False,
     )
 ):
-    """Grism Objects identified from a direct image catalog and segment map.
-
-    Parameters
-    ----------
-    sid : int
-        source identified
-    xcentroid : float
-        x center of object in pixels
-    ycentroid : float
-        y center of object in pixels
-    order_bounding : dict{order: tuple}
-        Contains the object x,y bounding locations on the image
-        keyed on spectral order
-    partial_order : bool
-        True if the order is only partially contained on the image
-    waverange : list
-        wavelength range for the order
-    is_extended : bool
-        True if marked as extended in the source catalog
-    isophotal_abmag : float
-        isophotal_abmag from the source catalog
-    sky_centroid: `~astropy.coordinates.SkyCoord`
-        ra and dec of the center of the object
-    sky_bbox_ll : `~astropy.coordinates.SkyCoord`
-        Lower left corner of the minimum bounding box
-    sky_bbox_lr : `~astropy.coordinates.SkyCoord`
-        Lower right corder of the minimum bounding box
-    sky_bbox_ul : `~astropy.coordinates.SkyCoord`
-        Upper left corner of the minimum bounding box
-    sky_bbox_ur : `~astropy.coordinates.SkyCoord`
-        Upper right corner of the minimum bounding box
+    """
+    Grism Objects identified from a direct image catalog and segment map.
 
     Notes
     -----
@@ -185,6 +156,44 @@ class GrismObject(
         is_extended=None,
         isophotal_abmag=None,
     ):
+        """
+        Create a new GrismObject.
+
+        Parameters
+        ----------
+        sid : int
+            source identified
+        order_bounding : dict{order: tuple}
+            Contains the object x,y bounding locations on the image
+            keyed on spectral order
+        sky_centroid: `~astropy.coordinates.SkyCoord`
+            ra and dec of the center of the object
+        partial_order : bool
+            True if the order is only partially contained on the image
+        waverange : list
+            wavelength range for the order
+        sky_bbox_ll : `~astropy.coordinates.SkyCoord`
+            Lower left corner of the minimum bounding box
+        sky_bbox_lr : `~astropy.coordinates.SkyCoord`
+            Lower right corder of the minimum bounding box
+        sky_bbox_ul : `~astropy.coordinates.SkyCoord`
+            Upper left corner of the minimum bounding box
+        sky_bbox_ur : `~astropy.coordinates.SkyCoord`
+            Upper right corner of the minimum bounding box
+        xcentroid : float
+            x center of object in pixels
+        ycentroid : float
+            y center of object in pixels
+        is_extended : bool
+            True if marked as extended in the source catalog
+        isophotal_abmag : float
+            isophotal_abmag from the source catalog
+
+        Returns
+        -------
+        GrismObject
+            A new GrismObject instance.
+        """
         return super(GrismObject, cls).__new__(
             cls,
             sid=sid,
@@ -222,14 +231,7 @@ class GrismObject(
 
 
 class MIRI_AB2Slice(Model):  # noqa: N801
-    """
-    MIRI MRS alpha, beta to slice transform
-
-    Parameters
-    ----------
-    beta_zero : float
-    beta_del : float
-    """
+    """MIRI MRS alpha, beta to slice transform."""
 
     standard_broadcasting = False
     _separable = False
@@ -246,6 +248,20 @@ class MIRI_AB2Slice(Model):  # noqa: N801
     """ MIRI MRS channel: one of 1, 2, 3, 4"""
 
     def __init__(self, beta_zero=beta_zero, beta_del=beta_del, channel=channel, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        beta_zero : float
+            Beta zero parameter. ADD HERE
+        beta_del : float
+            Beta delta parameter. ADD HERE
+        channel : int
+            MIRI MRS channel
+        **kwargs : dict
+            Additional keyword arguments to pass to Model.
+        """
         super().__init__(beta_zero=beta_zero, beta_del=beta_del, channel=channel, **kwargs)
         self.inputs = ("beta",)
         """ "beta": the beta angle """
@@ -254,20 +270,31 @@ class MIRI_AB2Slice(Model):  # noqa: N801
 
     @staticmethod
     def evaluate(beta, beta_zero, beta_del, channel):
+        """
+        Convert beta to slice number.
+
+        Parameters
+        ----------
+        beta : float
+            The beta angle. ADD HERE
+        beta_zero : float
+            Beta zero parameter. ADD HERE
+        beta_del : float
+            Beta delta parameter. ADD HERE
+        channel : int
+            MIRI MRS channel. ADD HERE
+
+        Returns
+        -------
+        int
+            The slice number.
+        """
         s = channel * 100 + (beta - beta_zero) / beta_del + 1
         return _toindex(s)
 
 
 class RefractionIndexFromPrism(Model):
-    """
-    Compute the refraction index of a prism (NIRSpec).
-
-    Parameters
-    ----------
-    prism_angle : float
-        Prism angle in deg.
-
-    """
+    """Compute the refraction index of a prism (NIRSpec)."""
 
     standard_broadcasting = False
     _separable = False
@@ -278,6 +305,16 @@ class RefractionIndexFromPrism(Model):
     prism_angle = Parameter(setter=np.deg2rad, getter=np.rad2deg)
 
     def __init__(self, prism_angle, name=None):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        prism_angle : float
+            Prism angle in degrees.
+        name : str, optional
+            Name of the model, by default None
+        """
         super(RefractionIndexFromPrism, self).__init__(prism_angle=prism_angle, name=name)
         self.inputs = (
             "alpha_in",
@@ -287,6 +324,23 @@ class RefractionIndexFromPrism(Model):
         self.outputs = ("n",)
 
     def evaluate(self, alpha_in, beta_in, alpha_out, prism_angle):
+        """
+        Compute the refraction index of a prism.
+
+        Parameters
+        ----------
+        alpha_in, beta_in : float
+            Angle of incidence in radians.
+        alpha_out : float
+            Angle of emergence in radians.
+        prism_angle : float
+            Prism angle in radians.
+
+        Returns
+        -------
+        float
+            Refraction index of the prism.
+        """
         # prism_angle is always a 1 element numpy array
         sangle = math.sin(prism_angle.item())
         cangle = math.cos(prism_angle.item())
@@ -340,37 +394,62 @@ class Gwa2Slit(Model):
 
     @property
     def slits(self):
+        """
+        Return the slits.
+
+        Returns
+        -------
+        list
+            List of `~stdatamodels.jwst.transforms.models.Slit` objects.
+        """
         if isiterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids
 
     def get_model(self, name):
+        """
+        Retrieve the model for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+
+        Returns
+        -------
+        `~astropy.modeling.core.Model`
+            Model for the given slit.
+        """
         index = self.slit_ids.index(name)
         return self.models[index]
 
     def evaluate(self, name, x, y, z):
+        """
+        Compute the x and y coordinates in the MSA frame for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+        x, y z : float
+            The three angle coordinates at the GWA going from detector to sky.
+
+        Returns
+        -------
+        name : str
+            Name of the slit.
+        x_slit, y_slit : float
+            x and y coordinates within the virtual slit.
+        lam : float
+            Wavelength.
+        """
         index = self.slit_ids.index(name)
         return (name,) + self.models[index](x, y, z)
 
 
 class Slit2Msa(Model):
-    """
-    Transform from Nirspec ``slit_frame`` to ``msa_frame``.
-
-    Parameters
-    ----------
-    slits : list
-        A list of open slits.
-        A slit is a namedtuple, `~stdatamodels.jwst.transforms.models.Slit`
-        Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
-        "quadrant", "source_id", "shutter_state", "source_name",
-        "source_alias", "stellarity", "source_xpos", "source_ypos",
-        "source_ra", "source_dec")
-    models : list
-        List of models (`~astropy.modeling.core.Model`) corresponding to the
-        list of slits.
-    """
+    """Transform from Nirspec ``slit_frame`` to ``msa_frame``."""
 
     _separable = False
 
@@ -378,6 +457,22 @@ class Slit2Msa(Model):
     n_outputs = 2
 
     def __init__(self, slits, models):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        slits : list
+            A list of open slits.
+            A slit is a namedtuple, `~stdatamodels.jwst.transforms.models.Slit`
+            Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
+            "quadrant", "source_id", "shutter_state", "source_name",
+            "source_alias", "stellarity", "source_xpos", "source_ypos",
+            "source_ra", "source_dec")
+        models : list
+            List of models (`~astropy.modeling.core.Model`) corresponding to the
+            list of slits.
+        """
         super(Slit2Msa, self).__init__()
         self.inputs = ("name", "x_slit", "y_slit")
         """ Name of the slit, x and y coordinates within the virtual slit."""
@@ -393,33 +488,58 @@ class Slit2Msa(Model):
 
     @property
     def slits(self):
+        """
+        Return the slits.
+
+        Returns
+        -------
+        list
+            List of `~stdatamodels.jwst.transforms.models.Slit` objects.
+        """
         if isiterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids
 
     def get_model(self, name):
+        """
+        Retrieve the model for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+
+        Returns
+        -------
+        `~astropy.modeling.core.Model`
+            Model for the given slit.
+        """
         index = self.slit_ids.index(name)
         return self.models[index]
 
     def evaluate(self, name, x, y):
+        """
+        Compute the x and y coordinates in the MSA frame for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+        x, y : float
+            x and y coordinates within the virtual slit.
+
+        Returns
+        -------
+        x_msa, y_msa : float
+            x and y coordinates in the MSA frame.
+        """
         index = self.slit_ids.index(name)
         return self.models[index](x, y)
 
 
 class NirissSOSSModel(Model):
-    """
-    NIRISS SOSS wavelength solution model.
-
-    Parameters
-    ----------
-    spectral_orders : list of int
-        Spectral orders for which there is a wavelength solution.
-    models : list of `~astropy.modeling.core.Model`
-        A list of transforms representing the wavelength solution for
-        each order in spectral orders. It should match the order in
-        ``spectral_orders``.
-    """
+    """NIRISS SOSS wavelength solution model."""
 
     _separable = False
 
@@ -427,6 +547,18 @@ class NirissSOSSModel(Model):
     n_outputs = 3
 
     def __init__(self, spectral_orders, models):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        spectral_orders : list of int
+            Spectral orders for which there is a wavelength solution.
+        models : list of `~astropy.modeling.core.Model`
+            A list of transforms representing the wavelength solution for
+            each order in spectral orders. It should match the order in
+            ``spectral_orders``.
+        """
         super(NirissSOSSModel, self).__init__()
         self.inputs = ("x", "y", "spectral_order")
         """ x and y pixel coordinates and spectral order"""
@@ -437,9 +569,39 @@ class NirissSOSSModel(Model):
         self.models = dict(zip(spectral_orders, models, strict=False))
 
     def get_model(self, spectral_order):
+        """
+        Retrieve model for a given spectral order.
+
+        Parameters
+        ----------
+        spectral_order : int
+            Spectral order for which to retrieve the model.
+
+        Returns
+        -------
+        model : `~astropy.modeling.core.Model`
+            Model for the given spectral order.
+        """
         return self.models[spectral_order]
 
     def evaluate(self, x, y, spectral_order):
+        """
+        Compute the RA, Dec, and wavelength for a given pixel coordinate and spectral order.
+
+        Parameters
+        ----------
+        x, y : float
+            Pixel coordinates.
+        spectral_order : int
+            The input spectral order.
+
+        Returns
+        -------
+        ra, dec : float
+            RA and Dec coordinates.
+        lam : float
+            Wavelength.
+        """
         # The spectral_order variable is coming in as an array/list of one element.
         # So, we are going to just take the 0'th element and use that as the index.
         try:
@@ -455,17 +617,6 @@ class Logical(Model):
     Substitute values in an array where the condition is evaluated to True.
 
     Similar to numpy's where function.
-
-    Parameters
-    ----------
-    condition : str
-        A string representing the logical, one of GT, LT, NE, EQ
-    compareto : float, ndarray
-        A number to compare to using the condition
-        If ndarray then the input array, compareto and value should have the
-        same shape.
-    value : float, ndarray
-        Value to substitute where condition is True.
     """
 
     n_inputs = 1
@@ -475,6 +626,22 @@ class Logical(Model):
     conditions = {"GT": np.greater, "LT": np.less, "EQ": np.equal, "NE": np.not_equal}
 
     def __init__(self, condition, compareto, value, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        condition : str
+            A string representing the logical, one of GT, LT, NE, EQ
+        compareto : float, ndarray
+            A number to compare to using the condition
+            If ndarray then the input array, compareto and value should have the
+            same shape.
+        value : float, ndarray
+            Value to substitute where condition is True.
+        **kwargs : dict
+            Additional keyword arguments to pass to Model.
+        """
         self.condition = condition.upper()
         self.compareto = compareto
         self.value = value
@@ -483,6 +650,19 @@ class Logical(Model):
         self.outputs = ("x",)
 
     def evaluate(self, x):
+        """
+        Compare x to compareto and substitute value where condition is True.
+
+        Parameters
+        ----------
+        x : array-like
+            Input array.
+
+        Returns
+        -------
+        array-like
+            The input array with values substituted where the condition is True.
+        """
         x = x.copy()
         m = ~np.isnan(x)
         m_ind = np.flatnonzero(m)
@@ -501,10 +681,11 @@ class Logical(Model):
 
 class IdealToV2V3(Model):
     """
-    Performs the transform from Ideal to telescope V2,V3 coordinate system.
+    Perform the transform from Ideal to telescope V2,V3 coordinate system.
+
     The two systems have the same origin: V2_REF, V3_REF.
 
-    Note: This model has no schema implemented - add schema if needed.
+    Note that this model has no schema implemented - add schema if needed.
     """
 
     _separable = False
@@ -528,6 +709,8 @@ class IdealToV2V3(Model):
     @staticmethod
     def evaluate(xidl, yidl, v3idlyangle, v2ref, v3ref, vparity):
         """
+        Transform from Ideal to V2, V3 telescope system.
+
         Parameters
         ----------
         xidl, yidl : ndarray-like
@@ -543,7 +726,6 @@ class IdealToV2V3(Model):
         -------
         v2, v3 : ndarray-like
             Coordinates in the (V2, V3) telescope system [in arcsec].
-
         """
         v3idlyangle = np.deg2rad(v3idlyangle)
 
@@ -551,16 +733,17 @@ class IdealToV2V3(Model):
         v3 = v3ref - vparity * xidl * np.sin(v3idlyangle) + yidl * np.cos(v3idlyangle)
         return v2, v3
 
-    def inverse(self):
+    def inverse(self):  # noqa: D102
         return V2V3ToIdeal(self.v3idlyangle, self.v2ref, self.v3ref, self.vparity)
 
 
 class V2V3ToIdeal(Model):
     """
-    Performs the transform from telescope V2,V3 to Ideal coordinate system.
+    Perform the transform from telescope V2,V3 to Ideal coordinate system.
+
     The two systems have the same origin - V2_REF, V3_REF.
 
-    Note: This model has no schema implemented - add if needed.
+    Note that this model has no schema implemented - add if needed.
     """
 
     _separable = False
@@ -585,12 +768,14 @@ class V2V3ToIdeal(Model):
     @staticmethod
     def evaluate(v2, v3, v3idlyangle, v2ref, v3ref, vparity):
         """
+        Transform from V2, V3 to Ideal telescope system.
+
         Parameters
         ----------
         xidl, yidl : ndarray-like
             Coordinates in Ideal System [in arcsec]
         v3idlyangle : float
-            Angle between Ideal Y-axis and V3 [ in deg]
+            Angle between Ideal Y-axis and V3 [in deg]
         v2ref, v3ref : ndarray-like
             Coordinates in V2, V3 [in arcsec]
         vparity : int
@@ -600,7 +785,6 @@ class V2V3ToIdeal(Model):
         -------
         xidl, yidl : ndarray-like
             Coordinates in the Ideal telescope system [in arcsec].
-
         """
         v3idlyangle = np.deg2rad(v3idlyangle)
 
@@ -609,7 +793,7 @@ class V2V3ToIdeal(Model):
 
         return xidl, yidl
 
-    def inverse(self):
+    def inverse(self):  # noqa: D102
         return IdealToV2V3(self.v3idlyangle, self.v2ref, self.v3ref, self.vparity)
 
 
@@ -637,30 +821,8 @@ def _toindex(value):
 
 
 class NIRCAMForwardRowGrismDispersion(Model):
-    """Return the transform from grism to image for the given spectral order.
-
-    Parameters
-    ----------
-    orders : list [int]
-        List of orders which are available
-
-    lmodels : list [astropy.modeling.Model]
-        List of models which govern the wavelength solutions for each order
-
-    xmodels : list [astropy.modeling.Model]
-        List of models which govern the x solutions for each order
-
-    ymodels : list [astropy.modeling.Model]
-        List of models which govern the y solutions for each order
-
-    inv_xmodels : list [astropy.modeling.Model]
-        List of models which will be used if inverse ymodels
-        cannot be analytically derived
-
-    Returns
-    -------
-    x, y, wavelength, order in the grism image for the pixel at x0,y0 that was
-    specified as input using the input delta pix for the specified order
+    """
+    Return the transform from grism to image for the given spectral order.
 
     Notes
     -----
@@ -689,6 +851,30 @@ class NIRCAMForwardRowGrismDispersion(Model):
         name=None,
         meta=None,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        orders : list [int]
+            List of orders which are available
+        lmodels : list [astropy.modeling.Model]
+            List of models which govern the wavelength solutions
+        xmodels : list [astropy.modeling.Model]
+            List of models which govern the x solutions
+        ymodels : list [astropy.modeling.Model]
+            List of models which govern the y solutions
+        inv_lmodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse lmodels cannot be analytically derived
+        inv_xmodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse xmodels cannot be analytically derived
+        inv_ymodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse ymodels cannot be analytically derived
+        name : str, optional
+            Name of the model, by default None
+        meta : dict, optional
+            Unused
+        """
         self.orders = orders
         self.lmodels = lmodels
         self.xmodels = xmodels
@@ -705,20 +891,26 @@ class NIRCAMForwardRowGrismDispersion(Model):
         self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
-        """Return the transform from grism to image for the given spectral order.
+        """
+        Transform from the grism plane to the image plane.
 
         Parameters
         ----------
-        x : float
-            input x pixel
-        y : float
-            input y pixel
-        x0 : float
-            input x-center of object
-        y0 : float
-            input y-center of object
+        x, y :  int,float,list
+            Input x, y location
+        x0, y0 : int,float,list
+            Source object x-center, y-center
         order : int
-            the spectral order to use
+            Input spectral order
+
+        Returns
+        -------
+        x0, y0 : float
+            Coordinates of image plane x-center, y-center, same as input.
+        l_poly : float
+            Wavelength solution for the given spectral order.
+        order : int
+            The spectral order, same as input.
         """
         try:
             iorder = self._order_mapping[int(order.flatten()[0])]
@@ -751,6 +943,25 @@ class NIRCAMForwardRowGrismDispersion(Model):
         return x0, y0, l_poly, order
 
     def invdisp_interp(self, order, x0, y0, dx):
+        """
+        Make a polynomial fit to xmodel and interpolate to find the wavelength.
+
+        Parameters
+        ----------
+        model : astropy.modeling.Model
+            The model governing the y-solutions, indexable by order.
+        order : int
+            The input spectral order
+        x0, y0 : float
+            Source object x-center, y-center.
+        dx : float
+            The offset from x0 in the dispersion direction
+
+        Returns
+        -------
+        f : float
+            The wavelength solution for the given dx
+        """
         if len(dx.shape) == 2:
             dx = dx[0, :]
 
@@ -786,30 +997,8 @@ class NIRCAMForwardRowGrismDispersion(Model):
 
 
 class NIRCAMForwardColumnGrismDispersion(Model):
-    """Return the transform from grism to image for the given spectral order.
-
-    Parameters
-    ----------
-    orders : list [int]
-        List of orders which are available
-
-    lmodels : list [astropy.modeling.Model]
-        List of models which govern the wavelength solutions
-
-    xmodels : list [astropy.modeling.Model]
-        List of models which govern the x solutions
-
-    ymodels : list [astropy.modeling.Model]
-        List of models which govern the y solutions
-
-    inv_ymodels : list [astropy.modeling.Model]
-        List of models which will be used if inverse ymodels
-        cannot be analytically derived
-
-    Returns
-    -------
-    x, y, lam, order in the grism image for the pixel at x0,y0 that was
-    specified as input using the input delta pix for the specified order
+    """
+    Return the transform from grism to image for the given spectral order.
 
     Notes
     -----
@@ -838,6 +1027,30 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         name=None,
         meta=None,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        orders : list [int]
+            List of orders which are available
+        lmodels : list [astropy.modeling.Model]
+            List of models which govern the wavelength solutions
+        xmodels : list [astropy.modeling.Model]
+            List of models which govern the x solutions
+        ymodels : list [astropy.modeling.Model]
+            List of models which govern the y solutions
+        inv_lmodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse lmodels cannot be analytically derived
+        inv_xmodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse xmodels cannot be analytically derived
+        inv_ymodels : list [astropy.modeling.Model]
+            List of models which will be used if inverse ymodels cannot be analytically derived
+        name : str, optional
+            Name of the model, by default None
+        meta : dict, optional
+            Unused
+        """
         self.orders = orders
         self.lmodels = lmodels
         self.xmodels = xmodels
@@ -854,20 +1067,26 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
-        """Return the transform from grism to image for the given spectral order.
+        """
+        Transform from the grism plane to the image plane.
 
         Parameters
         ----------
-        x : float
-            input x pixel
-        y : float
-            input y pixel
-        x0 : float
-            input x-center of object
-        y0 : float
-            input y-center of object
+        x, y :  int,float,list
+            Input x, y location
+        x0, y0 : int,float,list
+            Source object x-center, y-center
         order : int
-            the spectral order to use
+            Input spectral order
+
+        Returns
+        -------
+        x0, y0 : float
+            Coordinates of image plane x-center, y-center, same as input.
+        l_poly : float
+            Wavelength solution for the given spectral order.
+        order : int
+            The spectral order, same as input.
         """
 
         def apply_poly(coeff_model, inputs, t):
@@ -901,6 +1120,25 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         return x0, y0, l_poly, order
 
     def invdisp_interp(self, model, order, x0, y0, dy):
+        """
+        Make a polynomial fit to ymodel and interpolate to find the wavelength.
+
+        Parameters
+        ----------
+        model : astropy.modeling.Model
+            The model governing the y-solutions, indexable by order.
+        order : int
+            The input spectral order
+        x0, y0 : float
+            Source object x-center, y-center.
+        dy : float
+            The offset from y0 in the dispersion direction
+
+        Returns
+        -------
+        f : float
+            The wavelength solution for the given dy
+        """
         if len(dy.shape) == 2:
             dy = dy[0, :]
 
@@ -936,30 +1174,8 @@ class NIRCAMForwardColumnGrismDispersion(Model):
 
 
 class NIRCAMBackwardGrismDispersion(Model):
-    """Return the valid pixel(s) and wavelengths given center x,y and lam
-
-    Parameters
-    ----------
-    orders : list [int]
-        List of orders which are available
-
-    lmodels : list [astropy.modeling.Model]
-        List of models which govern the wavelength solutions
-
-    xmodels : list [astropy.modeling.Model]
-        List of models which govern the x solutions
-
-    ymodels : list [astropy.modeling.Model]
-        List of models which govern the y solutions
-
-    inv_lmodels: list [astropy.modeling.Model]
-        List of models which will be used if inverse lmodels
-        cannot be analytically derived
-
-    Returns
-    -------
-    x, y, lam, order in the grism image for the pixel at x0,y0 that was
-    specified as input using the wavelength l for the specified order
+    """
+    Calculate the dispersion extent of NIRCAM pixels.
 
     Notes
     -----
@@ -987,6 +1203,33 @@ class NIRCAMBackwardGrismDispersion(Model):
         name=None,
         meta=None,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        orders : list [int]
+            List of orders which are available
+        lmodels : list [astropy.modeling.Model]
+            List of models which govern the wavelength solutions
+        xmodels : list [astropy.modeling.Model]
+            List of models which govern the x solutions
+        ymodels : list [astropy.modeling.Model]
+            List of models which govern the y solutions
+        inv_lmodels: list [astropy.modeling.Model]
+            List of models which will be used if inverse lmodels
+            cannot be analytically derived
+        inv_xmodels: list [astropy.modeling.Model]
+            List of models which will be used if inverse xmodels
+            cannot be analytically derived
+        inv_ymodels: list [astropy.modeling.Model]
+            List of models which will be used if inverse ymodels
+            cannot be analytically derived
+        name : str, optional
+            Name of the model, by default None.
+        meta : dict
+            Unused
+        """
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.orders = orders
         self.lmodels = lmodels
@@ -1003,18 +1246,26 @@ class NIRCAMBackwardGrismDispersion(Model):
         self.outputs = ("x", "y", "x0", "y0", "order")
 
     def evaluate(self, x, y, wavelength, order):
-        """Return the transform from image to grism for the given spectral order.
+        """
+        Transform from the direct image plane to the dispersed plane.
 
         Parameters
         ----------
-        x : float
-            input x pixel
-        y : float
-            input y pixel
+        x, y : float
+            input x, y pixel
         wavelength : float
-            input wavelength in angstroms
+            Wavelength in angstroms
         order : int
-            specifies the spectral order
+            Input spectral order
+
+        Returns
+        -------
+        x, y : float
+            The x, y values in the dispersed plane.
+        x0, y0 : float
+            Source object x-center, y-center. Same as input x, y.
+        order : int
+            Output spectral order, same as input
         """
         try:
             iorder = self._order_mapping[int(order.flatten()[0])]
@@ -1037,6 +1288,23 @@ class NIRCAMBackwardGrismDispersion(Model):
         return x + dx, y + dy, x, y, order
 
     def invdisp_interp(self, model, x0, y0, wavelength):
+        """
+        Make a polynomial fit to lmodel and interpolate to find the inverse dispersion.
+
+        Parameters
+        ----------
+        model : astropy.modeling.Model
+            The model governing the wavelength solution for a given order
+        x0, y0 : float
+            Source object x-center, y-center.
+        wavelength : float
+            Wavelength in angstroms
+
+        Returns
+        -------
+        f : float
+            The inverse dispersion value for the given wavelength
+        """
         t0 = np.linspace(0.0, 1.0, 40)
         t_re = np.reshape(t0, [len(t0), *map(int, np.ones_like(np.shape(x0)))])
 
@@ -1066,31 +1334,13 @@ class NIRCAMBackwardGrismDispersion(Model):
 
 
 class NIRISSBackwardGrismDispersion(Model):
-    """This model calculates the dispersion extent of NIRISS pixels.
-
-    The dispersion is relative to the input x,y for a given wavelength.
-
-    Parameters
-    ----------
-    xmodels : list[tuple]
-        The list of tuple(models) for the polynomial model in x
-    ymodels : list[tuple]
-        The list of tuple(models) for the polynomial model in y
-    lmodels : list
-        The list of models for the polynomial model in l
-    orders : list
-        The list of orders which are available to the model
-    theta : float
-        Angle [deg] - defines the NIRISS filter wheel position
+    """
+    Calculate the dispersion extent of NIRISS pixels.
 
     Notes
     -----
-    Given the x,y, wave, order as known on the direct image,
-    it returns the tuple of x, y, wave, order for that wave in the dispersed image.
-
     This model needs to be generalized, at the moment it satisfies the
     2t x 6(xy)th order polynomial currently used by NIRISS.
-
     """
 
     standard_broadcasting = False
@@ -1104,6 +1354,26 @@ class NIRISSBackwardGrismDispersion(Model):
     def __init__(
         self, orders, lmodels=None, xmodels=None, ymodels=None, theta=0.0, name=None, meta=None
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        xmodels : list[tuple]
+            The list of tuple(models) for the polynomial model in x
+        ymodels : list[tuple]
+            The list of tuple(models) for the polynomial model in y
+        lmodels : list
+            The list of models for the polynomial model in l
+        orders : list
+            The list of orders which are available to the model
+        theta : float
+            Angle [deg] - defines the NIRISS filter wheel position
+        name : str, optional
+            Name of the model, by default None.
+        meta : dict
+            Unused
+        """
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
@@ -1118,26 +1388,26 @@ class NIRISSBackwardGrismDispersion(Model):
         self.outputs = ("x", "y", "x0", "y0", "order")
 
     def evaluate(self, x, y, wavelength, order):
-        """Return the valid pixel(s) and wavelengths given center x,y and lam
+        """
+        Transform from the direct image plane to the dispersed plane.
 
         Parameters
         ----------
+        x, y : float
+            Input x, y location
         wavelength : float
-            Input wavelength you want to know about, will be converted to float
-        x : float
-            Input x location
-        y : float
-            Input y location
-        wavelength : float
-            Wavelength to disperse
-        order : list
-            The order to use
-
+            Wavelength in angstroms
+        order : int
+            Input spectral order
 
         Returns
         -------
-        x, y, wavelength, order in the grism image for the pixel at x,y that was
-        specified as input using the wavelength and order specified
+        x, y : float
+            The x, y values in the dispersed plane.
+        x0, y0 : float
+            Source object x-center, y-center. Same as input x, y.
+        order : int
+            Output spectral order, same as input
 
         Notes
         -----
@@ -1145,7 +1415,6 @@ class NIRISSBackwardGrismDispersion(Model):
         depends on x,y as well as the filter wheel rotation. Theta is
         usu. taken to be the different between fwcpos_ref in the specwcs
         reference file and fwcpos from the input image.
-
         """
         if (wavelength < 0).any():
             raise ValueError("Wavelength should be greater than zero")
@@ -1170,32 +1439,16 @@ class NIRISSBackwardGrismDispersion(Model):
 
 
 class NIRISSForwardRowGrismDispersion(Model):
-    """This model calculates the wavelengths of vertically dispersed NIRISS grism data.
+    """
+    Calculate the wavelengths of vertically dispersed NIRISS grism data.
 
     The dispersion polynomial is relative to the input x,y pixels
     in the direct image for a given wavelength.
 
-    Parameters
-    ----------
-    orders : list
-        The list of orders which are available to the model
-    xmodels : list[tuples]
-        The list of tuple(models) for the polynomial model in x
-    ymodels : list[tuples]
-        The list of tuple(models) for the polynomial model in y
-    lmodels : list
-        The list of models for the polynomial model in l
-    theta : float
-        Angle [deg] - defines the NIRISS filter wheel position
-
     Notes
     -----
-    Given the x,y, source location as known on the dispersed image, as well as order,
-    it returns the tuple of x,y,wavelength,order.
-
     This model needs to be generalized, at the moment it satisfies the
     2t x 6(xy)th order polynomial currently used by NIRISS.
-
     """
 
     standard_broadcasting = False
@@ -1209,6 +1462,26 @@ class NIRISSForwardRowGrismDispersion(Model):
     def __init__(
         self, orders, lmodels=None, xmodels=None, ymodels=None, theta=0.0, name=None, meta=None
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        orders : list
+            The list of orders which are available to the model
+        xmodels : list[tuples]
+            The list of tuple(models) for the polynomial model in x
+        ymodels : list[tuples]
+            The list of tuple(models) for the polynomial model in y
+        lmodels : list
+            The list of models for the polynomial model in l
+        theta : float
+            Angle [deg] - defines the NIRISS filter wheel position
+        name : str, optional
+            Name of the model, by default None.
+        meta : dict
+            Unused
+        """
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
@@ -1224,36 +1497,31 @@ class NIRISSForwardRowGrismDispersion(Model):
         self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
-        """Return the valid pixel(s) and wavelengths given center x,y and lam
+        """
+        Transform from the dispersed plane into the direct image plane.
 
         Parameters
         ----------
-        x0: int,float,list
-            Source object x-center
-
-        y0: int,float,list
-            Source object y-center
-
-        x :  int,float,list
-            Input x location
-
-        y :  int,float,list
-            Input y location
-
+        x, y :  int,float,list
+            Input x, y location
+        x0, y0 : int,float,list
+            Source object x-center, y-center
         order : int
-            Spectral order to use
-
+            Input spectral order
 
         Returns
         -------
-        x, y, lambda, order, theta,  in the direct image for the pixel that was
-        specified as input using the wavelength l and spectral order
+        x, y : float
+            The x, y values in the direct image, same as x0, y0.
+        lambda : float
+            Wavelength in angstroms
+        order : int
+            Output spectral order, same as input
 
         Notes
         -----
         There's spatial dependence for NIRISS as well as dependence on the
         filter wheel rotation during the exposure.
-
         """
         try:
             iorder = self._order_mapping[int(order.flatten()[0])]
@@ -1288,31 +1556,13 @@ class NIRISSForwardRowGrismDispersion(Model):
 
 
 class NIRISSForwardColumnGrismDispersion(Model):
-    """This model calculates the wavelengths for horizontally dispersed NIRISS grism data.
+    """
+    Calculate the wavelengths for horizontally dispersed NIRISS grism data.
 
     The dispersion polynomial is relative to the input x,y pixels
-    in the direct image for a given wavelength.
-
-    Parameters
-    ----------
-    orders : list
-        The list of orders which are available to the model.
-    xmodels : list[tuple]
-        The list of tuple(models) for the polynomial model in x
-    ymodels : list[tuple]
-        The list of tuple(models) for the polynomial model in y
-    lmodels : list
-        The list of models for the polynomial model in wavelength.
-    theta : float
-        Angle [deg] - defines the NIRISS filter wheel position
-
-    Notes
-    -----
-    Given the x,y, source location, order, it returns the tuple of
-    x,y,wavelength,order on the dispersed image. It also requires
+    in the direct image for a given wavelength. The transform also requires
     FWCPOS from the image header, this is the filter wheel position
     in degrees.
-
     """
 
     standard_broadcasting = False
@@ -1324,8 +1574,35 @@ class NIRISSForwardColumnGrismDispersion(Model):
     n_outputs = 4
 
     def __init__(
-        self, orders, lmodels=None, xmodels=None, ymodels=None, theta=None, name=None, meta=None
+        self,
+        orders,
+        lmodels=None,
+        xmodels=None,
+        ymodels=None,
+        theta=None,
+        name=None,
+        meta=None,
     ):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        orders : list
+            The list of orders which are available to the model.
+        xmodels : list[tuple]
+            The list of tuple(models) for the polynomial model in x
+        ymodels : list[tuple]
+            The list of tuple(models) for the polynomial model in y
+        lmodels : list
+            The list of models for the polynomial model in wavelength.
+        theta : float
+            Angle [deg] - defines the NIRISS filter wheel position
+        name : str
+            The name of the model, by default None.
+        meta : dict
+            Unused.
+        """
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
@@ -1341,32 +1618,34 @@ class NIRISSForwardColumnGrismDispersion(Model):
         self.outputs = ("x", "y", "wavelength", "order")
 
     def evaluate(self, x, y, x0, y0, order):
-        """Return the valid pixel(s) and wavelengths given center x,y and lam
+        """
+        Transform from the dispersed plane into the direct image plane.
 
         Parameters
         ----------
-        x0: int,float
-            Source object x-center
-        y0: int,float
-            Source object y-center
         x :  int,float
             Input x location
         y :  int,float
             Input y location
+        x0: int,float
+            Source object x-center
+        y0: int,float
+            Source object y-center
         order : int
-            Spectral order to use
-        theta : float
-            input filter wheel rotation angle in degrees
+            Input spectral order
 
         Returns
         -------
-        x, y, lambda, order,  in the direct image for the pixel that was
-        specified as input using the wavelength l and spectral order
+        x, y : float
+            The x, y values in the direct image, same as x0, y0.
+        lambda : float
+            Wavelength in angstroms
+        order : int
+            Output spectral order, same as input.
 
         Notes
         -----
         There's spatial dependence for NIRISS as well as rotation for the filter wheel
-
         """
         try:
             iorder = self._order_mapping[int(order.flatten()[0])]
@@ -1399,13 +1678,8 @@ class NIRISSForwardColumnGrismDispersion(Model):
 class Rotation3DToGWA(Model):
     """
     Perform a 3D rotation given an angle in degrees.
+
     Positive angles represent a counter-clockwise rotation and vice-versa.
-    Parameters
-    ----------
-    angles : array-like
-        Angles of rotation in deg in the order of axes_order.
-    axes_order : str
-        A sequence of 'x', 'y', 'z' corresponding of axis of rotation/
     """
 
     standard_broadcasting = False
@@ -1419,6 +1693,16 @@ class Rotation3DToGWA(Model):
     angles = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, angles, axes_order, name=None):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        angles : array-like
+            Angles of rotation in deg in the order of axes_order.
+        axes_order : str
+            A sequence of 'x', 'y', 'z' corresponding to axis of rotation
+        """
         if len(angles) != len(axes_order):
             raise InputParameterError("Number of angles must equal number of axes in axes_order.")
 
@@ -1462,8 +1746,19 @@ class Rotation3DToGWA(Model):
     def evaluate(self, x, y, z, angles):
         """
         Apply the rotation to a set of 3D Cartesian coordinates.
-        """
 
+        Parameters
+        ----------
+        x, y, z : array-like
+            Cartesian coordinates
+        angles : array-like
+            Angles of rotation in deg in the order of axes_order.
+
+        Returns
+        -------
+        x, y, z : array-like
+            Rotated Cartesian coordinates
+        """
         if x.shape != y.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
 
@@ -1478,27 +1773,7 @@ class Rotation3DToGWA(Model):
 
 
 class Snell(Model):
-    """
-    Apply transforms, including Snell law, through the NIRSpec prism.
-    Parameters
-    ----------
-    angle : float
-        Prism angle in deg.
-    kcoef : list
-        K coefficients in Sellmeier equation.
-    lcoef : list
-        L coefficients in Sellmeier equation.
-    tcoef : list
-        Thermal coefficients of glass.
-    tref : float
-        Reference temperature in K.
-    pref : float
-        Reference pressure in ATM.
-    temperature : float
-        System temperature during observation in K
-    pressure : float
-        System pressure during observation in ATM.
-    """
+    """Apply transforms, including Snell law, through the NIRSpec prism."""
 
     standard_broadcasting = False
     _separable = False
@@ -1507,6 +1782,30 @@ class Snell(Model):
     n_outputs = 3
 
     def __init__(self, angle, kcoef, lcoef, tcoef, tref, pref, temperature, pressure, name=None):
+        """
+        Initialize the model of the NIRSpec prism.
+
+        Parameters
+        ----------
+        angle : float
+            Prism angle in deg.
+        kcoef : list
+            K coefficients in Sellmeier equation.
+        lcoef : list
+            L coefficients in Sellmeier equation.
+        tcoef : list
+            Thermal coefficients of glass.
+        tref : float
+            Reference temperature in K.
+        pref : float
+            Reference pressure in ATM.
+        temperature : float
+            System temperature during observation in K
+        pressure : float
+            System pressure during observation in ATM.
+        name : str, optional
+            Name of the model, by default None.
+        """
         self.prism_angle = angle
         self.kcoef = np.array(kcoef, dtype=float)
         self.lcoef = np.array(lcoef, dtype=float)
@@ -1522,7 +1821,6 @@ class Snell(Model):
     @staticmethod
     def compute_refraction_index(lam, temp, tref, pref, pressure, kcoef, lcoef, tcoef):
         """Calculate and return the refraction index."""
-
         # Convert to microns
         lam = np.asarray(lam * 1e6)
         KtoC = 273.15  # kelvin to celsius conversion  # noqa: N806
@@ -1585,7 +1883,23 @@ class Snell(Model):
         return n
 
     def evaluate(self, lam, alpha_in, beta_in, zin):
-        """Go through the prism"""
+        """
+        Go through the prism, evaluating refraction and reflection of each surface.
+
+        Parameters
+        ----------
+        lam : float
+            Wavelength.
+        alpha_in, beta_in : float
+            Incident angles.
+        zin : float
+            Incoming z coordinate. Not used for the calculation.
+
+        Returns
+        -------
+        xout, yout, zout : float
+            Outgoing x, y, z coordinates.
+        """
         n = self.compute_refraction_index(
             lam, self.temp, self.tref, self.pref, self.pressure, self.kcoef, self.lcoef, self.tcoef
         )
@@ -1614,16 +1928,7 @@ class Snell(Model):
 
 
 class AngleFromGratingEquation(Model):
-    """
-    Solve the 3D Grating Dispersion Law for the refracted angle.
-
-    Parameters
-    ----------
-    groove_density : int
-        Grating ruling density.
-    order : int
-        Spectral order.
-    """
+    """Solve the 3D Grating Dispersion Law for the refracted angle."""
 
     _separable = False
     n_inputs = 4
@@ -1636,6 +1941,18 @@ class AngleFromGratingEquation(Model):
     """ Spectral order."""
 
     def __init__(self, groove_density, order, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        groove_density : float
+            Grating ruling density.
+        order : int
+            Spectral order.
+        **kwargs : dict
+            Additional keyword arguments to pass to Model base class.
+        """
         super().__init__(groove_density=groove_density, order=order, **kwargs)
         self.inputs = ("lam", "alpha_in", "beta_in", "z")
         """ Wavelength and 3 angle coordinates going into the grating."""
@@ -1644,6 +1961,27 @@ class AngleFromGratingEquation(Model):
         """ Three angles coming out of the grating. """
 
     def evaluate(self, lam, alpha_in, beta_in, z, groove_density, order):
+        """
+        Solve the 3D Grating Dispersion Law for the refracted angle.
+
+        Parameters
+        ----------
+        lam : float
+            The wavelength.
+        alpha_in, beta_in : float
+            The incident angle.
+        z : float
+            Unused except to match the interface.
+        groove_density : float
+            The grating ruling density.
+        order : int
+            The spectral order.
+
+        Returns
+        -------
+        x, y, z : float
+            The refracted x,y, and z angles.
+        """
         if alpha_in.shape != beta_in.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
         orig_shape = alpha_in.shape or (1,)
@@ -1655,16 +1993,7 @@ class AngleFromGratingEquation(Model):
 
 
 class WavelengthFromGratingEquation(Model):
-    """
-    Solve the 3D Grating Dispersion Law for the wavelength.
-
-    Parameters
-    ----------
-    groove_density : int
-        Grating ruling density.
-    order : int
-        Spectral order.
-    """
+    """Solve the 3D Grating Dispersion Law for the wavelength."""
 
     _separable = False
     n_inputs = 3
@@ -1676,6 +2005,18 @@ class WavelengthFromGratingEquation(Model):
     """ Spectral order."""
 
     def __init__(self, groove_density, order, **kwargs):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        groove_density : int
+            Grating ruling density.
+        order : int
+            Spectral order.
+        **kwargs : dict
+            Additional keyword arguments to pass to Model base class.
+        """
         super().__init__(groove_density=groove_density, order=order, **kwargs)
         self.inputs = ("alpha_in", "beta_in", "alpha_out")
         """
@@ -1685,9 +2026,33 @@ class WavelengthFromGratingEquation(Model):
         """ Wavelength."""
 
     def evaluate(self, alpha_in, beta_in, alpha_out, groove_density, order):
-        # beta_in is not used in this equation but is here because it's
-        # needed for the prism computation. Currently these two computations
-        # need to have the same interface.
+        """
+        Solve the 3D Grating Dispersion Law for the wavelength.
+
+        Parameters
+        ----------
+        alpha_in : float
+            The incident angle.
+        beta_in : float
+            Not used; see Notes.
+        alpha_out : float
+            The refracted angle.
+        groove_density : float
+            The grating ruling density.
+        order : int
+            The spectral order.
+
+        Returns
+        -------
+        float
+            The wavelength
+
+        Notes
+        -----
+        beta_in is not used in this equation but is here because it's
+        needed for the prism computation. Currently these two computations
+        need to have the same interface.
+        """
         return -(alpha_in + alpha_out) / (groove_density * order)
 
 
@@ -1696,13 +2061,6 @@ class Rotation3D(Model):
     Perform a series of rotations about different axis in 3D space.
 
     Positive angles represent a counter-clockwise rotation.
-
-    Parameters
-    ----------
-    angles : array-like
-        Angles of rotation in deg in the order of axes_order.
-    axes_order : str
-        A sequence of 'x', 'y', 'z' corresponding of axis of rotation.
     """
 
     standard_broadcasting = False
@@ -1714,6 +2072,28 @@ class Rotation3D(Model):
     angles = Parameter(getter=np.rad2deg, setter=np.deg2rad)
 
     def __init__(self, angles, axes_order, name=None):
+        """
+        Initialize the 3D rotation model.
+
+        Parameters
+        ----------
+        angles : array-like
+            Angles of rotation in deg in the order of axes_order.
+        axes_order : str
+            A sequence of 'x', 'y', 'z' corresponding of axis of rotation.
+
+        Parameters
+        ----------
+        angles : list
+            A sequence of angles (in deg).
+            The angles are [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF].
+        axes_order : str
+            A sequence of characters ('x', 'y', or 'z') corresponding to the
+            axis of rotation and matching the order in ``angles``.
+            The axes are "zyxyz".
+        name : str, optional
+            The name of the transform, by default None.
+        """
         self.axes = ["x", "y", "z"]
         unrecognized = set(axes_order).difference(self.axes)
         if unrecognized:
@@ -1779,12 +2159,35 @@ class Rotation3D(Model):
     def rotation_matrix_from_angle(angle):
         """
         Clockwise rotation matrix.
+
+        Parameters
+        ----------
+        angle : float
+            Angle in radians.
+
+        Returns
+        -------
+        np.ndarray
+            Rotation matrix.
         """
         return np.array([[math.cos(angle), -math.sin(angle)], [math.sin(angle), math.cos(angle)]])
 
     def evaluate(self, x, y, z, angles):
         """
         Apply the rotation to a set of 3D Cartesian coordinates.
+
+        Parameters
+        ----------
+        x, y, z : float
+            Cartesian coordinates.
+        angles : list
+            A sequence of angles (in deg).
+            The angles are [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF].
+
+        Returns
+        -------
+        x, y, z : float
+            Rotated Cartesian coordinates.
         """
         if x.shape != y.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
@@ -1799,19 +2202,7 @@ class Rotation3D(Model):
 
 
 class V23ToSky(Rotation3D):
-    """
-    Transform from V2V3 to a standard coordinate system (ICRS).
-
-    Parameters
-    ----------
-    angles : list
-        A sequence of angles (in deg).
-        The angles are [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF].
-    axes_order : str
-        A sequence of characters ('x', 'y', or 'z') corresponding to the
-        axis of rotation and matching the order in ``angles``.
-        The axes are "zyxyz".
-    """
+    """Transform from V2V3 to a standard coordinate system (ICRS)."""
 
     _separable = False
 
@@ -1819,6 +2210,21 @@ class V23ToSky(Rotation3D):
     n_outputs = 2
 
     def __init__(self, angles, axes_order, name=None):
+        """
+        Initialize the transform from V2V3 to ICRS.
+
+        Parameters
+        ----------
+        angles : list
+            A sequence of angles (in deg).
+            The angles are [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF].
+        axes_order : str
+            A sequence of characters ('x', 'y', or 'z') corresponding to the
+            axis of rotation and matching the order in ``angles``.
+            The axes are "zyxyz".
+        name : str, optional
+            The name of the transform, by default None.
+        """
         super(V23ToSky, self).__init__(angles, axes_order=axes_order, name=name)
         self._inputs = ("v2", "v3")
         """ ("v2", "v3"): Coordinates in the (V2, V3) telescope frame."""
@@ -1826,7 +2232,7 @@ class V23ToSky(Rotation3D):
         """ ("ra", "dec"): RA, DEC coordinates in ICRS."""
 
     @property
-    def inputs(self):
+    def inputs(self):  # noqa: D102
         return self._inputs
 
     @inputs.setter
@@ -1834,7 +2240,7 @@ class V23ToSky(Rotation3D):
         self._inputs = val
 
     @property
-    def outputs(self):
+    def outputs(self):  # noqa: D102
         return self._outputs
 
     @outputs.setter
@@ -1845,6 +2251,16 @@ class V23ToSky(Rotation3D):
     def spherical2cartesian(alpha, delta):
         """
         Convert spherical coordinates (in deg) to cartesian.
+
+        Parameters
+        ----------
+        alpha, delta : float
+            Spherical coordinates in deg.
+
+        Returns
+        -------
+        x, y, z : float
+            Cartesian coordinates
         """
         alpha = np.deg2rad(alpha)
         delta = np.deg2rad(delta)
@@ -1857,6 +2273,16 @@ class V23ToSky(Rotation3D):
     def cartesian2spherical(x, y, z):
         """
         Convert cartesian coordinates to spherical coordinates (in deg).
+
+        Parameters
+        ----------
+        x, y, z : float
+            Cartesian coordinates.
+
+        Returns
+        -------
+        alpha, delta : float
+            Spherical coordinates in deg.
         """
         h = np.hypot(x, y)
         alpha = np.rad2deg(np.arctan2(y, x))
@@ -1864,6 +2290,22 @@ class V23ToSky(Rotation3D):
         return alpha, delta
 
     def evaluate(self, v2, v3, angles):
+        """
+        Apply the rotation to a set of spherical coordinates.
+
+        Parameters
+        ----------
+        v2, v3 : float
+            V2, V3 coordinates in deg.
+        angles : list
+            A sequence of angles (in deg).
+            The angles are [-V2_REF, V3_REF, -ROLL_REF, -DEC_REF, RA_REF].
+
+        Returns
+        -------
+        ra, dec : float
+            ICRS coordinates in deg.
+        """
         x, y, z = self.spherical2cartesian(v2, v3)
         x1, y1, z1 = super(V23ToSky, self).evaluate(x, y, z, angles)
         ra, dec = self.cartesian2spherical(x1, y1, z1)
@@ -1871,6 +2313,7 @@ class V23ToSky(Rotation3D):
         return ra, dec
 
     def __call__(self, v2, v3, **kwargs):
+        """Override default call to efficiently iterate over an array."""
         from itertools import chain
 
         inputs, format_info = self.prepare_inputs(v2, v3)
@@ -1884,9 +2327,7 @@ class V23ToSky(Rotation3D):
 
 
 class Unitless2DirCos(Model):
-    """
-    Transform a vector to directional cosines.
-    """
+    """Transform a vector to directional cosines."""
 
     _separable = False
     n_inputs = 2
@@ -1898,6 +2339,21 @@ class Unitless2DirCos(Model):
         self.outputs = ("x", "y", "z")
 
     def evaluate(self, x, y):
+        """
+        Find the direction cosines of a vector of unit length specified by (x,y,1).
+
+        Parameters
+        ----------
+        x : float
+            The vector x-component.
+        y : float
+            The vector y-component.
+
+        Returns
+        -------
+        cosa, cosb, cosc : float
+            The direction cosines alpha, beta, and gamma of the vector.
+        """
         vabs = np.sqrt(1.0 + x**2 + y**2)
         cosa = x / vabs
         cosb = y / vabs
@@ -1909,9 +2365,7 @@ class Unitless2DirCos(Model):
 
 
 class DirCos2Unitless(Model):
-    """
-    Transform directional cosines to vector.
-    """
+    """Transform directional cosines to vector."""
 
     _separable = False
     n_inputs = 3

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -135,7 +135,6 @@ class GrismObject(
     order_bounding is stored as a lookup dictionary per order and contains
     the object x,y bounding location on the grism image
     GrismObject(order_bounding={"+1":((xmin,xmax),(ymin,ymax)),"+2":((2,3),(2,3))})
-
     """
 
     __slots__ = ()  # prevent instance dictionary for lower memory
@@ -162,32 +161,30 @@ class GrismObject(
         Parameters
         ----------
         sid : int
-            source identified
+            Source identified
         order_bounding : dict{order: tuple}
             Contains the object x,y bounding locations on the image
             keyed on spectral order
-        sky_centroid: `~astropy.coordinates.SkyCoord`
-            ra and dec of the center of the object
+        sky_centroid : `~astropy.coordinates.SkyCoord`
+            RA and Dec of the center of the object
         partial_order : bool
             True if the order is only partially contained on the image
         waverange : list
-            wavelength range for the order
+            Wavelength range for the order
         sky_bbox_ll : `~astropy.coordinates.SkyCoord`
             Lower left corner of the minimum bounding box
         sky_bbox_lr : `~astropy.coordinates.SkyCoord`
             Lower right corder of the minimum bounding box
-        sky_bbox_ul : `~astropy.coordinates.SkyCoord`
-            Upper left corner of the minimum bounding box
         sky_bbox_ur : `~astropy.coordinates.SkyCoord`
             Upper right corner of the minimum bounding box
-        xcentroid : float
-            x center of object in pixels
-        ycentroid : float
-            y center of object in pixels
+        sky_bbox_ul : `~astropy.coordinates.SkyCoord`
+            Upper left corner of the minimum bounding box
+        xcentroid, ycentroid : float
+            The x, y center of object in pixels
         is_extended : bool
             True if marked as extended in the source catalog
         isophotal_abmag : float
-            isophotal_abmag from the source catalog
+            The isophotal_abmag from the source catalog
 
         Returns
         -------
@@ -432,7 +429,7 @@ class Gwa2Slit(Model):
         ----------
         name : str
             Name of the slit.
-        x, y z : float
+        x, y, z : float
             The three angle coordinates at the GWA going from detector to sky.
 
         Returns
@@ -440,7 +437,7 @@ class Gwa2Slit(Model):
         name : str
             Name of the slit.
         x_slit, y_slit : float
-            x and y coordinates within the virtual slit.
+            The x and y coordinates within the virtual slit.
         lam : float
             Wavelength.
         """
@@ -527,12 +524,12 @@ class Slit2Msa(Model):
         name : str
             Name of the slit.
         x, y : float
-            x and y coordinates within the virtual slit.
+            The x and y coordinates within the virtual slit.
 
         Returns
         -------
         x_msa, y_msa : float
-            x and y coordinates in the MSA frame.
+            The x and y coordinates in the MSA frame.
         """
         index = self.slit_ids.index(name)
         return self.models[index](x, y)
@@ -772,12 +769,12 @@ class V2V3ToIdeal(Model):
 
         Parameters
         ----------
-        xidl, yidl : ndarray-like
-            Coordinates in Ideal System [in arcsec]
+        v2, v3 : ndarray-like
+            Coordinates in the telescope (V2, V3) frame [in arcsec].
         v3idlyangle : float
             Angle between Ideal Y-axis and V3 [in deg]
         v2ref, v3ref : ndarray-like
-            Coordinates in V2, V3 [in arcsec]
+            Reference coordinates in V2, V3 [in arcsec]
         vparity : int
             Parity.
 
@@ -805,6 +802,16 @@ def _toindex(value):
     corresponding to the center of the pixel.
     The convention is that the center of the pixel is
     (0, 0), while the lower left corner is (-0.5, -0.5).
+
+    Parameters
+    ----------
+    value : ndarray
+        Input coordinates.
+
+    Returns
+    -------
+    ndarray
+        Integer coordinates representing pixel centers.
 
     Examples
     --------
@@ -948,8 +955,6 @@ class NIRCAMForwardRowGrismDispersion(Model):
 
         Parameters
         ----------
-        model : astropy.modeling.Model
-            The model governing the y-solutions, indexable by order.
         order : int
             The input spectral order
         x0, y0 : float
@@ -1216,13 +1221,13 @@ class NIRCAMBackwardGrismDispersion(Model):
             List of models which govern the x solutions
         ymodels : list [astropy.modeling.Model]
             List of models which govern the y solutions
-        inv_lmodels: list [astropy.modeling.Model]
+        inv_lmodels : list [astropy.modeling.Model]
             List of models which will be used if inverse lmodels
             cannot be analytically derived
-        inv_xmodels: list [astropy.modeling.Model]
+        inv_xmodels : list [astropy.modeling.Model]
             List of models which will be used if inverse xmodels
             cannot be analytically derived
-        inv_ymodels: list [astropy.modeling.Model]
+        inv_ymodels : list [astropy.modeling.Model]
             List of models which will be used if inverse ymodels
             cannot be analytically derived
         name : str, optional
@@ -1252,7 +1257,7 @@ class NIRCAMBackwardGrismDispersion(Model):
         Parameters
         ----------
         x, y : float
-            input x, y pixel
+            Input x, y pixel
         wavelength : float
             Wavelength in angstroms
         order : int
@@ -1359,14 +1364,14 @@ class NIRISSBackwardGrismDispersion(Model):
 
         Parameters
         ----------
+        orders : list
+            The list of orders which are available to the model
+        lmodels : list
+            The list of models for the polynomial model in l
         xmodels : list[tuple]
             The list of tuple(models) for the polynomial model in x
         ymodels : list[tuple]
             The list of tuple(models) for the polynomial model in y
-        lmodels : list
-            The list of models for the polynomial model in l
-        orders : list
-            The list of orders which are available to the model
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str, optional
@@ -1469,12 +1474,12 @@ class NIRISSForwardRowGrismDispersion(Model):
         ----------
         orders : list
             The list of orders which are available to the model
+        lmodels : list
+            The list of models for the polynomial model in l
         xmodels : list[tuples]
             The list of tuple(models) for the polynomial model in x
         ymodels : list[tuples]
             The list of tuple(models) for the polynomial model in y
-        lmodels : list
-            The list of models for the polynomial model in l
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str, optional
@@ -1590,12 +1595,12 @@ class NIRISSForwardColumnGrismDispersion(Model):
         ----------
         orders : list
             The list of orders which are available to the model.
+        lmodels : list
+            The list of models for the polynomial model in wavelength.
         xmodels : list[tuple]
             The list of tuple(models) for the polynomial model in x
         ymodels : list[tuple]
             The list of tuple(models) for the polynomial model in y
-        lmodels : list
-            The list of models for the polynomial model in wavelength.
         theta : float
             Angle [deg] - defines the NIRISS filter wheel position
         name : str
@@ -1623,14 +1628,10 @@ class NIRISSForwardColumnGrismDispersion(Model):
 
         Parameters
         ----------
-        x :  int,float
-            Input x location
-        y :  int,float
-            Input y location
-        x0: int,float
-            Source object x-center
-        y0: int,float
-            Source object y-center
+        x, y :  int,float
+            Input x,y location
+        x0, y0 : int,float
+            Source object x-center, y-center
         order : int
             Input spectral order
 
@@ -1820,7 +1821,33 @@ class Snell(Model):
 
     @staticmethod
     def compute_refraction_index(lam, temp, tref, pref, pressure, kcoef, lcoef, tcoef):
-        """Calculate and return the refraction index."""
+        """
+        Calculate and return the refraction index.
+
+        Parameters
+        ----------
+        lam : float
+            Wavelength in microns.
+        temp : float
+            System temperature during observation in K.
+        tref : float
+            Reference temperature in K.
+        pref : float
+            Reference pressure in ATM.
+        pressure : float
+            System pressure during observation in ATM.
+        kcoef : list
+            K coefficients in Sellmeier equation.
+        lcoef : list
+            L coefficients in Sellmeier equation.
+        tcoef : list
+            Thermal coefficients of glass.
+
+        Returns
+        -------
+        n : float
+            Refraction index.
+        """
         # Convert to microns
         lam = np.asarray(lam * 1e6)
         KtoC = 273.15  # kelvin to celsius conversion  # noqa: N806
@@ -2074,13 +2101,6 @@ class Rotation3D(Model):
     def __init__(self, angles, axes_order, name=None):
         """
         Initialize the 3D rotation model.
-
-        Parameters
-        ----------
-        angles : array-like
-            Angles of rotation in deg in the order of axes_order.
-        axes_order : str
-            A sequence of 'x', 'y', 'z' corresponding of axis of rotation.
 
         Parameters
         ----------

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -251,11 +251,11 @@ class MIRI_AB2Slice(Model):  # noqa: N801
         Parameters
         ----------
         beta_zero : float
-            Beta zero parameter. ADD HERE
+            Beta coordinate of the center of slice 1 in the MIRI MRS.
         beta_del : float
-            Beta delta parameter. ADD HERE
+            Slice width.
         channel : int
-            MIRI MRS channel
+            MIRI MRS channel number. Valid values are 1, 2, 3, 4.
         **kwargs : dict
             Additional keyword arguments to pass to Model.
         """
@@ -273,13 +273,13 @@ class MIRI_AB2Slice(Model):  # noqa: N801
         Parameters
         ----------
         beta : float
-            The beta angle. ADD HERE
+            The beta angle.
         beta_zero : float
-            Beta zero parameter. ADD HERE
+            Beta coordinate of the center of slice 1 in the MIRI MRS.
         beta_del : float
-            Beta delta parameter. ADD HERE
+            Slice width.
         channel : int
-            MIRI MRS channel. ADD HERE
+            MIRI MRS channel number. Valid values are 1, 2, 3, 4.
 
         Returns
         -------

--- a/src/stdatamodels/jwst/transforms/resources/__init__.py
+++ b/src/stdatamodels/jwst/transforms/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Schemas and manifests for JWST transforms."""

--- a/src/stdatamodels/jwst/transforms/resources/manifests/__init__.py
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/__init__.py
@@ -1,0 +1,1 @@
+"""Manifests for JWST transforms."""

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/__init__.py
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Schemas for JWST transforms."""

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -132,7 +132,7 @@ class DataModel(properties.ObjectNode):
             contains metadata about extensions that are not available.
             Defaults to `True`.
 
-        kwargs : dict
+        **kwargs : dict
             Additional keyword arguments passed to lower level functions. These arguments
             are generally file format-specific.
         """
@@ -333,9 +333,7 @@ class DataModel(properties.ObjectNode):
         """
         Get the CRDS observatory code for this model.
 
-        Returns
-        -------
-        str
+        Subclasses should override this to return a str.
         """
         raise NotImplementedError(
             "The base DataModel class cannot be used to select best references"
@@ -345,9 +343,7 @@ class DataModel(properties.ObjectNode):
         """
         Get the parameters used by CRDS to select references for this model.
 
-        Returns
-        -------
-        dict
+        Subclasses should override this to return a dict.
         """
         raise NotImplementedError(
             "The base DataModel class cannot be used to select best references"
@@ -381,7 +377,14 @@ class DataModel(properties.ObjectNode):
 
     @property
     def override_handle(self):
-        """Identify in-memory models where a filepath would normally be used."""
+        """
+        Identify in-memory models where a filepath would normally be used.
+
+        Returns
+        -------
+        str
+            A string that can be used to identify the model as an in-memory model.
+        """
         # Arbitrary choice to look something like crds://
         return "override://" + self.__class__.__name__
 
@@ -453,11 +456,11 @@ class DataModel(properties.ObjectNode):
         validate.value_change(str(self), self._instance, self._schema, self)
 
     def info(self, *args, **kwargs):
-        """Return information about the model."""
+        """Return information about the model."""  # numpydoc ignore=RT01
         return self._asdf.info(**kwargs)
 
     def search(self, *args, **kwargs):
-        """Search the asdf tree for nodes that match the given criteria."""
+        """Search the asdf tree for nodes that match the given criteria."""  # numpydoc ignore=RT01
         return self._asdf.search(*args, **kwargs)
 
     try:
@@ -543,18 +546,18 @@ class DataModel(properties.ObjectNode):
 
         Parameters
         ----------
-        path : string or func
+        path : str or func
             File path to save to.
             If function, it takes one argument with is
             model.meta.filename and returns the full path string.
 
-        dir_path: string
+        dir_path : str
             Directory to save to. If not None, this will override
             any directory information in the `path`
 
         Returns
         -------
-        output_path: str
+        output_path : str
             The file path the model was saved in.
         """
         if callable(path):
@@ -629,9 +632,9 @@ class DataModel(properties.ObjectNode):
             - str : file path: initialize from the given file
             - readable file object: Initialize from the given file object
             - `~asdf.AsdfFile` : Initialize from the given`~asdf.AsdfFile`.
-        schema :
+        schema : dict
             Same as for `__init__`
-        kwargs : dict
+        **kwargs : dict
             Aadditional arguments passed to lower level functions
 
         Returns
@@ -653,9 +656,10 @@ class DataModel(properties.ObjectNode):
         Parameters
         ----------
         init : file path or file object
-        args : tuple, list
+            The file to write to.
+        *args : tuple, list
             Additional positional arguments passed to `~asdf.AsdfFile.write_to`.
-        kwargs : dict
+        **kwargs : dict
             Any additional keyword arguments are passed along to
             `~asdf.AsdfFile.write_to`.
         """
@@ -681,11 +685,9 @@ class DataModel(properties.ObjectNode):
             - readable file object: Initialize from the given file object
             - astropy.io.fits.HDUList: Initialize from the given
               `~astropy.io.fits.HDUList`.
-
         schema : dict, str
             Same as for `__init__`
-
-        kwargs : dict
+        **kwargs : dict
             Aadditional arguments passed to lower level functions.
 
         Returns
@@ -707,10 +709,11 @@ class DataModel(properties.ObjectNode):
         Parameters
         ----------
         init : file path or file object
-
-        args, kwargs
-            Any additional arguments are passed along to
-            `astropy.io.fits.writeto`.
+            The file to write to.
+        *args : tuple, list
+            Additional positional arguments passed to `astropy.io.fits.writeto`.
+        **kwargs : dict
+            Additional keyword arguments passed to `astropy.io.fits.writeto`.
         """
         self.on_save(init)
 
@@ -831,7 +834,7 @@ class DataModel(properties.ObjectNode):
 
         return schema.search_schema(self.schema, substring)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # numpydoc ignore=RT01
         """Get a metadata value using a dotted name."""
         assert isinstance(key, str)
         meta = self
@@ -931,10 +934,10 @@ class DataModel(properties.ObjectNode):
         d : `~jwst.datamodels.DataModel` or dictionary-like object
             The model to copy the metadata elements from. Can also be a
             dictionary or dictionary of dictionaries or lists.
-        only: str, None
+        only : str, None
             Update only the named hdu, e.g. ``only='PRIMARY'``. Can either be
             a string or list of hdu names. Default is to update all the hdus.
-        extra_fits : boolean
+        extra_fits : bool
             Update from ``extra_fits``.  Default is False.
         """
 
@@ -1127,16 +1130,16 @@ class DataModel(properties.ObjectNode):
             named HDU's, not numerical order HDUs. To get the primary
             HDU, pass ``'PRIMARY'``.
 
+        hdu_ver : int, optional
+            The extension version. Used when there is more than one
+            extension with the same name. The default value, 1,
+            is the first.
+
         key : str, optional
             The name of a particular WCS transform to use.  This may
             be either ``' '`` or ``'A'``-``'Z'`` and corresponds to
             the ``"a"`` part of the ``CTYPEia`` cards.  *key* may only
             be provided if *header* is also provided.
-
-        hdu_ver: int, optional
-            The extension version. Used when there is more than one
-            extension with the same name. The default value, 1,
-            is the first.
 
         Returns
         -------

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1202,6 +1202,11 @@ class DataModel(properties.ObjectNode):
         ----------
         *args, **kwargs : tuple, dict
             Additional arguments passed to the model init function.
+
+        Returns
+        -------
+        model : `~jwst.datamodels.DataModel`
+            A data model.
         """
         warnings.warn("read is deprecated, use __init__ instead.", DeprecationWarning, stacklevel=2)
         return self.__init__(*args, **kwargs)

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path, PurePath
 import sys
 import warnings
+import functools
 
 import numpy as np
 
@@ -452,15 +453,15 @@ class DataModel(properties.ObjectNode):
     __copy__ = __deepcopy__ = copy
 
     def validate(self):
-        """Re-validate the model instance against its schema."""
+        """Validate the model instance against its schema."""
         validate.value_change(str(self), self._instance, self._schema, self)
 
-    def info(self, *args, **kwargs):
-        """Return information about the model."""  # numpydoc ignore=RT01
+    @functools.wraps(asdf.AsdfFile.info)
+    def info(self, *args, **kwargs):  # noqa: D102
         return self._asdf.info(**kwargs)
 
-    def search(self, *args, **kwargs):
-        """Search the asdf tree for nodes that match the given criteria."""  # numpydoc ignore=RT01
+    @functools.wraps(asdf.AsdfFile.search)
+    def search(self, *args, **kwargs):  # noqa: D102
         return self._asdf.search(*args, **kwargs)
 
     try:
@@ -550,7 +551,6 @@ class DataModel(properties.ObjectNode):
             File path to save to.
             If function, it takes one argument with is
             model.meta.filename and returns the full path string.
-
         dir_path : str
             Directory to save to. If not None, this will override
             any directory information in the `path`
@@ -756,8 +756,8 @@ class DataModel(properties.ObjectNode):
 
         Returns
         -------
-        schema : DataModel
-            The updated schema.
+        self : DataModel
+            The datamodel with its schema updated.
         """
         schema = {"allOf": [self._schema, new_schema]}
         self._schema = mschema.merge_property_trees(schema)
@@ -779,8 +779,8 @@ class DataModel(properties.ObjectNode):
 
         Returns
         -------
-        schema : DataModel
-            The updated schema.
+        self : DataModel
+            The datamodel with the schema entry added.
         """
         parts = position.split(".")
         schema = new_schema
@@ -871,7 +871,7 @@ class DataModel(properties.ObjectNode):
 
     def items(self):
         """
-        Iterate over all of the schema items in a flat way.
+        Iterate over all of the datamodel contents in a flat way.
 
         Each element is a pair (`key`, `value`).  Each `key` is a
         dot-separated name.  For example, the schema element
@@ -898,7 +898,7 @@ class DataModel(properties.ObjectNode):
 
     def keys(self):
         """
-        Iterate over all of the schema keys in a flat way.
+        Iterate over all of the datamodel contents in a flat way.
 
         Yields
         ------
@@ -913,7 +913,7 @@ class DataModel(properties.ObjectNode):
 
     def values(self):
         """
-        Iterate over all of the schema values in a flat way.
+        Iterate over all of the datamodel contents in a flat way.
 
         Yields
         ------
@@ -1048,7 +1048,7 @@ class DataModel(properties.ObjectNode):
 
     def to_flat_dict(self, include_arrays=True):
         """
-        Return a dictionary of all of the schema items as a flat dictionary.
+        Return a dictionary of all of the datamodel contents as a flat dictionary.
 
         Each dictionary key is a dot-separated name.  For example, the
         schema element `meta.observation.date` will end up in the
@@ -1065,7 +1065,7 @@ class DataModel(properties.ObjectNode):
         Returns
         -------
         flat_dict : dict
-            A dictionary of all of the schema items as a flat dictionary.
+            A dictionary of all of the datamodel contents as a flat dictionary.
         """
 
         def convert_val(val):
@@ -1085,7 +1085,15 @@ class DataModel(properties.ObjectNode):
             }
 
     @property
-    def schema(self):  # noqa: D102
+    def schema(self):
+        """
+        Retrieve the schema for this model.
+
+        Returns
+        -------
+        dict
+            The datamodel schema.
+        """
         return self._schema
 
     @property
@@ -1129,12 +1137,10 @@ class DataModel(properties.ObjectNode):
             The name of the HDU to get the WCS from.  This must use
             named HDU's, not numerical order HDUs. To get the primary
             HDU, pass ``'PRIMARY'``.
-
         hdu_ver : int, optional
             The extension version. Used when there is more than one
             extension with the same name. The default value, 1,
             is the first.
-
         key : str, optional
             The name of a particular WCS transform to use.  This may
             be either ``' '`` or ``'A'``-``'Z'`` and corresponds to
@@ -1163,7 +1169,6 @@ class DataModel(properties.ObjectNode):
         ----------
         wcs : `astropy.wcs.WCS` or `pywcs.WCS` object
             The object containing FITS WCS information
-
         hdu_name : str, optional
             The name of the HDU to set the WCS from.  This must use
             named HDU's, not numerical order HDUs.  To set the primary

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1,6 +1,4 @@
-"""
-Data model class hierarchy
-"""
+"""Data model class hierarchy."""
 
 import copy
 import datetime
@@ -50,9 +48,7 @@ _DEFAULT_SCHEMA = {
 
 
 class DataModel(properties.ObjectNode):
-    """
-    Base class of all of the data models.
-    """
+    """Base class of all of the data models."""
 
     schema_url = None
     """
@@ -74,6 +70,8 @@ class DataModel(properties.ObjectNode):
         **kwargs,
     ):
         """
+        Initialize a data model.
+
         Parameters
         ----------
         init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None
@@ -138,7 +136,6 @@ class DataModel(properties.ObjectNode):
             Additional keyword arguments passed to lower level functions. These arguments
             are generally file format-specific.
         """
-
         # Override value of validation parameters if not explicitly set.
         if pass_invalid_values is None:
             pass_invalid_values = get_envar_as_boolean("PASS_INVALID_VALUES", False)
@@ -297,8 +294,7 @@ class DataModel(properties.ObjectNode):
 
     def _migrate_hdulist(self, hdulist):
         """
-        Optional method that can migrate a hdulist for an old (incompatible)
-        format to a new format.
+        Migrate a hdulist for an old (incompatible) format to a new format.
 
         For example, say you have a file with a table that is missing a
         column that is now required. This method can be used to add the
@@ -385,9 +381,7 @@ class DataModel(properties.ObjectNode):
 
     @property
     def override_handle(self):
-        """override_handle identifies in-memory models where a filepath
-        would normally be used.
-        """
+        """Identify in-memory models where a filepath would normally be used."""
         # Arbitrary choice to look something like crds://
         return "override://" + self.__class__.__name__
 
@@ -398,6 +392,7 @@ class DataModel(properties.ObjectNode):
         self.close()
 
     def close(self):
+        """Close all file references."""
         # This method is called by __del__, which may be invoked
         # even when the model failed to initialize.  Consequently,
         # we can't assume that any attributes have been set.
@@ -409,6 +404,21 @@ class DataModel(properties.ObjectNode):
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):
+        """
+        Clone the contents of one model into another.
+
+        Parameters
+        ----------
+        target : DataModel
+            The model to clone into.
+        source : DataModel
+            The model to clone from.
+        deepcopy : bool
+            If `True`, perform a deep copy of the source model.
+            If `False`, perform a shallow copy.
+        memo : dict
+            A dictionary to use as a memoization table for deep copy.
+        """
         if deepcopy:
             instance = copy.deepcopy(source._instance, memo=memo)
             target._asdf = AsdfFile()
@@ -427,9 +437,7 @@ class DataModel(properties.ObjectNode):
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):
-        """
-        Returns a deep copy of this model.
-        """
+        """Return a deep copy of this model."""
         result = self.__class__(
             init=None,
             pass_invalid_values=self._pass_invalid_values,
@@ -441,15 +449,15 @@ class DataModel(properties.ObjectNode):
     __copy__ = __deepcopy__ = copy
 
     def validate(self):
-        """
-        Re-validate the model instance against its schema
-        """
+        """Re-validate the model instance against its schema."""
         validate.value_change(str(self), self._instance, self._schema, self)
 
     def info(self, *args, **kwargs):
+        """Return information about the model."""
         return self._asdf.info(**kwargs)
 
     def search(self, *args, **kwargs):
+        """Search the asdf tree for nodes that match the given criteria."""
         return self._asdf.search(*args, **kwargs)
 
     try:
@@ -460,10 +468,16 @@ class DataModel(properties.ObjectNode):
 
     def get_primary_array_name(self):
         """
-        Returns the name "primary" array for this model, which
-        controls the size of other arrays that are implicitly created.
+        Retrieve the name of the "primary" array for this model.
+
+        The primary array controls the size of other arrays that are implicitly created.
         This is intended to be overridden in the subclasses if the
         primary array's name is not "data".
+
+        Returns
+        -------
+        primary_array_name : str
+            The name of the primary array.
         """
         if properties._find_property(self._schema, "data"):
             primary_array_name = "data"
@@ -473,7 +487,7 @@ class DataModel(properties.ObjectNode):
 
     def on_init(self, init):
         """
-        Hook used to customize model attributes at the end of ``__init__``.
+        Customize model attributes at the end of ``__init__``.
 
         Parameters
         ----------
@@ -498,8 +512,9 @@ class DataModel(properties.ObjectNode):
 
     def on_save(self, path=None):
         """
-        This is a hook that is called just before saving the file.
-        It can be used, for example, to update values in the metadata
+        Modify the model just before saving to disk.
+
+        This hook can be used, for example, to update values in the metadata
         that are based on the content of the data.
 
         Override it in the subclass to make it do something, but don't
@@ -570,7 +585,24 @@ class DataModel(properties.ObjectNode):
     @staticmethod
     def open_asdf(init=None, ignore_unrecognized_tag=False, **kwargs):
         """
-        Open an asdf object from a filename or create a new asdf object
+        Open an asdf object from a filename or create a new asdf object.
+
+        Parameters
+        ----------
+        init : str, file object, `~asdf.AsdfFile`, dict
+            - str : file path: initialize from the given file
+            - readable file object: Initialize from the given file object
+            - `~asdf.AsdfFile` : Initialize from the given`~asdf.AsdfFile`.
+            - dict : Initialize from the given dictionary.
+        ignore_unrecognized_tag : bool
+            If `True`, ignore tags that are not recognized.
+        **kwargs : dict
+            Additional arguments passed to asdf.open.
+
+        Returns
+        -------
+        asdffile : `~asdf.AsdfFile`
+            An asdf file object.
         """
         warnings.warn(
             "open_asdf is deprecated, use asdf.open instead.", DeprecationWarning, stacklevel=2
@@ -696,6 +728,7 @@ class DataModel(properties.ObjectNode):
 
     @property
     def shape(self):
+        """Return the shape of the primary array."""
         if self._shape is None:
             primary_array_name = self.get_primary_array_name()
             if primary_array_name and self.hasattr(primary_array_name):
@@ -711,13 +744,17 @@ class DataModel(properties.ObjectNode):
 
     def extend_schema(self, new_schema):
         """
-        Extend the model's schema using the given schema, by combining
-        it in an "allOf" array.
+        Extend the model's schema using the given schema, by combining it in an "allOf" array.
 
         Parameters
         ----------
         new_schema : dict
             Schema tree.
+
+        Returns
+        -------
+        schema : DataModel
+            The updated schema.
         """
         schema = {"allOf": [self._schema, new_schema]}
         self._schema = mschema.merge_property_trees(schema)
@@ -726,8 +763,9 @@ class DataModel(properties.ObjectNode):
 
     def add_schema_entry(self, position, new_schema):
         """
-        Extend the model's schema by placing the given new_schema at
-        the given dot-separated position in the tree.
+        Extend the model's schema.
+
+        Place the given ``new_schema`` at the given dot-separated position in the tree.
 
         Parameters
         ----------
@@ -735,6 +773,11 @@ class DataModel(properties.ObjectNode):
             Dot separated string indicating the position, e.g. ``meta.instrument.name``.
         new_schema : dict
             Schema tree.
+
+        Returns
+        -------
+        schema : DataModel
+            The updated schema.
         """
         parts = position.split(".")
         schema = new_schema
@@ -745,9 +788,9 @@ class DataModel(properties.ObjectNode):
     # return_result retained for backward compatibility
     def find_fits_keyword(self, keyword, return_result=True):
         """
-        Utility function to find a reference to a FITS keyword in this
-        model's schema.  This is intended for interactive use, and not
-        for use within library code.
+        Find a reference to a FITS keyword in this model's schema.
+
+        This is intended for interactive use, and not for use within library code.
 
         Parameters
         ----------
@@ -767,8 +810,7 @@ class DataModel(properties.ObjectNode):
 
     def search_schema(self, substring):
         """
-        Utility function to search the metadata schema for a
-        particular phrase.
+        Search the metadata schema for a particular phrase.
 
         This is intended for interactive use, and not for use within
         library code.
@@ -783,15 +825,14 @@ class DataModel(properties.ObjectNode):
         Returns
         -------
         locations : list of tuples
+            The locations within the schema where the element is found.
         """
         from . import schema
 
         return schema.search_schema(self.schema, substring)
 
     def __getitem__(self, key):
-        """
-        Get a metadata value using a dotted name.
-        """
+        """Get a metadata value using a dotted name."""
         assert isinstance(key, str)
         meta = self
         for part in key.split("."):
@@ -802,9 +843,7 @@ class DataModel(properties.ObjectNode):
         return meta
 
     def __setitem__(self, key, value):
-        """
-        Set a metadata value using a dotted name.
-        """
+        """Set a metadata value using a dotted name."""
         assert isinstance(key, str)
         meta = self
         parts = key.split(".")
@@ -829,7 +868,7 @@ class DataModel(properties.ObjectNode):
 
     def items(self):
         """
-        Iterates over all of the schema items in a flat way.
+        Iterate over all of the schema items in a flat way.
 
         Each element is a pair (`key`, `value`).  Each `key` is a
         dot-separated name.  For example, the schema element
@@ -856,26 +895,34 @@ class DataModel(properties.ObjectNode):
 
     def keys(self):
         """
-        Iterates over all of the schema keys in a flat way.
+        Iterate over all of the schema keys in a flat way.
 
-        Each result of the iterator is a `key`.  Each `key` is a
-        dot-separated name.  For example, the schema element
-        `meta.observation.date` will end up in the result as the
-        string `"meta.observation.date"`.
+        Yields
+        ------
+        key : str
+            The key of the schema element. Each `key` is a
+            dot-separated name.  For example, the schema element
+            `meta.observation.date` will end up in the result as the
+            string `"meta.observation.date"`.
         """
         for key, _ in self.items():
             yield key
 
     def values(self):
         """
-        Iterates over all of the schema values in a flat way.
+        Iterate over all of the schema values in a flat way.
+
+        Yields
+        ------
+        value : object
+            The value of the schema element.
         """
         for _, val in self.items():
             yield val
 
     def update(self, d, only=None, extra_fits=False):
         """
-        Updates this model with the metadata elements from another model.
+        Update this model with the metadata elements from another model.
 
         Note: The ``update`` method skips a WCS object, if present.
 
@@ -998,7 +1045,7 @@ class DataModel(properties.ObjectNode):
 
     def to_flat_dict(self, include_arrays=True):
         """
-        Returns a dictionary of all of the schema items as a flat dictionary.
+        Return a dictionary of all of the schema items as a flat dictionary.
 
         Each dictionary key is a dot-separated name.  For example, the
         schema element `meta.observation.date` will end up in the
@@ -1006,6 +1053,16 @@ class DataModel(properties.ObjectNode):
 
             {"meta.observation.date": "2012-04-22T03:22:05.432"}
 
+        Parameters
+        ----------
+        include_arrays : bool
+            If `True`, include arrays in the output.  If `False`, exclude
+            arrays.  Default is `True`.
+
+        Returns
+        -------
+        flat_dict : dict
+            A dictionary of all of the schema items as a flat dictionary.
         """
 
         def convert_val(val):
@@ -1025,13 +1082,18 @@ class DataModel(properties.ObjectNode):
             }
 
     @property
-    def schema(self):
+    def schema(self):  # noqa: D102
         return self._schema
 
     @property
     def history(self):
         """
-        Get the history as a list of entries
+        Get the history as a list of entries.
+
+        Returns
+        -------
+        history : `HistoryList`
+            A list of history entries.
         """
         return HistoryList(self._asdf)
 
@@ -1046,7 +1108,6 @@ class DataModel(properties.ObjectNode):
             For FITS files this should be a list of strings.
             For ASDF files use a list of ``HistoryEntry`` object. It can be created
             with `~jwst.datamodels.util.create_history_entry`.
-
         """
         entries = self.history
         entries.clear()
@@ -1054,8 +1115,7 @@ class DataModel(properties.ObjectNode):
 
     def get_fits_wcs(self, hdu_name="SCI", hdu_ver=1, key=" "):
         """
-        Get a `astropy.wcs.WCS` object created from the FITS WCS
-        information in the model.
+        Get a `astropy.wcs.WCS` object created from the FITS WCS information in the model.
 
         Note that modifying the returned WCS object will not modify
         the data in this model.  To update the model, use `set_fits_wcs`.
@@ -1091,8 +1151,7 @@ class DataModel(properties.ObjectNode):
 
     def set_fits_wcs(self, wcs, hdu_name="SCI"):
         """
-        Sets the FITS WCS information on the model using the given
-        `astropy.wcs.WCS` object.
+        Set the FITS WCS information on the model using the given `astropy.wcs.WCS` object.
 
         Note that the "key" of the WCS is stored in the WCS object
         itself, so it can not be set as a parameter to this method.
@@ -1123,21 +1182,43 @@ class DataModel(properties.ObjectNode):
 
         self._instance = properties.merge_tree(self._instance, ff.tree)
 
-    # --------------------------------------------------------
-    # These two method aliases are here for astropy.registry
-    # compatibility and should not be called directly
-    # --------------------------------------------------------
-
     def read(self, *args, **kwargs):
+        """
+        Read the model from a file.
+
+        This method is only defined for compatibility with astropy.registry
+        and should not be called directly.  Use `__init__` instead.
+        This method is deprecated and will be removed in a future version.
+
+        Parameters
+        ----------
+        *args, **kwargs : tuple, dict
+            Additional arguments passed to the model init function.
+        """
         warnings.warn("read is deprecated, use __init__ instead.", DeprecationWarning, stacklevel=2)
         return self.__init__(*args, **kwargs)
 
     def write(self, path, *args, **kwargs):
+        """
+        Write the model to a file.
+
+        This method is only defined for compatibility with astropy.registry
+        and should not be called directly.  Use `save` instead.
+        This method is deprecated and will be removed in a future version.
+
+        Parameters
+        ----------
+        path : str
+            The path to the file to write to.
+        *args, **kwargs : tuple, dict
+            Additional arguments passed to the model save function.
+        """
         warnings.warn("write is deprecated, use save instead.", DeprecationWarning, stacklevel=2)
         self.save(path, *args, **kwargs)
 
     def getarray_noinit(self, attribute):
-        """Retrieve array but without initialization
+        """
+        Retrieve array but without initialization.
 
         Arrays initialize when directly referenced if they had
         not previously been initialized. This circumvents the
@@ -1165,9 +1246,9 @@ class DataModel(properties.ObjectNode):
 
 class _FileReference:
     """
-    Reference counter for open file pointers managed by
-    DataModel.  Once decremented to zero the file will
-    be closed.
+    Reference counter for open file pointers managed by DataModel.
+
+    Once decremented to zero the file will be closed.
     """
 
     def __init__(self, file):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -101,7 +101,7 @@ class DataModel(properties.ObjectNode):
             will be used.
 
         memmap : bool
-            Turn memmap of FITS/ASDF file on or off.  (default: False).
+            Turn memmap of FITS/ASDF file on or off.
 
         pass_invalid_values : bool or None
             If `True`, values that do not validate the schema
@@ -133,7 +133,7 @@ class DataModel(properties.ObjectNode):
             contains metadata about extensions that are not available.
             Defaults to `True`.
 
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments passed to lower level functions. These arguments
             are generally file format-specific.
         """
@@ -334,7 +334,10 @@ class DataModel(properties.ObjectNode):
         """
         Get the CRDS observatory code for this model.
 
-        Subclasses should override this to return a str.
+        Raises
+        ------
+        NotImplementedError
+            Subclasses should override this method to return a str.
         """
         raise NotImplementedError(
             "The base DataModel class cannot be used to select best references"
@@ -344,7 +347,10 @@ class DataModel(properties.ObjectNode):
         """
         Get the parameters used by CRDS to select references for this model.
 
-        Subclasses should override this to return a dict.
+        Raises
+        ------
+        NotImplementedError
+            Subclasses should override this method to return a dict.
         """
         raise NotImplementedError(
             "The base DataModel class cannot be used to select best references"
@@ -417,10 +423,10 @@ class DataModel(properties.ObjectNode):
             The model to clone into.
         source : DataModel
             The model to clone from.
-        deepcopy : bool
+        deepcopy : bool, optional
             If `True`, perform a deep copy of the source model.
             If `False`, perform a shallow copy.
-        memo : dict
+        memo : dict, optional
             A dictionary to use as a memoization table for deep copy.
         """
         if deepcopy:
@@ -441,7 +447,14 @@ class DataModel(properties.ObjectNode):
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):
-        """Return a deep copy of this model."""
+        """
+        Return a deep copy of this model.
+
+        Parameters
+        ----------
+        memo : dict, optional
+            A dictionary to use as a memoization table for deep copy.
+        """
         result = self.__class__(
             init=None,
             pass_invalid_values=self._pass_invalid_values,
@@ -475,6 +488,8 @@ class DataModel(properties.ObjectNode):
         Retrieve the name of the "primary" array for this model.
 
         The primary array controls the size of other arrays that are implicitly created.
+        If the schema has the "data" property, then this method returns "data".
+        Otherwise, it returns an empty string.
         This is intended to be overridden in the subclasses if the
         primary array's name is not "data".
 
@@ -572,7 +587,7 @@ class DataModel(properties.ObjectNode):
             path_head = dir_path
         output_path = os.path.join(path_head, path_tail)  # noqa: PTH118
 
-        # TODO: Support gzip-compressed fits
+        # TODO: Support gzip-compressed FITS
         if ext == ".fits":
             # TODO: remove 'clobber' check once depreciated fully in astropy
             if "clobber" not in kwargs:
@@ -588,7 +603,7 @@ class DataModel(properties.ObjectNode):
     @staticmethod
     def open_asdf(init=None, ignore_unrecognized_tag=False, **kwargs):
         """
-        Open an asdf object from a filename or create a new asdf object.
+        Open an ASDF object from a filename or create a new ASDF object.
 
         Parameters
         ----------
@@ -599,13 +614,13 @@ class DataModel(properties.ObjectNode):
             - dict : Initialize from the given dictionary.
         ignore_unrecognized_tag : bool
             If `True`, ignore tags that are not recognized.
-        **kwargs : dict
+        **kwargs
             Additional arguments passed to asdf.open.
 
         Returns
         -------
         asdffile : `~asdf.AsdfFile`
-            An asdf file object.
+            An ASDF file object.
         """
         warnings.warn(
             "open_asdf is deprecated, use asdf.open instead.", DeprecationWarning, stacklevel=2
@@ -634,7 +649,7 @@ class DataModel(properties.ObjectNode):
             - `~asdf.AsdfFile` : Initialize from the given`~asdf.AsdfFile`.
         schema : dict
             Same as for `__init__`
-        **kwargs : dict
+        **kwargs
             Aadditional arguments passed to lower level functions
 
         Returns
@@ -657,9 +672,9 @@ class DataModel(properties.ObjectNode):
         ----------
         init : file path or file object
             The file to write to.
-        *args : tuple, list
+        *args
             Additional positional arguments passed to `~asdf.AsdfFile.write_to`.
-        **kwargs : dict
+        **kwargs
             Any additional keyword arguments are passed along to
             `~asdf.AsdfFile.write_to`.
         """
@@ -687,7 +702,7 @@ class DataModel(properties.ObjectNode):
               `~astropy.io.fits.HDUList`.
         schema : dict, str
             Same as for `__init__`
-        **kwargs : dict
+        **kwargs
             Aadditional arguments passed to lower level functions.
 
         Returns
@@ -710,9 +725,9 @@ class DataModel(properties.ObjectNode):
         ----------
         init : file path or file object
             The file to write to.
-        *args : tuple, list
+        *args
             Additional positional arguments passed to `astropy.io.fits.writeto`.
-        **kwargs : dict
+        **kwargs
             Additional keyword arguments passed to `astropy.io.fits.writeto`.
         """
         self.on_save(init)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -127,7 +127,7 @@ def _cast(val, schema):
 
 def _as_fitsrec(val):
     """
-    Convert a numpy record into a fits record if it is not one already.
+    Convert a numpy record into a FITS record if it is not one already.
 
     Parameters
     ----------

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -154,7 +154,7 @@ def _as_fitsrec(val):
 
 def _get_schema_type(schema):
     """
-    Find the type of a schema and its subschemas.
+    Find the type or types used by a schema.
 
     Create a list of types used by a schema and its subschemas when
     the subschemas are joined by combiners. Then return a type string
@@ -167,8 +167,8 @@ def _get_schema_type(schema):
 
     Returns
     -------
-    schema_type : str
-        The type of the schema, or 'mixed' if the schema has multiple types.
+    str
+        The type used by a schema, or 'mixed' if the schema has multiple types.
     """
 
     def callback(subschema, path, combiner, types, recurse):
@@ -336,7 +336,7 @@ def _find_property(schema, attr):
 
 
 class Node:
-    """A schema-validated object."""
+    """An object that supports validation against a schema."""
 
     def __init__(self, attr, instance, schema, ctx, parent):
         self._name = attr
@@ -354,7 +354,7 @@ class Node:
 
 
 class ObjectNode(Node):
-    """A schema-validated dictionary-like structure."""
+    """A dictionary-like Node."""
 
     def __dir__(self):
         added = set(self._schema.get("properties", {}).keys())
@@ -436,7 +436,7 @@ class ObjectNode(Node):
 
 
 class ListNode(Node):
-    """A list of schema-validated objects."""
+    """A list-like Node."""
 
     def __cast(self, other):
         if isinstance(other, ListNode):
@@ -570,7 +570,7 @@ def put_value(path, value, tree):
         The path to the element.
     value : any
         The value to place
-    tree : JSON object tree
+    tree : `asdf.tags.core.AsdfObject`
         The tree to place the value into.
     """
     cursor = tree
@@ -598,14 +598,14 @@ def merge_tree(a, b):
 
     Parameters
     ----------
-    a : JSON object tree
+    a : `asdf.tags.core.AsdfObject`
         The tree to merge into.
-    b : JSON object tree
+    b : `asdf.tags.core.AsdfObject`
         The tree to merge from.
 
     Returns
     -------
-    a : JSON object tree
+    a : `asdf.tags.core.AsdfObject`
         The merged tree.
     """
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -570,7 +570,7 @@ def put_value(path, value, tree):
         The path to the element.
     value : any
         The value to place
-    tree : `asdf.tags.core.AsdfObject`
+    tree : dict
         The tree to place the value into.
     """
     cursor = tree
@@ -598,14 +598,14 @@ def merge_tree(a, b):
 
     Parameters
     ----------
-    a : `asdf.tags.core.AsdfObject`
+    a : dict
         The tree to merge into.
-    b : `asdf.tags.core.AsdfObject`
+    b : dict
         The tree to merge from.
 
     Returns
     -------
-    a : `asdf.tags.core.AsdfObject`
+    a : dict
         The merged tree.
     """
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -126,7 +126,19 @@ def _cast(val, schema):
 
 
 def _as_fitsrec(val):
-    """Convert a numpy record into a fits record if it is not one already."""
+    """
+    Convert a numpy record into a fits record if it is not one already.
+
+    Parameters
+    ----------
+    val : numpy.ndarray
+        The numpy record to convert.
+
+    Returns
+    -------
+    fits.FITS_rec
+        The converted FITS record.
+    """
     if isinstance(val, fits.FITS_rec):
         return val
     else:
@@ -556,11 +568,10 @@ def put_value(path, value, tree):
     ----------
     path : list of str or int
         The path to the element.
-
     value : any
         The value to place
-
     tree : JSON object tree
+        The tree to place the value into.
     """
     cursor = tree
     for i in range(len(path) - 1):
@@ -582,7 +593,21 @@ def put_value(path, value, tree):
 
 
 def merge_tree(a, b):
-    """Merge elements from tree `b` into tree `a`."""
+    """
+    Merge elements from tree `b` into tree `a`.
+
+    Parameters
+    ----------
+    a : JSON object tree
+        The tree to merge into.
+    b : JSON object tree
+        The tree to merge from.
+
+    Returns
+    -------
+    a : JSON object tree
+        The merged tree.
+    """
 
     def recurse(a, b):
         if isinstance(b, dict):

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -126,9 +126,7 @@ def _cast(val, schema):
 
 
 def _as_fitsrec(val):
-    """
-    Convert a numpy record into a fits record if it is not one already
-    """
+    """Convert a numpy record into a fits record if it is not one already."""
     if isinstance(val, fits.FITS_rec):
         return val
     else:
@@ -144,9 +142,21 @@ def _as_fitsrec(val):
 
 def _get_schema_type(schema):
     """
+    Find the type of a schema and its subschemas.
+
     Create a list of types used by a schema and its subschemas when
     the subschemas are joined by combiners. Then return a type string
-    if all the types are the same or 'mixed' if they differ
+    if all the types are the same or 'mixed' if they differ.
+
+    Parameters
+    ----------
+    schema : dict
+        The schema to analyze.
+
+    Returns
+    -------
+    schema_type : str
+        The type of the schema, or 'mixed' if the schema has multiple types.
     """
 
     def callback(subschema, path, combiner, types, recurse):
@@ -314,6 +324,8 @@ def _find_property(schema, attr):
 
 
 class Node:
+    """A schema-validated object."""
+
     def __init__(self, attr, instance, schema, ctx, parent):
         self._name = attr
         self._instance = instance
@@ -330,6 +342,8 @@ class Node:
 
 
 class ObjectNode(Node):
+    """A schema-validated dictionary-like structure."""
+
     def __dir__(self):
         added = set(self._schema.get("properties", {}).keys())
         return sorted(set(super().__dir__()) | added)
@@ -397,10 +411,10 @@ class ObjectNode(Node):
     def __iter__(self):
         return NodeIterator(self)
 
-    def hasattr(self, attr):
+    def hasattr(self, attr):  # noqa: D102
         return attr in self._instance
 
-    def items(self):
+    def items(self):  # noqa: D102
         # Return a (key, value) tuple for the node
         for key in self:
             val = self
@@ -410,6 +424,8 @@ class ObjectNode(Node):
 
 
 class ListNode(Node):
+    """A list of schema-validated objects."""
+
     def __cast(self, other):
         if isinstance(other, ListNode):
             return other._instance
@@ -449,7 +465,7 @@ class ListNode(Node):
         if self._ctx._validate_on_assignment:
             self._validate()
 
-    def append(self, item):
+    def append(self, item):  # noqa: D102
         schema = _get_schema_for_index(self._schema, len(self._instance))
         item = _cast(item, schema)
         node = ObjectNode(self._name, item, schema, self._ctx, self)
@@ -459,7 +475,7 @@ class ListNode(Node):
         else:
             self._instance.append(item)
 
-    def insert(self, i, item):
+    def insert(self, i, item):  # noqa: D102
         schema = _get_schema_for_index(self._schema, i)
         item = _cast(item, schema)
         node = ObjectNode(self._name, item, schema, self._ctx, self)
@@ -469,31 +485,31 @@ class ListNode(Node):
         else:
             self._instance.insert(i, item)
 
-    def pop(self, i=-1):
+    def pop(self, i=-1):  # noqa: D102
         schema = _get_schema_for_index(self._schema, 0)
         x = self._instance.pop(i)
         return _make_node(self._name, x, schema, self._ctx, self)
 
-    def remove(self, item):
+    def remove(self, item):  # noqa: D102
         self._instance.remove(item)
 
-    def count(self, item):
+    def count(self, item):  # noqa: D102
         return self._instance.count(item)
 
-    def index(self, item):
+    def index(self, item):  # noqa: D102
         return self._instance.index(item)
 
-    def reverse(self):
+    def reverse(self):  # noqa: D102
         self._instance.reverse()
 
-    def sort(self, *args, **kwargs):
+    def sort(self, *args, **kwargs):  # noqa: D102
         self._instance.sort(*args, **kwargs)
 
-    def extend(self, other):
+    def extend(self, other):  # noqa: D102
         for part in _unmake_node(other):
             self.append(part)
 
-    def item(self, **kwargs):
+    def item(self, **kwargs):  # noqa: D102
         assert isinstance(self._schema["items"], dict)
         node = ObjectNode(self._name, kwargs, self._schema["items"], self._ctx, self)
         if not self._ctx._validate_on_assignment:
@@ -504,9 +520,7 @@ class ListNode(Node):
 
 
 class NodeIterator:
-    """
-    An iterator for a node which flattens the hierarchical structure
-    """
+    """An iterator for a node which flattens the hierarchical structure."""
 
     def __init__(self, node):
         self.key_stack = []
@@ -536,8 +550,7 @@ class NodeIterator:
 
 def put_value(path, value, tree):
     """
-    Put a value at the given path into tree, replacing it if it is
-    already present.
+    Put a value at the given path into tree, replacing it if it is already present.
 
     Parameters
     ----------
@@ -569,9 +582,7 @@ def put_value(path, value, tree):
 
 
 def merge_tree(a, b):
-    """
-    Merge elements from tree `b` into tree `a`.
-    """
+    """Merge elements from tree `b` into tree `a`."""
 
     def recurse(a, b):
         if isinstance(b, dict):

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -6,8 +6,9 @@ import re
 # return_result included for backward compatibility
 def find_fits_keyword(schema, keyword, return_result=False):
     """
-    Utility function to find a reference to a FITS keyword in a given
-    schema.  This is intended for interactive use, and not for use
+    Find references to a FITS keyword in a given schema.
+
+    This is intended for interactive use, and not for use
     within library code.
 
     Parameters
@@ -21,6 +22,7 @@ def find_fits_keyword(schema, keyword, return_result=False):
     Returns
     -------
     locations : list of str
+        A list of paths to instances of the keyword in the schema
     """
 
     def find_fits_keyword(subschema, path, combiner, ctx, recurse):
@@ -36,6 +38,8 @@ def find_fits_keyword(schema, keyword, return_result=False):
 
 
 class SearchSchemaResults(list):
+    """A list of search results with nicely-formatted string representation."""
+
     def __repr__(self):
         import textwrap
 
@@ -50,8 +54,7 @@ class SearchSchemaResults(list):
 
 def search_schema(schema, substring):
     """
-    Utility function to search the metadata schema for a particular
-    phrase.
+    Search the metadata schema for a particular phrase.
 
     This is intended for interactive use, and not for use within
     library code.
@@ -69,6 +72,8 @@ def search_schema(schema, substring):
     Returns
     -------
     locations : list of tuples
+        A list of tuples, each containing a path to the substring
+        and a description of the schema item at that path.
     """
     substring = substring.lower()
 
@@ -96,8 +101,7 @@ def search_schema(schema, substring):
 
 def walk_schema(schema, callback, ctx=None):
     """
-    Walks a JSON schema tree in breadth-first order, calling a
-    callback function at each entry.
+    Walk a JSON schema tree in breadth-first order, calling a callback function at each entry.
 
     Parameters
     ----------
@@ -223,10 +227,8 @@ def build_docstring(klass, template="{fits_hdu} {title}"):
     """
     Build a docstring for the specified DataModel class from its schema.
 
-
     Parameters
     ----------
-
     klass : Python class
         A class instance of a datamodel
     template : str

--- a/src/stdatamodels/schema.py
+++ b/src/stdatamodels/schema.py
@@ -106,6 +106,7 @@ def walk_schema(schema, callback, ctx=None):
     Parameters
     ----------
     schema : JSON schema
+        The schema to walk
 
     callback : callable
         The callback receives the following arguments at each entry:
@@ -172,6 +173,16 @@ def merge_property_trees(schema):
     This allows datamodel schemas to be more modular, since various components
     can be represented in individual files and then referenced elsewhere. They
     are then combined by this function into a single schema data structure.
+
+    Parameters
+    ----------
+    schema : JSON schema
+        The schema to be merged
+
+    Returns
+    -------
+    JSON schema
+        The merged schema
     """
     # track the "combined" and "top" items separately
     # this allows the top level "id", "$schema", etc to overwrite

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -210,12 +210,16 @@ def create_history_entry(description, software=None):
         ``homepage``: A URI to the homepage of the software
         ``version``: The version of the software
 
+    Returns
+    -------
+    asdf.tags.core.HistoryEntry
+        The history entry object
+
     Examples
     --------
     >>> soft = {'name': 'jwreftools', 'author': 'STSCI', \
                 'homepage': 'https://github.com/spacetelescope/jwreftools', 'version': "0.7"}
     >>> entry = create_history_entry(description="HISTORY of this file", software=soft)
-
     """
     from asdf.tags.core import Software, HistoryEntry
     import datetime
@@ -248,6 +252,11 @@ def get_envar_as_boolean(name, default=False):
         The name of the environmental variable to retrieve
     default : bool
         If the environmental variable cannot be accessed, use as the default.
+
+    Returns
+    -------
+    bool
+        The value of the environmental variable interpreted as a boolean
     """
     truths = ("true", "t", "yes", "y")
     falses = ("false", "f", "no", "n")
@@ -275,10 +284,12 @@ def get_model_type(init):
     Parameters
     ----------
     init : asdf.AsdfFile or astropy.io.fits.HDUList
+        The file object to extract the model type from.
 
     Returns
     -------
     str or None
+        The model type
     """
     if isinstance(init, asdf.AsdfFile):
         if "meta" in init:
@@ -326,6 +337,11 @@ def convert_fitsrec_to_array_in_tree(tree):
     ----------
     tree : object
         The root node of the tree.
+
+    Returns
+    -------
+    object
+        Modified tree.
     """
 
     def _convert_fitsrec(node):

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -36,7 +36,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
         The dtype of the new array.
     allow_extra_columns : bool
         If True, extra columns in the input array are allowed and will be
-        appended to the output array. If False, extra columns will raise an
+        included in the output array. If False, extra columns will raise an
         exception.
 
     Returns
@@ -284,7 +284,7 @@ def get_model_type(init):
     Parameters
     ----------
     init : asdf.AsdfFile or astropy.io.fits.HDUList
-        The file object to extract the model type from.
+        The object to extract the model type from.
 
     Returns
     -------
@@ -311,12 +311,12 @@ def remove_none_from_tree(tree):
 
     Parameters
     ----------
-    tree : object
+    tree : dict
         The root node of the tree.
 
     Returns
     -------
-    object
+    dict
         Modified tree.
     """
 
@@ -335,13 +335,13 @@ def convert_fitsrec_to_array_in_tree(tree):
 
     Parameters
     ----------
-    tree : object
-        The root node of the tree.
+    tree : dict
+        A tree that may contain FITS record arrays.
 
     Returns
     -------
     object
-        Modified tree.
+        A copy of the input tree with FITS record arrays converted to numpy arrays.
     """
 
     def _convert_fitsrec(node):

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -1,6 +1,4 @@
-"""
-Various utility functions and data types
-"""
+"""Various utility functions and data types."""
 
 import copy
 import os
@@ -26,24 +24,23 @@ log.addHandler(logging.NullHandler())
 
 def gentle_asarray(a, dtype, allow_extra_columns=False):
     """
-    Convert ``a`` to dtype ``dtype`` ignoring case differences in
-    dtype field (column) names for structured arrays (tables).
+    Convert to dtype ignoring case differences in column names for structured arrays (tables).
 
-    When name conflicts occur (the cases differ) the name from
-    ``dtype`` will be used.
+    When name conflicts occur (the cases differ) the name from ``dtype`` will be used.
 
     Parameters
     ----------
-
     a : np.ndarray
         Array which will be converted to the new dtype.
-
     dtype : np.dtype
         The dtype of the new array.
+    allow_extra_columns : bool
+        If True, extra columns in the input array are allowed and will be
+        appended to the output array. If False, extra columns will raise an
+        exception.
 
     Returns
     -------
-
     new_array : np.ndarray
         Array converted to the new dtype.
     """
@@ -87,7 +84,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
     # We can remove this once the issue is resolved in astropy:
     # https://github.com/astropy/astropy/issues/8862
     if isinstance(a, fits.fitsrec.FITS_rec):
-        a.dtype = rebuild_fits_rec_dtype(a)
+        a.dtype = _rebuild_fits_rec_dtype(a)
         in_dtype = a.dtype
 
     if in_dtype == out_dtype:
@@ -237,7 +234,8 @@ def create_history_entry(description, software=None):
 
 
 def get_envar_as_boolean(name, default=False):
-    """Interpret an environmental as a boolean flag
+    """
+    Interpret an environmental as a boolean flag.
 
     Truth is any numeric value that is not 0 or
     any of the following case-insensitive strings:
@@ -248,7 +246,6 @@ def get_envar_as_boolean(name, default=False):
     ----------
     name : str
         The name of the environmental variable to retrieve
-
     default : bool
         If the environmental variable cannot be accessed, use as the default.
     """
@@ -296,7 +293,9 @@ def get_model_type(init):
 
 def remove_none_from_tree(tree):
     """
-    Remove None values from a tree.  Both dictionary keys
+    Remove None values from a tree.
+
+    Both dictionary keys
     and list indices with None values will be removed.
 
     Parameters
@@ -320,6 +319,15 @@ def remove_none_from_tree(tree):
 
 
 def convert_fitsrec_to_array_in_tree(tree):
+    """
+    Convert all FITS record array objects in a tree to numpy arrays.
+
+    Parameters
+    ----------
+    tree : object
+        The root node of the tree.
+    """
+
     def _convert_fitsrec(node):
         if isinstance(node, fits.FITS_rec):
             return _fits_rec_to_array(node)
@@ -329,7 +337,7 @@ def convert_fitsrec_to_array_in_tree(tree):
     return treeutil.walk_and_modify(tree, _convert_fitsrec)
 
 
-def rebuild_fits_rec_dtype(fits_rec):
+def _rebuild_fits_rec_dtype(fits_rec):
     dtype = fits_rec.dtype
     new_dtype = []
     for field_name in dtype.fields:
@@ -353,7 +361,7 @@ def _fits_rec_to_array(fits_rec):
     ]
     if not len(bad_columns):
         return fits_rec.view(np.ndarray)
-    new_dtype = rebuild_fits_rec_dtype(fits_rec)
+    new_dtype = _rebuild_fits_rec_dtype(fits_rec)
     arr = np.asarray(fits_rec, new_dtype).copy()
     for name in bad_columns:
         arr[name] = fits_rec[name]

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -1,6 +1,4 @@
-"""
-Functions that support validation of model changes
-"""
+"""Functions that support validation of model changes."""
 
 import warnings
 from asdf import schema as asdf_schema
@@ -22,8 +20,23 @@ warnings.filterwarnings("always", category=ValidationWarning, append=True)
 
 def value_change(path, value, schema, ctx):
     """
-    Validate a change in value against a schema.
-    Trap error and return a flag.
+    Validate a change in value against a schema, trap the error, and return a flag.
+
+    Parameters
+    ----------
+    path : str or list
+        The path to the attribute being validated.
+    value
+        The value to validate.
+    schema
+        The schema to validate against.
+    ctx
+        The datamodel that the value is being added to
+
+    Returns
+    -------
+    bool
+        True if the value is valid, False if it is invalid.
     """
     try:
         _check_value(value, schema, ctx)
@@ -43,12 +56,30 @@ def value_change(path, value, schema, ctx):
 
 def _validate_datatype(validator, schema_datatype, instance, schema):
     """
+    Validate that an array has the correct datatype.
+
     This extends the ASDF datatype validator to support ndim
     and max_ndim within individual fields of structured arrays,
     and handle the absence of the shape field correctly.
 
     Additionally, dtypes are required to be equivalent, instead
     of just "safe" to cast.
+
+    Parameters
+    ----------
+    validator : asdf.schema.validator.Validator
+        The validator object.
+    schema_datatype : str or list of str
+        The datatype(s) specified in the schema.
+    instance : object
+        The instance to validate.
+    schema : dict
+        The schema that the instance is being validated against.
+
+    Yields
+    ------
+    ValidationError
+        If the instance does not match the schema datatype.
     """
     allow_extra_columns = schema.get("allow_extra_columns", False)
     if isinstance(instance, list):
@@ -144,6 +175,15 @@ _VALIDATORS["max_ndim"] = ndarray.validate_max_ndim
 def _check_value(value, schema, ctx):
     """
     Perform the actual validation.
+
+    Parameters
+    ----------
+    value
+        The value to validate.
+    schema
+        The schema to validate against.
+    ctx
+        The datamodel that the value is being added to
     """
     # Do not validate None values.  These are regarded as missing in DataModel,
     # and will eventually be stripped out when the model is saved to FITS or ASDF.
@@ -168,7 +208,19 @@ def _check_value(value, schema, ctx):
 
 def _error_message(path, error):
     """
-    Add the path to the attribute as context for a validation error
+    Add the path to the attribute as context for a validation error.
+
+    Parameters
+    ----------
+    path : str or list
+        The path to the attribute that was being validated.
+    error : Exception
+        The exception that was raised during validation.
+
+    Returns
+    -------
+    str
+        The error message with the path prepended.
     """
     if isinstance(path, list):
         spath = [str(p) for p in path]

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -56,7 +56,7 @@ def value_change(path, value, schema, ctx):
 
 def _validate_datatype(validator, schema_datatype, instance, schema):
     """
-    Validate that an array has the correct datatype.
+    Validate a datatype instance against a schema.
 
     This extends the ASDF datatype validator to support ndim
     and max_ndim within individual fields of structured arrays,
@@ -183,7 +183,7 @@ def _check_value(value, schema, ctx):
     schema : dict
         The schema to validate against.
     ctx : DataModel
-        The datamodel that the value is being added to
+        The datamodel to use as context.
     """
     # Do not validate None values.  These are regarded as missing in DataModel,
     # and will eventually be stripped out when the model is saved to FITS or ASDF.

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -26,11 +26,11 @@ def value_change(path, value, schema, ctx):
     ----------
     path : str or list
         The path to the attribute being validated.
-    value
+    value : object
         The value to validate.
-    schema
+    schema : dict
         The schema to validate against.
-    ctx
+    ctx : DataModel
         The datamodel that the value is being added to
 
     Returns
@@ -178,11 +178,11 @@ def _check_value(value, schema, ctx):
 
     Parameters
     ----------
-    value
+    value : object
         The value to validate.
-    schema
+    schema : dict
         The schema to validate against.
-    ctx
+    ctx : DataModel
         The datamodel that the value is being added to
     """
     # Do not validate None values.  These are regarded as missing in DataModel,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Project default for pytest"""
+"""Project defaults for pytest."""
 
 from pathlib import Path
 
@@ -8,6 +8,7 @@ import asdf
 
 
 def pytest_addoption(parser):
+    """Add options to the pytest command line."""
     parser.addoption(
         "--no-crds",
         action="store_true",
@@ -18,6 +19,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session", autouse=True)
 def register_schemas():
+    """Register the schemas directory with asdf."""
     schemas_root = Path(__file__).parent / "schemas"
     with asdf.config_context() as config:
         config.add_resource_mapping(
@@ -28,10 +30,7 @@ def register_schemas():
 
 @pytest.fixture(autouse=True)
 def patch_env_variables(monkeypatch):
-    """
-    Make sure the environment doesn't initially contain these so
-    that test results are consistent.
-    """
+    """Make sure the environment doesn't initially contain these so test results are consistent."""
     for var in [
         "PASS_INVALID_VALUES",
         "STRICT_VALIDATION",

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,4 @@
-"""Dummy models for testing."""
+"""Mock models for testing."""
 
 from stdatamodels import DataModel
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,30 +1,25 @@
-"""
-Dummy models for testing.
-"""
+"""Dummy models for testing."""
 
 from stdatamodels import DataModel
 
 
 class BasicModel(DataModel):
-    """
-    Model with minimal metadata and a single 2D float32
-    data array.
-    """
+    """Model with minimal metadata and a single 2D float32data array."""
 
     schema_url = "http://example.com/schemas/basic_model"
 
 
 class ValidationModel(DataModel):
-    """
-    Model with various kinds of validated attributes.
-    """
+    """Model with various kinds of validated attributes."""
 
     schema_url = "http://example.com/schemas/validation_model"
 
 
 class RequiredModel(DataModel):
     """
-    Model that includes a required attribute.  Uses JSON Schema's
+    Model that includes a required attribute.
+
+    Uses JSON Schema's
     built-in 'required' property rather than the custom fits_required.
     """
 
@@ -32,40 +27,32 @@ class RequiredModel(DataModel):
 
 
 class AnyOfModel(DataModel):
-    """
-    Model for which the attribute 'meta.foo' has conflicting
-    default values due to use of an anyOf combiner.
-    """
+    """Model for which 'meta.foo' has conflicting default values due to use of an anyOf combiner."""
 
     schema_url = "http://example.com/schemas/anyof_model"
 
 
 class FitsModel(DataModel):
-    """
-    Model whose schema includes support for writing to FITS
-    files.
-    """
+    """Model whose schema includes support for writing to FITS files."""
 
     schema_url = "http://example.com/schemas/fits_model"
 
 
 class PureFitsModel(FitsModel):
+    """Model without an asdf extension."""
+
     def __init__(self, init=None, **kwargs):
         super().__init__(init=init, **kwargs)
         self._no_asdf_extension = True
 
 
 class TransformModel(DataModel):
-    """
-    Model with an astropy.modeling model in one of its attributes.
-    """
+    """Model with an astropy.modeling model in one of its attributes."""
 
     schema_url = "http://example.com/schemas/transform_model"
 
 
 class TableModel(DataModel):
-    """
-    Model that includes a recarray-style table.
-    """
+    """Model that includes a recarray-style table."""
 
     schema_url = "http://example.com/schemas/table_model"

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -381,14 +381,14 @@ def test_metadata_from_fits(tmp_path):
 
 
 def test_get_short_doc():
-    assert fits_support.get_short_doc({}) == ""
-    assert fits_support.get_short_doc({"title": "Some schema title."}) == "Some schema title."
+    assert fits_support._get_short_doc({}) == ""
+    assert fits_support._get_short_doc({"title": "Some schema title."}) == "Some schema title."
     assert (
-        fits_support.get_short_doc({"title": "Some schema title.\nWhoops, another line."})
+        fits_support._get_short_doc({"title": "Some schema title.\nWhoops, another line."})
         == "Some schema title."
     )
     assert (
-        fits_support.get_short_doc(
+        fits_support._get_short_doc(
             {
                 "title": "Some schema title.",
                 "description": "Some schema description.",
@@ -397,7 +397,7 @@ def test_get_short_doc():
         == "Some schema title."
     )
     assert (
-        fits_support.get_short_doc(
+        fits_support._get_short_doc(
             {
                 "description": "Some schema description.",
             }
@@ -405,7 +405,7 @@ def test_get_short_doc():
         == "Some schema description."
     )
     assert (
-        fits_support.get_short_doc(
+        fits_support._get_short_doc(
             {
                 "description": "Some schema description.\nWhoops, another line.",
             }


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3885](https://jira.stsci.edu/browse/JP-3885)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/jwst#9182

<!-- describe the changes comprising this PR here -->
This PR turns on the Ruff "D" rules and numpydoc-validation pre-commit hook in order to ensure that all docstrings in stdatamodels follow the same style as jwst.

In order to bring the repository into compliance, I had to add a lot of brand-new docstrings to specific reference models, and these were not always models that I understand very well - during review, please pay special attention to these.

A few docstrings, specifically in `wcs_ref_models.py`, remain that I couldn't easily figure out how to populate because I didn't know enough about how the distortion models work.  Hopefully one of the reviewers can provide clarity there.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
