### PR TITLE
Replace os.path with pathlib in filetype check

### DIFF
--- a/src/stdatamodels/filetype.py
+++ b/src/stdatamodels/filetype.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 
 def check(init):
@@ -18,18 +18,20 @@ def check(init):
     supported = ("asdf", "fits", "json")
 
     if isinstance(init, str):
-        path, ext = os.path.splitext(init)  # noqa: PTH122
-        ext = ext.strip(".")
+        path = Path(init)
 
-        if not ext:
+        if len(path.suffixes) == 0:
             raise ValueError(f"Input file path does not have an extension: {init}")
 
+        ext = path.suffixes[-1].strip(".")
         if ext not in supported:  # Could be the file is zipped; try splitting again
-            path, ext = os.path.splitext(path)  # noqa: PTH122
-            ext = ext.strip(".")
-
+            err_msg = f"Unrecognized file type for: {init}"
+            try:
+                ext = path.suffixes[-2].strip(".")
+            except IndexError:
+                raise ValueError(err_msg) from None
             if ext not in supported:
-                raise ValueError(f"Unrecognized file type for: {init}")
+                raise ValueError(err_msg) from None
 
         if ext == "json":  # Assume json input is an association
             return "asn"

--- a/src/stdatamodels/filetype.py
+++ b/src/stdatamodels/filetype.py
@@ -15,28 +15,21 @@ def check(init):
     file_type: a string with the file type ("asdf", "asn", or "fits")
 
     """
-    supported = ("asdf", "fits", "json")
-
     if isinstance(init, str):
         path = Path(init)
 
-        if len(path.suffixes) == 0:
+        # Could be the file is zipped; consider last 2 suffixes
+        suffixes = path.suffixes[-2:]
+        if not suffixes:
             raise ValueError(f"Input file path does not have an extension: {init}")
 
-        ext = path.suffixes[-1].strip(".")
-        if ext not in supported:  # Could be the file is zipped; try splitting again
-            err_msg = f"Unrecognized file type for: {init}"
-            try:
-                ext = path.suffixes[-2].strip(".")
-            except IndexError:
-                raise ValueError(err_msg) from None
-            if ext not in supported:
-                raise ValueError(err_msg) from None
-
-        if ext == "json":  # Assume json input is an association
-            return "asn"
-
-        return ext
+        for suffix in suffixes[::-1]:
+            ext = suffix.strip(".")
+            if ext in ["asdf", "fits"]:
+                return ext
+            if ext == "json":
+                return "asn"
+        raise ValueError(f"Unrecognized file type for: {init}")
 
     if hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -17,6 +17,7 @@ from stdatamodels.filetype import check
         ("test_file.json.gz", "asn"),
         ("test_file.asdf", "asdf"),
         ("test_file.asdf.gz", "asdf"),
+        ("test_file.asdf.fits", "fits"),
         ("stpipe.MyPipeline.fits", "fits"),
         ("stpipe.MyPipeline.fits.gz", "fits"),
     ],

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -26,7 +26,7 @@ def test_supported_filename(filename, expected_filetype):
     assert check(filename) == expected_filetype
 
 
-@pytest.mark.parametrize("filename", ["test_file", "test_file.mp4"])
+@pytest.mark.parametrize("filename", ["test_file", "test_file.mp4", "test_file.tar.gz"])
 def test_unsupported_filename(filename):
     with pytest.raises(ValueError):
         check(filename)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3884](https://jira.stsci.edu/browse/JP-3884)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #387 

<!-- describe the changes comprising this PR here -->
This PR switches `filetype.check()` from os.path to pathlib.Path.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
