### PR TITLE
fix validators run during fits array writing

### DIFF
--- a/changes/443.bugfix.rst
+++ b/changes/443.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ndim, max_ndim and datatype validation during FITS array writing.

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -289,7 +289,7 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
     if "max_ndim" in schema:
         yield from ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
     if "datatype" in schema:
-        yield from ndarray.validate_datatype(validator, schema["datatype"], instance, schema)
+        yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
 
     hdu_name = _get_hdu_name(schema)
     _assert_non_primary_hdu(hdu_name)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -285,11 +285,11 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
         return
 
     if "ndim" in schema:
-        ndarray.validate_ndim(validator, schema["ndim"], instance, schema)
+        yield from ndarray.validate_ndim(validator, schema["ndim"], instance, schema)
     if "max_ndim" in schema:
-        ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
-    if "dtype" in schema:
-        ndarray.validate_dtype(validator, schema["dtype"], instance, schema)
+        yield from ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
+    if "datatype" in schema:
+        yield from ndarray.validate_datatype(validator, schema["datatype"], instance, schema)
 
     hdu_name = _get_hdu_name(schema)
     _assert_non_primary_hdu(hdu_name)

--- a/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
@@ -115,7 +115,7 @@ def test_multislit_copy(tmp_path):
     path = tmp_path / "multislit.fits"
     with MultiSlitModel() as input_file:
         for _ in range(4):
-            input_file.slits.append(input_file.slits.item(data=np.empty((50, 50))))
+            input_file.slits.append(input_file.slits.item(data=np.empty((50, 50), dtype="float32")))
 
         assert len(input_file.slits) == 4
         input_file.save(path)

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -50,6 +50,7 @@ def _validate_datatype(validator, schema_datatype, instance, schema):
     Additionally, dtypes are required to be equivalent, instead
     of just "safe" to cast.
     """
+    allow_extra_columns = schema.get("allow_extra_columns", False)
     if isinstance(instance, list):
         array = ndarray.inline_data_asarray(instance)
         instance_datatype, _ = ndarray.numpy_dtype_to_asdf_datatype(array.dtype)
@@ -86,7 +87,7 @@ def _validate_datatype(validator, schema_datatype, instance, schema):
                 f"Expected structured datatype '{schema_datatype}', got '{instance_datatype}'"
             )
 
-        if len(instance_dtype.fields) != len(schema_dtype.fields):
+        if not allow_extra_columns and len(instance_dtype.fields) != len(schema_dtype.fields):
             yield ValidationError(
                 f"Mismatch in number of fields: Expected {len(schema_datatype)}, "
                 f"got {len(instance_datatype)}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,7 +8,7 @@ from asdf.exceptions import ValidationError
 import numpy as np
 
 from stdatamodels.exceptions import ValidationWarning
-from models import BasicModel, ValidationModel, RequiredModel
+from models import BasicModel, FitsModel, ValidationModel, RequiredModel
 
 
 class _DoesNotRaiseContext:
@@ -412,6 +412,14 @@ def test_ndarray_validation(tmp_path):
     with pytest.raises(ValidationError, match="Wrong number of dimensions: Expected 2, got 1"):
         with BasicModel(file_path, strict_validation=True, validate_arrays=True) as model:
             model.validate()
+
+
+def test_ndarray_datatype_validation(tmp_path):
+    file_path = tmp_path / "test.fits"
+    m = FitsModel(validate_arrays=True)
+    m.instance["data"] = np.ones((4, 4), dtype=np.float64)
+    with pytest.raises(ValidationError, match="Can not safely cast from 'float64' to 'float32'"):
+        m.save(file_path)
 
 
 def test_validation_memory_leak():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -418,7 +418,9 @@ def test_ndarray_datatype_validation(tmp_path):
     file_path = tmp_path / "test.fits"
     m = FitsModel(validate_arrays=True)
     m.instance["data"] = np.ones((4, 4), dtype=np.float64)
-    with pytest.raises(ValidationError, match="Can not safely cast from 'float64' to 'float32'"):
+    with pytest.raises(
+        ValidationError, match="Array datatype 'float64' is not compatible with 'float32'"
+    ):
         m.save(file_path)
 
 


### PR DESCRIPTION
Closes #279

This PR fixes the ndim, max_ndim and datatype validation during FITS array writing by yielding from the corresponding validators (these return generators that are not consumed on main).

This PR also fixes the `if` check for `dtype` to instead check for `datatype` (the keyword used in the schema) and uses the custom `_validate_datatype` defined in this package (rather than `validate_dtype` from asdf which doesn't support `ndim` in structured datatypes or `allow_extra_columns`.

An update to one of the `test_multislit.py` unit tests was required where a float64 was being assigned to an array with a float32 dtype defined in the schema.

jwst regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/13841630347/job/38773673047

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
