### PR TITLE
deprecate open_asdf

### DIFF
--- a/changes/450.removal.rst
+++ b/changes/450.removal.rst
@@ -1,0 +1,1 @@
+Deprecate DataModel.open_asdf use asdf.open instead.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -366,3 +366,8 @@ def test_write_deprecation(tmp_path):
     m = DataModel()
     with pytest.warns(DeprecationWarning, match="write is deprecated"):
         m.write(fn)
+
+
+def test_open_asdf_deprecation():
+    with pytest.warns(DeprecationWarning, match="open_asdf is deprecated"):
+        DataModel.open_asdf(None)


### PR DESCRIPTION
This PR deprecates `Datamodel.open_asdf` which is unused outside of this package.

See https://github.com/spacetelescope/stdatamodels/issues/299

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/13864903866
failures match those on main: https://github.com/spacetelescope/RegressionTests/actions/runs/13864937894/job/38801959229

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
