### PR TITLE
skip crds schema comparison tests on windows and fix a few unit tests for windows

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -57,5 +57,5 @@ jobs:
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
         - macos: py311-xdist
-        - windows: py311-xdist
-        - windows: py3-xdist
+        - windows: py311-xdist-nocrds
+        - windows: py3-xdist-nocrds

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -721,13 +721,14 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
     else:
         m.flat_table = make_data(m.flat_table.dtype)
     m.save(fn)
+    fn2 = tmp_path / "test2.fits"
     with fits.open(fn) as ff:
         for ext in ff:
             if ext.name != "FAST_VARIATION":
                 continue
             # drop the error column
             ext.data = drop_fields(ext.data, "error")
-        ff.writeto(fn, overwrite=True)
+        ff.writeto(fn2, overwrite=True)
 
     def check_error_column(model):
         if isinstance(model, NirspecQuadFlatModel):
@@ -737,10 +738,10 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
         assert np.all(np.isnan(table["error"]))
 
     # check that migration works with datamodels.open
-    with datamodels.open(fn) as dm:
+    with datamodels.open(fn2) as dm:
         check_error_column(dm)
     # and with DataModel(fn)
-    with model(fn) as dm:
+    with model(fn2) as dm:
         check_error_column(dm)
 
 
@@ -756,13 +757,14 @@ def test_moving_target_table_migration(tmp_path):
     m = Level1bModel()
     m.moving_target = make_data(m.moving_target.dtype)
     m.save(fn)
+    fn2 = tmp_path / "test_mt2.fits"
     with fits.open(fn) as ff:
         for ext in ff:
             if ext.name != "MOVING_TARGET_POSITION":
                 continue
             # drop the error column
             ext.data = drop_fields(ext.data, ("mt_v2", "mt_v3"))
-        ff.writeto(fn, overwrite=True)
+        ff.writeto(fn2, overwrite=True)
 
     def check_error_column(model):
         table = model.moving_target
@@ -770,8 +772,8 @@ def test_moving_target_table_migration(tmp_path):
         assert np.all(np.isnan(table["mt_v3"]))
 
     # check that migration works with datamodels.open
-    with datamodels.open(fn) as dm:
+    with datamodels.open(fn2) as dm:
         check_error_column(dm)
     # and with DataModel(fn)
-    with Level1bModel(fn) as dm:
+    with Level1bModel(fn2) as dm:
         check_error_column(dm)

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema.py
@@ -58,6 +58,7 @@ def test_data_array(tmp_path):
         assert len(x.arr) == 2
         x.save(path)
 
+    path2 = str(tmp_path / "data_array2.fits")
     with JwstDataModel(path, schema=data_array_schema) as x:
         assert len(x.arr) == 2
         assert_array_almost_equal(x.arr[0].data, array1)
@@ -79,11 +80,11 @@ def test_data_array(tmp_path):
         assert len(x.arr) == 3
         del x.arr[1]
         assert len(x.arr) == 2
-        x.save(path)
+        x.save(path2)
 
     from astropy.io import fits
 
-    with fits.open(path) as hdulist:
+    with fits.open(path2) as hdulist:
         x = set()
         for hdu in hdulist:
             x.add((hdu.header.get("EXTNAME"), hdu.header.get("EXTVER")))

--- a/tests/test_embedded_asdf.py
+++ b/tests/test_embedded_asdf.py
@@ -1,10 +1,12 @@
 from io import BytesIO
+import sys
 
 import asdf
 from asdf.constants import ASDF_MAGIC
 import numpy as np
 from numpy.testing import assert_array_equal
 from astropy.io import fits
+import pytest
 
 from models import FitsModel
 from stdatamodels.fits_support import _NDARRAY_TAG
@@ -170,6 +172,9 @@ def test_array_update_and_save_new_file(tmp_path):
             assert dm.data is hdul["SCI"].data
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="windows does not support overwriting an open file"
+)
 def test_array_update_and_save_same_file(tmp_path):
     file_path = tmp_path / "test.fits"
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -88,11 +88,13 @@ def test_extra_fits(tmp_path):
     with FitsModel() as dm:
         dm.save(file_path)
 
+    file_path2 = tmp_path / "test2.fits"
+
     with fits.open(file_path) as hdul:
         hdul[0].header["FOO"] = "BAR"
-        hdul.writeto(file_path, overwrite=True)
+        hdul.writeto(file_path2, overwrite=True)
 
-    with DataModel(file_path) as dm:
+    with DataModel(file_path2) as dm:
         assert any(h for h in dm.extra_fits.PRIMARY.header if h == ["FOO", "BAR", ""])
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -44,8 +44,8 @@ def test_historylist_methods():
     assert len(h1) == 0, "Clear history list"
 
 
-def test_history_from_model_to_fits(tmpdir):
-    tmpfits = str(tmpdir.join("tmp.fits"))
+def test_history_from_model_to_fits(tmp_path):
+    tmpfits = str(tmp_path / "tmp.fits")
     m = DataModel()
     m.history = [
         HistoryEntry(
@@ -62,6 +62,7 @@ def test_history_from_model_to_fits(tmpdir):
     with fits.open(tmpfits, memmap=False) as hdulist:
         assert list(hdulist[0].header["HISTORY"]) == ["First entry", "Second entry"]
 
+    tmpfits2 = str(tmp_path / "tmp2.fits")
     with DataModel(tmpfits) as m2:
         m2 = DataModel()
         m2.update(m)
@@ -69,26 +70,27 @@ def test_history_from_model_to_fits(tmpdir):
 
         assert m2.history == [{"description": "First entry"}, {"description": "Second entry"}]
 
-        m2.save(tmpfits)
+        m2.save(tmpfits2)
 
-    with fits.open(tmpfits, memmap=False) as hdulist:
+    with fits.open(tmpfits2, memmap=False) as hdulist:
         assert list(hdulist[0].header["HISTORY"]) == ["First entry", "Second entry"]
 
 
-def test_history_from_fits(tmpdir):
-    tmpfits = str(tmpdir.join("tmp.fits"))
+def test_history_from_fits(tmp_path):
+    tmpfits = str(tmp_path / "tmp.fits")
     header = fits.Header()
     header["HISTORY"] = "First entry"
     header["HISTORY"] = "Second entry"
     fits.writeto(tmpfits, np.array([]), header, overwrite=True)
 
+    tmpfits2 = str(tmp_path / "tmp2.fits")
     with DataModel(tmpfits) as m:
         assert m.history == [{"description": "First entry"}, {"description": "Second entry"}]
 
         del m.history[0]
         m.history.append(HistoryEntry({"description": "Third entry"}))
         assert m.history == [{"description": "Second entry"}, {"description": "Third entry"}]
-        m.save(tmpfits)
+        m.save(tmpfits2)
 
-    with DataModel(tmpfits) as m:
+    with DataModel(tmpfits2) as m:
         assert m.history == [{"description": "Second entry"}, {"description": "Third entry"}]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    test{,-jwst}{,-devdeps}-xdist{,-cov}
+    test{,-jwst}{,-devdeps}-xdist{,-cov}{,-nocrds}
     build-{docs,dist}
 
 # tox environments are constructed with so-called 'factors' (or terms)
@@ -44,6 +44,7 @@ commands =
     jwst: --pyargs jwst --ignore-glob=*/scripts/* \
     # TODO: fix bug with `.finalize()` in `jwst.associations`
     jwst: --ignore-glob=*/associations/tests/test_dms.py \
+    nocrds: --no-crds
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
This PR updates the scheduled run windows tests to not run the crds integration tests. The crds integration tests are failing on windows due to some path/setup issue https://github.com/spacetelescope/stdatamodels/actions/runs/13753985050/job/38458565540 As these tests are designed to compare the schema against the crds reference files it doesn't seem worthwhile to run these on windows.

This PR also updates a few unit tests that fail on windows since windows does not allow overwriting an open file.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
