### PR TITLE
don't track file reference to fileless AsdfFile

### DIFF
--- a/changes/461.bugfix.rst
+++ b/changes/461.bugfix.rst
@@ -1,0 +1,1 @@
+Remove file-less AsdfFile instances from DataModel file reference tracking.

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -126,6 +126,8 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
             else:
                 model = new_class(asdffile, **kwargs)
 
+            model._file_references.append(_FileReference(asdffile))
+
             return model
 
     elif isinstance(init, tuple):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -242,14 +242,13 @@ class DataModel(properties.ObjectNode):
 
             elif file_type == "asdf":
                 asdffile = asdf.open(init, memmap=memmap, **kwargs)
+                self._file_references.append(_FileReference(asdffile))
             else:
                 # TODO handle json files as well
                 raise OSError("File does not appear to be a FITS or ASDF file.")
 
         else:
             raise ValueError(f"Can't initialize datamodel using {str(type(init))}")
-
-        self._file_references.append(_FileReference(asdffile))
 
         # Initialize object fields as determined from the code above
         self._shape = shape
@@ -410,7 +409,7 @@ class DataModel(properties.ObjectNode):
             for file_reference in self._file_references:
                 file_reference.decrement()
             # Discard the list in case close is called a second time.
-            self._file_references = []
+            self._file_references.clear()
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):


### PR DESCRIPTION
This removes file-less AsdfFile instances from tracked file references for DataModels. It addresses an issue where exiting an interactive python 3.13 session with an open model results in a `TypeError`:
```
TypeError: 'NoneType' object is not callable
```
Code to replicate the issue is:
```python
from jwst import datamodels
a = datamodels.ImageModel()
```
However given the odd set of circumstances to trigger the exception (which does not result in a non-0 exit code) no unit test is added in this PR as I can't think of a way to trigger this in the CI.

regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14338332360

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
