### PR TITLE
JP-1028: Propagate slit name through NIRSpec WCS

### DIFF
--- a/changes/465.feature.rst
+++ b/changes/465.feature.rst
@@ -1,2 +1,2 @@
 Update NIRSpec transforms to support slit name propagation.
-Add inverse transforms for Slit2Msa and Gwa2Slit and add Slit2MsaLegacy to support reading existing data products.
+Add inverse transforms for Slit2Msa and Gwa2Slit; add Slit2MsaLegacy to support reading existing data products.

--- a/changes/465.feature.rst
+++ b/changes/465.feature.rst
@@ -1,0 +1,2 @@
+Update NIRSpec transforms to support slit name propagation.
+Add inverse transforms for Slit2Msa and Gwa2Slit and add Slit2MsaLegacy to support reading existing data products.

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -19,6 +19,8 @@ __all__ = [
     "SnellConverter",
     "CoordsConverter",
     "Rotation3DToGWAConverter",
+    "Slit2MsaConverter",
+    "Slit2GwaConverter"
 ]
 
 
@@ -137,10 +139,29 @@ class Gwa2SlitConverter(TransformConverterBase):
         return node
 
 
+class Slit2GwaConverter(TransformConverterBase):
+
+    tags = ["tag:stsci.edu:jwst_pipeline/slit_to_gwa-*"]
+
+    types = ["stdatamodels.jwst.transforms.models.Slit2Gwa"]
+
+    def from_yaml_tree_transform(self, node, tag, ctx):
+
+        from stdatamodels.jwst.transforms.models import Slit2Gwa
+
+        return Slit2Gwa(node['slits'], node['models'])
+
+    def to_yaml_tree_transform(self, model, tag, ctx):
+        node = {'slits': model._slits,
+                'models': model.models}
+        return node
+
+
 class Slit2MsaConverter(TransformConverterBase):
     tags = ["tag:stsci.edu:jwst_pipeline/slit_to_msa-*"]
 
-    types = ["stdatamodels.jwst.transforms.models.Slit2Msa"]
+    types = ["stdatamodels.jwst.transforms.models.Slit2Msa",
+             "stdatamodels.jwst.transforms.models.Msa2Slit"]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
         from stdatamodels.jwst.transforms.models import Slit2Msa
@@ -148,7 +169,25 @@ class Slit2MsaConverter(TransformConverterBase):
         return Slit2Msa(node["slits"], node["models"])
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        node = {"slits": model._slits, "models": model.models}
+        node = {'slits': model._slits,
+                'models': model.models,}
+        return node
+
+
+class Msa2SlitConverter(TransformConverterBase):
+
+    tags = ["tag:stsci.edu:jwst_pipeline/msa_to_slit-*"]
+
+    types = ["stdatamodels.jwst.transforms.models.Msa2Slit"]
+
+    def from_yaml_tree_transform(self, node, tag, ctx):
+
+        from stdatamodels.jwst.transforms.models import Msa2Slit
+
+        return Msa2Slit(node['slits'], node['models'])
+
+    def to_yaml_tree_transform(self, model, tag, ctx):
+        node = {'slits': model._slits, 'models': model.models,}
         return node
 
 

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -20,7 +20,7 @@ __all__ = [
     "CoordsConverter",
     "Rotation3DToGWAConverter",
     "Slit2MsaConverter",
-    "Slit2GwaConverter"
+    "Slit2GwaConverter",
 ]
 
 
@@ -140,54 +140,60 @@ class Gwa2SlitConverter(TransformConverterBase):
 
 
 class Slit2GwaConverter(TransformConverterBase):
-
     tags = ["tag:stsci.edu:jwst_pipeline/slit_to_gwa-*"]
 
     types = ["stdatamodels.jwst.transforms.models.Slit2Gwa"]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-
         from stdatamodels.jwst.transforms.models import Slit2Gwa
 
-        return Slit2Gwa(node['slits'], node['models'])
+        return Slit2Gwa(node["slits"], node["models"])
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        node = {'slits': model._slits,
-                'models': model.models}
+        node = {"slits": model._slits, "models": model.models}
         return node
 
 
 class Slit2MsaConverter(TransformConverterBase):
     tags = ["tag:stsci.edu:jwst_pipeline/slit_to_msa-*"]
 
-    types = ["stdatamodels.jwst.transforms.models.Slit2Msa",
-             "stdatamodels.jwst.transforms.models.Msa2Slit"]
+    types = [
+        "stdatamodels.jwst.transforms.models.Slit2Msa",
+        "stdatamodels.jwst.transforms.models.Msa2Slit",
+    ]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-        from stdatamodels.jwst.transforms.models import Slit2Msa
+        from stdatamodels.jwst.transforms.models import Slit2Msa, Slit2MsaLegacy
 
-        return Slit2Msa(node["slits"], node["models"])
+        if node.get("outputs") == ["x_msa", "y_msa"]:
+            # Handle old-style Slit2Msa transforms
+            return Slit2MsaLegacy(node["slits"], node["models"])
+        else:
+            return Slit2Msa(node["slits"], node["models"])
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        node = {'slits': model._slits,
-                'models': model.models,}
+        node = {
+            "slits": model._slits,
+            "models": model.models,
+        }
         return node
 
 
 class Msa2SlitConverter(TransformConverterBase):
-
     tags = ["tag:stsci.edu:jwst_pipeline/msa_to_slit-*"]
 
     types = ["stdatamodels.jwst.transforms.models.Msa2Slit"]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-
         from stdatamodels.jwst.transforms.models import Msa2Slit
 
-        return Msa2Slit(node['slits'], node['models'])
+        return Msa2Slit(node["slits"], node["models"])
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        node = {'slits': model._slits, 'models': model.models,}
+        node = {
+            "slits": model._slits,
+            "models": model.models,
+        }
         return node
 
 

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -6,7 +6,7 @@ from ....properties import ListNode
 
 __all__ = [
     "Gwa2SlitConverter",
-    "Slit2MsaConverter",
+    "Msa2SlitConverter",
     "LogicalConverter",
     "NirissSOSSConverter",
     "RefractionIndexConverter",
@@ -160,7 +160,6 @@ class Slit2MsaConverter(TransformConverterBase):
     types = [
         "stdatamodels.jwst.transforms.models.Slit2Msa",
         "stdatamodels.jwst.transforms.models.Slit2MsaLegacy",
-        "stdatamodels.jwst.transforms.models.Msa2Slit",
     ]
 
     def from_yaml_tree_transform(self, node, tag, ctx):

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -159,6 +159,7 @@ class Slit2MsaConverter(TransformConverterBase):
 
     types = [
         "stdatamodels.jwst.transforms.models.Slit2Msa",
+        "stdatamodels.jwst.transforms.models.Slit2MsaLegacy",
         "stdatamodels.jwst.transforms.models.Msa2Slit",
     ]
 

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -15,13 +15,14 @@ from .converters.jwst_models import (
     CoordsConverter,
     V23ToSkyConverter,
     Msa2SlitConverter,
-    Slit2GwaConverter
+    Slit2GwaConverter,
 )
 
 
 _CONVERTERS = [
     CoordsConverter(),
     Gwa2SlitConverter(),
+    Slit2GwaConverter(),
     Slit2MsaConverter(),
     Msa2SlitConverter(),
     LogicalConverter(),

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -14,6 +14,8 @@ from .converters.jwst_models import (
     Rotation3DToGWAConverter,
     CoordsConverter,
     V23ToSkyConverter,
+    Msa2SlitConverter,
+    Slit2GwaConverter
 )
 
 
@@ -21,6 +23,7 @@ _CONVERTERS = [
     CoordsConverter(),
     Gwa2SlitConverter(),
     Slit2MsaConverter(),
+    Msa2SlitConverter(),
     LogicalConverter(),
     NirissSOSSConverter(),
     RefractionIndexConverter(),

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -9,7 +9,9 @@ registered with ASDF through entry points.
 """
 
 import math
+import warnings
 from collections import namedtuple
+
 import numpy as np
 from astropy.modeling.core import Model
 from astropy.modeling.parameters import Parameter, InputParameterError
@@ -21,6 +23,7 @@ from ...properties import ListNode
 __all__ = [
     "Gwa2Slit",
     "Slit2Msa",
+    "Slit2MsaLegacy",
     "Logical",
     "NirissSOSSModel",
     "Slit",
@@ -441,9 +444,10 @@ class Gwa2Slit(Model):
             Wavelength.
         """
         index = self.slit_ids.index(name)
-        return (name, ) + self.models[index](x, y, z)
+        return (name,) + self.models[index](x, y, z)
 
     def inverse(self):
+        """Create an inverse model."""
         inv_models = [m.inverse for m in self.models]
         return Slit2Gwa(self.slits, inv_models)
 
@@ -465,6 +469,7 @@ class Slit2Gwa(Model):
         List of models (`~astropy.modeling.core.Model`) corresponding to the
         list of slits.
     """
+
     _separable = False
 
     n_inputs = 4
@@ -480,10 +485,10 @@ class Slit2Gwa(Model):
 
         self.models = models
         super(Slit2Gwa, self).__init__()
-        self.outputs = ('name', 'angle1', 'angle2', 'angle3')
-        """ Name of the slit and the three angle coordinates at the GWA going from detector to sky."""
-        self.inputs = ('name', 'x_slit', 'y_slit', 'lam')
-        """ Name of the slit, x and y coordinates within the virtual slit and wavelength."""
+        self.outputs = ("name", "angle1", "angle2", "angle3")
+        """Slit name and the three angle coordinates at the GWA going from detector to sky."""
+        self.inputs = ("name", "x_slit", "y_slit", "lam")
+        """Slit name, x and y coordinates within the virtual slit and wavelength."""
 
     @property
     def slits(self):
@@ -498,7 +503,104 @@ class Slit2Gwa(Model):
 
     def evaluate(self, name, x, y, z):
         index = self.slit_ids.index(name)
-        return (name, ) + self.models[index](x, y, z)
+        return (name,) + self.models[index](x, y, z)
+
+
+class Slit2MsaLegacy(Model):
+    """Transform from Nirspec ``slit_frame`` to ``msa_frame`` without passing slit name."""
+
+    _separable = False
+
+    n_inputs = 3
+    n_outputs = 2
+
+    def __init__(self, slits, models):
+        """
+        Initialize the model.
+
+        Parameters
+        ----------
+        slits : list
+            A list of open slits.
+            A slit is a namedtuple, `~stdatamodels.jwst.transforms.models.Slit`
+            Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
+            "quadrant", "source_id", "shutter_state", "source_name",
+            "source_alias", "stellarity", "source_xpos", "source_ypos",
+            "source_ra", "source_dec")
+        models : list
+            List of models (`~astropy.modeling.core.Model`) corresponding to the
+            list of slits.
+        """
+        super(Slit2MsaLegacy, self).__init__()
+        self.inputs = ("name", "x_slit", "y_slit")
+        """ Name of the slit, x and y coordinates within the virtual slit."""
+        self.outputs = ("x_msa", "y_msa")
+        """ x and y coordinates in the MSA frame."""
+        if isiterable(slits[0]):
+            self._slits = [tuple(s) for s in slits]
+            self.slit_ids = [s[0] for s in self._slits]
+        else:
+            self._slits = list(slits)
+            self.slit_ids = self._slits
+        self.models = models
+
+        warnings.warn(
+            "This model contains a deprecated Slit2Msa transform. "
+            "The WCS pipeline may be incomplete.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    @property
+    def slits(self):
+        """
+        Return the slits.
+
+        Returns
+        -------
+        list
+            List of `~stdatamodels.jwst.transforms.models.Slit` objects.
+        """
+        if isiterable(self._slits[0]):
+            return [Slit(*row) for row in self._slits]
+        else:
+            return self.slit_ids
+
+    def get_model(self, name):
+        """
+        Retrieve the model for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+
+        Returns
+        -------
+        `~astropy.modeling.core.Model`
+            Model for the given slit.
+        """
+        index = self.slit_ids.index(name)
+        return self.models[index]
+
+    def evaluate(self, name, x, y):
+        """
+        Compute the x and y coordinates in the MSA frame for a given slit.
+
+        Parameters
+        ----------
+        name : str
+            Name of the slit.
+        x, y : float
+            The x and y coordinates within the virtual slit.
+
+        Returns
+        -------
+        x_msa, y_msa : float
+            The x and y coordinates in the MSA frame.
+        """
+        index = self.slit_ids.index(name)
+        return self.models[index](x, y)
 
 
 class Slit2Msa(Model):
@@ -591,6 +693,7 @@ class Slit2Msa(Model):
         return self.models[index](x, y) + (name,)
 
     def inverse(self):
+        """Create an inverse model."""
         models = [m.inverse for m in self.models]
         inv_model = Msa2Slit(self.slits, models)
         return inv_model
@@ -613,6 +716,7 @@ class Msa2Slit(Model):
         List of models (`~astropy.modeling.core.Model`) corresponding to the
         list of slits.
     """
+
     _separable = False
 
     n_inputs = 3
@@ -620,9 +724,9 @@ class Msa2Slit(Model):
 
     def __init__(self, slits, models):
         super(Msa2Slit, self).__init__()
-        self.inputs = ('name', 'x_slit', 'y_slit')
+        self.inputs = ("name", "x_slit", "y_slit")
         """ Name of the slit, x and y coordinates within the virtual slit."""
-        self.outputs = ('name', 'x_msa', 'y_msa')
+        self.outputs = ("name", "x_msa", "y_msa")
         """ x and y coordinates in the MSA frame."""
         if isiterable(slits[0]):
             self._slits = [tuple(s) for s in slits]

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -72,6 +72,7 @@ Slit = namedtuple(
         "source_dec",
         "slit_xscale",
         "slit_yscale",
+        "slit_id",
     ],
 )
 """ Nirspec Slit structure definition"""
@@ -97,6 +98,7 @@ Slit.__new__.__defaults__ = (
     0.0,
     1.0,
     1.0,
+    -9999,
 )
 
 
@@ -376,8 +378,15 @@ class Gwa2Slit(Model):
 
     def __init__(self, slits, models):
         if np.iterable(slits[0]):
-            self._slits = [tuple(s) for s in slits]
-            self.slit_ids = [s[0] for s in self._slits]
+            self.slit_ids = []
+            self._slits = []
+            for slit in slits:
+                slit_tuple = Slit(*slit)
+                if slit_tuple.slit_id == -9999:
+                    self.slit_ids.append(slit_tuple.name)
+                else:
+                    self.slit_ids.append(slit_tuple.slit_id)
+                self._slits.append(tuple(slit_tuple))
         else:
             self._slits = list(slits)
             self.slit_ids = self._slits
@@ -476,9 +485,16 @@ class Slit2Gwa(Model):
     n_outputs = 4
 
     def __init__(self, slits, models):
-        if isiterable(slits[0]):
-            self._slits = [tuple(s) for s in slits]
-            self.slit_ids = [s[0] for s in self._slits]
+        if np.iterable(slits[0]):
+            self.slit_ids = []
+            self._slits = []
+            for slit in slits:
+                slit_tuple = Slit(*slit)
+                if slit_tuple.slit_id == -9999:
+                    self.slit_ids.append(slit_tuple.name)
+                else:
+                    self.slit_ids.append(slit_tuple.slit_id)
+                self._slits.append(tuple(slit_tuple))
         else:
             self._slits = list(slits)
             self.slit_ids = self._slits
@@ -492,7 +508,7 @@ class Slit2Gwa(Model):
 
     @property
     def slits(self):
-        if isiterable(self._slits[0]):
+        if np.iterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids
@@ -536,7 +552,7 @@ class Slit2MsaLegacy(Model):
         """ Name of the slit, x and y coordinates within the virtual slit."""
         self.outputs = ("x_msa", "y_msa")
         """ x and y coordinates in the MSA frame."""
-        if isiterable(slits[0]):
+        if np.iterable(slits[0]):
             self._slits = [tuple(s) for s in slits]
             self.slit_ids = [s[0] for s in self._slits]
         else:
@@ -561,7 +577,7 @@ class Slit2MsaLegacy(Model):
         list
             List of `~stdatamodels.jwst.transforms.models.Slit` objects.
         """
-        if isiterable(self._slits[0]):
+        if np.iterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids
@@ -634,8 +650,15 @@ class Slit2Msa(Model):
         self.outputs = ("x_msa", "y_msa", "name")
         """ x and y coordinates in the MSA frame."""
         if np.iterable(slits[0]):
-            self._slits = [tuple(s) for s in slits]
-            self.slit_ids = [s[0] for s in self._slits]
+            self.slit_ids = []
+            self._slits = []
+            for slit in slits:
+                slit_tuple = Slit(*slit)
+                if slit_tuple.slit_id == -9999:
+                    self.slit_ids.append(slit_tuple.name)
+                else:
+                    self.slit_ids.append(slit_tuple.slit_id)
+                self._slits.append(tuple(slit_tuple))
         else:
             self._slits = list(slits)
             self.slit_ids = self._slits
@@ -728,9 +751,16 @@ class Msa2Slit(Model):
         """ Name of the slit, x and y coordinates within the virtual slit."""
         self.outputs = ("name", "x_msa", "y_msa")
         """ x and y coordinates in the MSA frame."""
-        if isiterable(slits[0]):
-            self._slits = [tuple(s) for s in slits]
-            self.slit_ids = [s[0] for s in self._slits]
+        if np.iterable(slits[0]):
+            self.slit_ids = []
+            self._slits = []
+            for slit in slits:
+                slit_tuple = Slit(*slit)
+                if slit_tuple.slit_id == -9999:
+                    self.slit_ids.append(slit_tuple.name)
+                else:
+                    self.slit_ids.append(slit_tuple.slit_id)
+                self._slits.append(tuple(slit_tuple))
         else:
             self._slits = list(slits)
             self.slit_ids = self._slits
@@ -738,7 +768,7 @@ class Msa2Slit(Model):
 
     @property
     def slits(self):
-        if isiterable(self._slits[0]):
+        if np.iterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -631,7 +631,7 @@ class Slit2Msa(Model):
         super(Slit2Msa, self).__init__()
         self.inputs = ("name", "x_slit", "y_slit")
         """ Name of the slit, x and y coordinates within the virtual slit."""
-        self.outputs = ("name", "x_msa", "y_msa")
+        self.outputs = ("x_msa", "y_msa", "name")
         """ x and y coordinates in the MSA frame."""
         if np.iterable(slits[0]):
             self._slits = [tuple(s) for s in slits]

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -441,7 +441,64 @@ class Gwa2Slit(Model):
             Wavelength.
         """
         index = self.slit_ids.index(name)
-        return (name,) + self.models[index](x, y, z)
+        return (name, ) + self.models[index](x, y, z)
+
+    def inverse(self):
+        inv_models = [m.inverse for m in self.models]
+        return Slit2Gwa(self.slits, inv_models)
+
+
+class Slit2Gwa(Model):
+    """
+    NIRSpec slit to GWA transform.
+
+    Parameters
+    ----------
+    slits : list
+        A list of open slits.
+        A slit is a namedtuple of type `~stdatamodels.jwst.transforms.models.Slit`
+        Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
+        "quadrant", "source_id", "shutter_state", "source_name",
+        "source_alias", "stellarity", "source_xpos", "source_ypos",
+        "source_ra", "source_dec"])
+    models : list
+        List of models (`~astropy.modeling.core.Model`) corresponding to the
+        list of slits.
+    """
+    _separable = False
+
+    n_inputs = 4
+    n_outputs = 4
+
+    def __init__(self, slits, models):
+        if isiterable(slits[0]):
+            self._slits = [tuple(s) for s in slits]
+            self.slit_ids = [s[0] for s in self._slits]
+        else:
+            self._slits = list(slits)
+            self.slit_ids = self._slits
+
+        self.models = models
+        super(Slit2Gwa, self).__init__()
+        self.outputs = ('name', 'angle1', 'angle2', 'angle3')
+        """ Name of the slit and the three angle coordinates at the GWA going from detector to sky."""
+        self.inputs = ('name', 'x_slit', 'y_slit', 'lam')
+        """ Name of the slit, x and y coordinates within the virtual slit and wavelength."""
+
+    @property
+    def slits(self):
+        if isiterable(self._slits[0]):
+            return [Slit(*row) for row in self._slits]
+        else:
+            return self.slit_ids
+
+    def get_model(self, name):
+        index = self.slit_ids.index(name)
+        return self.models[index]
+
+    def evaluate(self, name, x, y, z):
+        index = self.slit_ids.index(name)
+        return (name, ) + self.models[index](x, y, z)
 
 
 class Slit2Msa(Model):
@@ -450,7 +507,7 @@ class Slit2Msa(Model):
     _separable = False
 
     n_inputs = 3
-    n_outputs = 2
+    n_outputs = 3
 
     def __init__(self, slits, models):
         """
@@ -472,7 +529,7 @@ class Slit2Msa(Model):
         super(Slit2Msa, self).__init__()
         self.inputs = ("name", "x_slit", "y_slit")
         """ Name of the slit, x and y coordinates within the virtual slit."""
-        self.outputs = ("x_msa", "y_msa")
+        self.outputs = ("name", "x_msa", "y_msa")
         """ x and y coordinates in the MSA frame."""
         if np.iterable(slits[0]):
             self._slits = [tuple(s) for s in slits]
@@ -531,7 +588,64 @@ class Slit2Msa(Model):
             The x and y coordinates in the MSA frame.
         """
         index = self.slit_ids.index(name)
-        return self.models[index](x, y)
+        return self.models[index](x, y) + (name,)
+
+    def inverse(self):
+        models = [m.inverse for m in self.models]
+        inv_model = Msa2Slit(self.slits, models)
+        return inv_model
+
+
+class Msa2Slit(Model):
+    """
+    Transform from Nirspec ``slit_frame`` to ``msa_frame``.
+
+    Parameters
+    ----------
+    slits : list
+        A list of open slits.
+        A slit is a namedtuple, `~stdatamodels.jwst.transforms.models.Slit`
+        Slit("name", "shutter_id", "dither_position", "xcen", "ycen", "ymin", "ymax",
+        "quadrant", "source_id", "shutter_state", "source_name",
+        "source_alias", "stellarity", "source_xpos", "source_ypos",
+        "source_ra", "source_dec")
+    models : list
+        List of models (`~astropy.modeling.core.Model`) corresponding to the
+        list of slits.
+    """
+    _separable = False
+
+    n_inputs = 3
+    n_outputs = 3
+
+    def __init__(self, slits, models):
+        super(Msa2Slit, self).__init__()
+        self.inputs = ('name', 'x_slit', 'y_slit')
+        """ Name of the slit, x and y coordinates within the virtual slit."""
+        self.outputs = ('name', 'x_msa', 'y_msa')
+        """ x and y coordinates in the MSA frame."""
+        if isiterable(slits[0]):
+            self._slits = [tuple(s) for s in slits]
+            self.slit_ids = [s[0] for s in self._slits]
+        else:
+            self._slits = list(slits)
+            self.slit_ids = self._slits
+        self.models = models
+
+    @property
+    def slits(self):
+        if isiterable(self._slits[0]):
+            return [Slit(*row) for row in self._slits]
+        else:
+            return self.slit_ids
+
+    def get_model(self, name):
+        index = self.slit_ids.index(name)
+        return self.models[index]
+
+    def evaluate(self, name, x, y):
+        index = self.slit_ids.index(name)
+        return (name,) + self.models[index](x, y)
 
 
 class NirissSOSSModel(Model):

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -747,9 +747,9 @@ class Msa2Slit(Model):
 
     def __init__(self, slits, models):
         super(Msa2Slit, self).__init__()
-        self.inputs = ("name", "x_slit", "y_slit")
+        self.inputs = ("x_msa", "y_msa", "name")
         """ Name of the slit, x and y coordinates within the virtual slit."""
-        self.outputs = ("name", "x_msa", "y_msa")
+        self.outputs = ("name", "x_slit", "y_slit")
         """ x and y coordinates in the MSA frame."""
         if np.iterable(slits[0]):
             self.slit_ids = []
@@ -777,7 +777,7 @@ class Msa2Slit(Model):
         index = self.slit_ids.index(name)
         return self.models[index]
 
-    def evaluate(self, name, x, y):
+    def evaluate(self, x, y, name):
         index = self.slit_ids.index(name)
         return (name,) + self.models[index](x, y)
 

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
@@ -32,12 +32,26 @@ tags:
     It maps slit to the transform from the Grating Wheel Assembly (GWA)
     to the coordinate frame of the slit, where (0, 0) is the center of
     the slit.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_gwa-1.0.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_gwa-1.0.0
+  title: NIRSPEC set of models from slit_frame to GWA.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It stores transforms mapping locations in the virtual slit
+    to locations at the Grating Wheel Assembly (GWA).
+    The center of the slit is at (0, 0).
 - tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_msa-1.1.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.1.0
   title: NIRSPEC set of models from slit_frame to the MSA frame.
   description: |-
     This model is used by the NIRSPEC WCS pipeline.
     It maps a slit to its position in the MSA plane.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/msa_to_slit-1.0.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/msa_to_slit-1.0.0
+  title: NIRSPEC set of models from the MSA to the slit frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It stores the transforms from the MSA plane to the slit_frame frame.
 - tag_uri: "tag:stsci.edu:jwst_pipeline/logical-1.1.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/logical-1.1.0
   title: A model performing logical operations on arrays.

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.1.0.yaml
@@ -32,26 +32,12 @@ tags:
     It maps slit to the transform from the Grating Wheel Assembly (GWA)
     to the coordinate frame of the slit, where (0, 0) is the center of
     the slit.
-- tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_gwa-1.0.0"
-  schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_gwa-1.0.0
-  title: NIRSPEC set of models from slit_frame to GWA.
-  description: |-
-    This model is used by the NIRSPEC WCS pipeline.
-    It stores transforms mapping locations in the virtual slit
-    to locations at the Grating Wheel Assembly (GWA).
-    The center of the slit is at (0, 0).
 - tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_msa-1.1.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.1.0
   title: NIRSPEC set of models from slit_frame to the MSA frame.
   description: |-
     This model is used by the NIRSPEC WCS pipeline.
     It maps a slit to its position in the MSA plane.
-- tag_uri: "tag:stsci.edu:jwst_pipeline/msa_to_slit-1.0.0"
-  schema_uri: http://stsci.edu/schemas/jwst_pipeline/msa_to_slit-1.0.0
-  title: NIRSPEC set of models from the MSA to the slit frame.
-  description: |-
-    This model is used by the NIRSPEC WCS pipeline.
-    It stores the transforms from the MSA plane to the slit_frame frame.
 - tag_uri: "tag:stsci.edu:jwst_pipeline/logical-1.1.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/logical-1.1.0
   title: A model performing logical operations on arrays.

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.2.0.yaml
@@ -32,12 +32,26 @@ tags:
     It maps slit to the transform from the Grating Wheel Assembly (GWA)
     to the coordinate frame of the slit, where (0, 0) is the center of
     the slit.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_gwa-1.0.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_gwa-1.0.0
+  title: NIRSPEC set of models from slit_frame to GWA.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It stores transforms mapping locations in the virtual slit
+    to locations at the Grating Wheel Assembly (GWA).
+    The center of the slit is at (0, 0).
 - tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_msa-1.2.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.2.0
   title: NIRSPEC set of models from slit_frame to the MSA frame.
   description: |-
     This model is used by the NIRSPEC WCS pipeline.
     It maps a slit to its position in the MSA plane.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/msa_to_slit-1.0.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/msa_to_slit-1.0.0
+  title: NIRSPEC set of models from the MSA to the slit frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It stores the transforms from the MSA plane to the slit_frame frame.
 - tag_uri: "tag:stsci.edu:jwst_pipeline/logical-1.2.0"
   schema_uri: http://stsci.edu/schemas/jwst_pipeline/logical-1.2.0
   title: A model performing logical operations on arrays.

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/msa_to_slit-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/msa_to_slit-1.0.0.yaml
@@ -1,0 +1,28 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/msa_to_slit-1.0.0"
+title: >
+  NIRSPEC set of models from the "msa_frame" to the "slit_frame" frame.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It stores the transforms from the MSA plane to a virtual slit frame.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      slits:
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+      models:
+        description: |
+          A compound model transferring positions in the MSA frame to
+          positions in the slit frame.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/msa_to_slit-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/msa_to_slit-1.0.0.yaml
@@ -9,7 +9,7 @@ description: |
   It stores the transforms from the MSA plane to a virtual slit frame.
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
   - type: object
     properties:
       slits:

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_gwa-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_gwa-1.0.0.yaml
@@ -1,0 +1,35 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/slit_to_gwa-1.0.0"
+title: >
+  NIRSPEC set of models from slit_frame to GWA.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It stores transforms from the virrtual slit frame, where (0, 0) 
+  is the center of the slit. to the Grating Wheel Assembly (GWA).
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - type: object
+    properties:
+      slits:
+        description: |
+          An array with slit numbers.
+          The slit number is computed from the quadrant and
+          the slit ID in this quadrant using
+
+          $P = quadrant * number_of_shutters_quadrant + slit_id$
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-*"
+      models:
+        description: |
+          A compound model transferring positions in the slit frame
+          to a location at the GWA.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_gwa-1.0.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_gwa-1.0.0.yaml
@@ -10,7 +10,7 @@ description: |
   is the center of the slit. to the Grating Wheel Assembly (GWA).
 
 allOf:
-  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.3.0"
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
   - type: object
     properties:
       slits:

--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -3,6 +3,7 @@
 Test jwst.transforms
 """
 
+import asdf
 import pytest
 from astropy.modeling.models import Identity
 from numpy.testing import assert_allclose
@@ -66,7 +67,7 @@ def test_refraction_index(wavelength, n):
     assert_allclose(n_pipeline, n)
 
 
-def test_slit_to_msa_from_ids():
+def test_slit_to_msa_from_ids(tmp_path):
     slits = list(range(5))
     transforms = [Identity(2)] * len(slits)
     slit2msa = models.Slit2Msa(slits, transforms)
@@ -85,8 +86,15 @@ def test_slit_to_msa_from_ids():
         # and the opposite on inverse
         assert slit2msa.inverse(200, 200, i) == (i, 200, 200)
 
+    # test roundtrip to file
+    tmp_file = tmp_path / "slit2msa.asdf"
+    asdf.AsdfFile({"model": slit2msa}).write_to(tmp_file)
+    with asdf.open(tmp_file) as af:
+        assert af["model"].slits == slits
+        assert af["model"].slit_ids == slits
 
-def test_slit_to_msa_from_slits():
+
+def test_slit_to_msa_from_slits(tmp_path):
     slits = []
     for i in range(3):
         slits.append(models.Slit(i))
@@ -108,8 +116,15 @@ def test_slit_to_msa_from_slits():
         # and the opposite on inverse
         assert slit2msa.inverse(200, 200, i) == (i, 200, 200)
 
+    # test roundtrip to file
+    tmp_file = tmp_path / "slit2msa.asdf"
+    asdf.AsdfFile({"model": slit2msa}).write_to(tmp_file)
+    with asdf.open(tmp_file) as af:
+        assert af["model"].slits == slits
+        assert af["model"].slit_ids == list(range(len(slits)))
 
-def test_gwa_to_slit_from_ids():
+
+def test_gwa_to_slit_from_ids(tmp_path):
     slits = list(range(5))
     transforms = [Identity(3)] * len(slits)
     gwa2slit = models.Gwa2Slit(slits, transforms)
@@ -128,8 +143,15 @@ def test_gwa_to_slit_from_ids():
         # and the same on inverse
         assert gwa2slit.inverse(i, 200, 200, 200) == (i, 200, 200, 200)
 
+    # test roundtrip to file
+    tmp_file = tmp_path / "gwa2slit.asdf"
+    asdf.AsdfFile({"model": gwa2slit}).write_to(tmp_file)
+    with asdf.open(tmp_file) as af:
+        assert af["model"].slits == slits
+        assert af["model"].slit_ids == slits
 
-def test_gwa_to_slit_from_slits():
+
+def test_gwa_to_slit_from_slits(tmp_path):
     slits = []
     for i in range(3):
         slits.append(models.Slit(i))
@@ -151,8 +173,15 @@ def test_gwa_to_slit_from_slits():
         # and the same on inverse
         assert gwa2slit.inverse(i, 200, 200, 200) == (i, 200, 200, 200)
 
+    # test roundtrip to file
+    tmp_file = tmp_path / "gwa2slit.asdf"
+    asdf.AsdfFile({"model": gwa2slit}).write_to(tmp_file)
+    with asdf.open(tmp_file) as af:
+        assert af["model"].slits == slits
+        assert af["model"].slit_ids == list(range(len(slits)))
 
-def test_slit_to_msa_legacy():
+
+def test_slit_to_msa_legacy(tmp_path):
     slits = []
     for i in range(3):
         slits.append(models.Slit(i))
@@ -171,3 +200,11 @@ def test_slit_to_msa_legacy():
     for i in range(len(slits)):
         # slit name is not propagated to output
         assert slit2msa(i, 200, 200) == (200, 200)
+
+    # test roundtrip to file
+    tmp_file = tmp_path / "slit2msa_legacy.asdf"
+    asdf.AsdfFile({"model": slit2msa}).write_to(tmp_file)
+    with pytest.warns(DeprecationWarning, match='WCS pipeline may be incomplete'):
+        with asdf.open(tmp_file) as af:
+            assert af["model"].slits == slits
+            assert af["model"].slit_ids == list(range(len(slits)))


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-1028](https://jira.stsci.edu/browse/JP-1028)

Requires https://github.com/spacetelescope/jwst/pull/9404

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Update NIRSpec WCS transforms to propagate the slit name throughout.

Changes include:
- Inverse transforms for Slit2Msa and Gwa2Slit
- Change outputs for Slit2Msa to include slit name
- Add a legacy model to handle old output structure for Slit2Msa
- Add a slit ID to the Slit tuple, to allow NIRSpec FS slits to be uniquely identified with a numerical value (slit.name is a string, which can't be passed through the WCS transforms).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
