### PR TITLE
Deprecate DataModel.from_fits and DataModel.from_asdf

### DIFF
--- a/changes/455.removal.rst
+++ b/changes/455.removal.rst
@@ -1,0 +1,1 @@
+Deprecate DataModel.from_fits and DataModel.from_asdf. Use DataModel.__init__ instead.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -607,6 +607,11 @@ class DataModel(properties.ObjectNode):
         model : `~jwst.datamodels.DataModel` instance
             A data model.
         """
+        warnings.warn(
+            "from_asdf is deprecated, use DataModel.__init__ instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return cls(init, schema=schema, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -656,6 +656,11 @@ class DataModel(properties.ObjectNode):
         model : `~jwst.datamodels.DataModel`
             A data model.
         """
+        warnings.warn(
+            "from_fits is deprecated, use DataModel.__init__ instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return cls(init, schema=schema, **kwargs)
 
     def to_fits(self, init, *args, **kwargs):

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -74,7 +74,7 @@ def test_from_scratch(tmp_path):
 
         dm.to_fits(file_path)
 
-        with FitsModel.from_fits(file_path) as dm2:
+        with FitsModel(file_path) as dm2:
             assert dm2.shape == (50, 50)
             assert dm2.meta.telescope == "EYEGLASSES"
             assert dm2.dq.dtype.name == "uint32"
@@ -599,7 +599,7 @@ def test_resave_duplication_bug(tmp_path):
     m = FitsModel(arr)
     m.save(fn1)
 
-    m2 = FitsModel.from_fits(fn1)
+    m2 = FitsModel(fn1)
     m2.save(fn2)
 
     with fits.open(fn1) as ff1, fits.open(fn2) as ff2:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -371,3 +371,8 @@ def test_write_deprecation(tmp_path):
 def test_open_asdf_deprecation():
     with pytest.warns(DeprecationWarning, match="open_asdf is deprecated"):
         DataModel.open_asdf(None)
+
+
+def test_from_fits_deprecation():
+    with pytest.warns(DeprecationWarning, match="from_fits is deprecated"):
+        DataModel.from_fits({})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -376,3 +376,8 @@ def test_open_asdf_deprecation():
 def test_from_fits_deprecation():
     with pytest.warns(DeprecationWarning, match="from_fits is deprecated"):
         DataModel.from_fits({})
+
+
+def test_from_asdf_deprecation():
+    with pytest.warns(DeprecationWarning, match="from_asdf is deprecated"):
+        DataModel.from_asdf({})


### PR DESCRIPTION
This PR deprecates 2 unused class methods on DataModel, `from_fits` and `from_asdf`. Both are unused in jwst and are effectively aliases of `DataModel.__init__`.

Regression tests all pass and show no instances of the DeprecationWarning added in this PR: https://github.com/spacetelescope/RegressionTests/actions/runs/13930838346

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
