### PR TITLE
remove SKIP_FITS_UPDATE environment variable

### DIFF
--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -334,16 +334,6 @@ STRICT_VALIDATION
   If ``False``, they will generate a warning.
   Default is ``False``.
 
-SKIP_FITS_UPDATE
-  DEPRECATED: In the future the FITS header will always be used.
-  Used by `~jwst.datamodels.JwstDataModel` when instantiating a
-  model from a FITS file. When ``False``, models opened from FITS files will
-  proceed and load the FITS header values into the model. When ``True`` and the
-  FITS file has an ASDF extension, the loading/validation of the FITS header
-  will be skipped, loading the model only from the ASDF extension. If not
-  defined, the instantiation routines will determine whether the loading/validation
-  of the FITS header can be skipped or not.
-
 DMODEL_ALLOWED_MEMORY
   Implemented by the utility function
   `jwst.datamodels.util.check_memory_allocation` and used by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ def patch_env_variables(monkeypatch):
     for var in [
         "PASS_INVALID_VALUES",
         "STRICT_VALIDATION",
-        "SKIP_FITS_UPDATE",
         "VALIDATE_ON_ASSIGNMENT",
     ]:
         monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
I noticed that I left out:
- removing `SKIP_FITS_UPDATE` from the docs
- removing `SKIP_FITS_UPDATE` from conftest

from #380

This PR makes those changes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
