### PR TITLE
Deprecate Datamodel.read Datamodel.write

### DIFF
--- a/changes/424.removal.rst
+++ b/changes/424.removal.rst
@@ -1,0 +1,1 @@
+Deprecate Datamodel.read and Datamodel.write.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1111,11 +1111,11 @@ class DataModel(properties.ObjectNode):
     # --------------------------------------------------------
 
     def read(self, *args, **kwargs):
-        warnings.warn("read is deprecated and will be removed", DeprecationWarning, stacklevel=2)
+        warnings.warn("read is deprecated, use __init__ instead.", DeprecationWarning, stacklevel=2)
         return self.__init__(*args, **kwargs)
 
     def write(self, path, *args, **kwargs):
-        warnings.warn("write is deprecated and will be removed", DeprecationWarning, stacklevel=2)
+        warnings.warn("write is deprecated, use save instead.", DeprecationWarning, stacklevel=2)
         self.save(path, *args, **kwargs)
 
     def getarray_noinit(self, attribute):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1110,9 +1110,12 @@ class DataModel(properties.ObjectNode):
     # compatibility and should not be called directly
     # --------------------------------------------------------
 
-    read = __init__
+    def read(self, *args, **kwargs):
+        warnings.warn("read is deprecated and will be removed", DeprecationWarning, stacklevel=2)
+        return self.__init__(*args, **kwargs)
 
     def write(self, path, *args, **kwargs):
+        warnings.warn("write is deprecated and will be removed", DeprecationWarning, stacklevel=2)
         self.save(path, *args, **kwargs)
 
     def getarray_noinit(self, attribute):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -351,3 +351,18 @@ def test_garbage_collectable(ModelType, tmp_path):  # noqa: N803
             # many models which would indicate they are difficult to garbage
             # collect.
             assert len(mids) < 2
+
+
+def test_read_deprecation(tmp_path):
+    fn = tmp_path / "test.fits"
+    m = DataModel()
+    m.save(fn)
+    with pytest.warns(DeprecationWarning, match="read is deprecated"):
+        m.read(fn)
+
+
+def test_write_deprecation(tmp_path):
+    fn = tmp_path / "test.fits"
+    m = DataModel()
+    with pytest.warns(DeprecationWarning, match="write is deprecated"):
+        m.write(fn)


### PR DESCRIPTION
This PR deprecates the unused `Datamodel.read` and `Datamodel.write`.

`read` is a little odd. It needs to be called using a `Datamodel` instance (not the class) which I suspect is not the intent. However it's unused, untested and being removed so that bug will be "fixed" when it's removed.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/13553243677

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
