### PR TITLE
Add new informational keys for slit-specific processing

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/slitmeta.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/slitmeta.schema.yaml
@@ -125,3 +125,18 @@ properties:
     type: number
     fits_keyword: SLTYSCL
     fits_hdu: SCI
+  wavelength_corrected:
+    title: Wavelength corrected (T/F)
+    type: boolean
+    fits_keyword: WAVECOR
+    fits_hdu: SCI
+  pathloss_correction_type:
+    title: Type of pathloss correction applied
+    type: string
+    fits_keyword: PTHLOSS
+    fits_hdu: SCI
+  barshadow_corrected:
+    title: Barshadow corrected (T/F)
+    type: boolean
+    fits_keyword: BARSHDW
+    fits_hdu: SCI

--- a/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
@@ -184,3 +184,18 @@ properties:
     type: number
     fits_keyword: TDB-END
     fits_hdu: EXTRACT1D
+  wavelength_corrected:
+    title: Wavelength corrected (T/F)
+    type: boolean
+    fits_keyword: WAVECOR
+    fits_hdu: EXTRACT1D
+  pathloss_correction_type:
+    title: Type of pathloss correction applied
+    type: string
+    fits_keyword: PTHLOSS
+    fits_hdu: EXTRACT1D
+  barshadow_corrected:
+    title: Barshadow corrected (T/F)
+    type: boolean
+    fits_keyword: BARSHDW
+    fits_hdu: EXTRACT1D


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3630](https://jira.stsci.edu/browse/JP-3630)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Add some new informational metadata/FITS keywords for slit-specific processing.  

This is intended for NIRSpec MultiSlit data (MOS, FS), which runs the wavecorr, pathloss, and barshadow steps.  These steps have different behavior depending on the slit source type, so it is helpful to add keywords to each slit/spectrum about what type of processing was applied.  For other kinds of data, or if the step is skipped, these keys won't appear.

This will need a JWSTKD ticket for the new keywords.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
