### PR TITLE
Set bkg reftype check to use WfssBkgModel

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -135,6 +135,7 @@ ref_to_multiples_dict = {
 ref_to_datamodel_dict = {
     "abvegaoffset": dm.ABVegaOffsetModel,
     "barshadow": dm.BarshadowModel,
+    "bkg": dm.WfssBkgModel,
     "camera": dm.CameraModel,
     "collimator": dm.CollimatorModel,
     "dark": dm.DarkModel,


### PR DESCRIPTION
The new jwst context https://jwst-crds.stsci.edu/context_table/jwst_1361.pmap contains a new `bkg` reftype which does not have a corresponding datamodel. At the moment all new `bkg` are `WFSS` so we can use `WfssBkgModel`.

This is causing test failures on main: https://github.com/spacetelescope/stdatamodels/actions/runs/14044807882

This PR updates the schema/crds test to use `WfssBkgModel` for the `bkg` reftype.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
