### PR TITLE
replace astropy isiterable with np.iterable

### DIFF
--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -15,7 +15,6 @@ from astropy.modeling.core import Model
 from astropy.modeling.parameters import Parameter, InputParameterError
 from astropy.modeling.models import Rotation2D, Mapping, Tabular1D, Const1D
 from astropy.modeling.models import math as astmath
-from astropy.utils import isiterable
 from ...properties import ListNode
 
 
@@ -373,7 +372,7 @@ class Gwa2Slit(Model):
     n_outputs = 4
 
     def __init__(self, slits, models):
-        if isiterable(slits[0]):
+        if np.iterable(slits[0]):
             self._slits = [tuple(s) for s in slits]
             self.slit_ids = [s[0] for s in self._slits]
         else:
@@ -399,7 +398,7 @@ class Gwa2Slit(Model):
         list
             List of `~stdatamodels.jwst.transforms.models.Slit` objects.
         """
-        if isiterable(self._slits[0]):
+        if np.iterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids
@@ -475,7 +474,7 @@ class Slit2Msa(Model):
         """ Name of the slit, x and y coordinates within the virtual slit."""
         self.outputs = ("x_msa", "y_msa")
         """ x and y coordinates in the MSA frame."""
-        if isiterable(slits[0]):
+        if np.iterable(slits[0]):
             self._slits = [tuple(s) for s in slits]
             self.slit_ids = [s[0] for s in self._slits]
         else:
@@ -493,7 +492,7 @@ class Slit2Msa(Model):
         list
             List of `~stdatamodels.jwst.transforms.models.Slit` objects.
         """
-        if isiterable(self._slits[0]):
+        if np.iterable(self._slits[0]):
             return [Slit(*row) for row in self._slits]
         else:
             return self.slit_ids


### PR DESCRIPTION
Astropy has deprecated `isiterable`:
https://github.com/astropy/astropy/pull/18053
it's implementation is identical to `np.iterable`:
https://numpy.org/doc/1.23/reference/generated/numpy.iterable.html

This PR switches `isiterable` usage to `np.iterable`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
