### PR TITLE
Add support for multi-valued defaults in recarray-like schemas

### DIFF
--- a/changes/469.feature.rst
+++ b/changes/469.feature.rst
@@ -1,0 +1,1 @@
+Add support for multi-valued defaults in table schemas

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -243,7 +243,11 @@ def _make_default_array(attr, schema, ctx):
     if default is not None:
         if isinstance(default, list):
             # support multi-valued defaults for when array is recarray
-            default = np.array(tuple(default), dtype=dtype)
+            try:
+                default = np.array(tuple(default), dtype=dtype)
+            except ValueError:
+                msg = f"Invalid default value {default} for recarray dtype {dtype}"
+                raise ValueError(msg) from None
         array[...] = default
     return array
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -241,6 +241,9 @@ def _make_default_array(attr, schema, ctx):
 
     array = np.empty(shape, dtype=dtype)
     if default is not None:
+        if isinstance(default, list):
+            # support multi-valued defaults for when array is recarray
+            default = np.array(tuple(default), dtype=dtype)
         array[...] = default
     return array
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -59,3 +59,12 @@ class TableModel(DataModel):
 
     def get_primary_array_name(self):  # noqa: D102
         return "table"
+
+
+class TableModelBad(DataModel):
+    """Model that includes a recarray-style table with bad defaults."""
+
+    schema_url = "http://example.com/schemas/table_model_bad_defaults"
+
+    def get_primary_array_name(self):  # noqa: D102
+        return "table"

--- a/tests/models.py
+++ b/tests/models.py
@@ -56,3 +56,6 @@ class TableModel(DataModel):
     """Model that includes a recarray-style table."""
 
     schema_url = "http://example.com/schemas/table_model"
+
+    def get_primary_array_name(self):  # noqa: D102
+        return "table"

--- a/tests/schemas/table_model.yaml
+++ b/tests/schemas/table_model.yaml
@@ -8,6 +8,7 @@ allOf:
     properties:
       table:
         fits_hdu: TABLE
+        default: [0, 42, NaN, "foo", 42.0, 0.0]
         datatype:
           - name: int16_column
             datatype: int16

--- a/tests/schemas/table_model_bad_defaults.yaml
+++ b/tests/schemas/table_model_bad_defaults.yaml
@@ -1,0 +1,27 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/basic_model
+title: Model with a recarray-style table.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      table:
+        fits_hdu: TABLE
+        default: [0, "bar", NaN, "foo", "baz", 0.0]
+        datatype:
+          - name: int16_column
+            datatype: int16
+          - name: uint16_column
+            datatype: uint16
+          - name: float32_column
+            datatype: float32
+          - name: ascii_column
+            datatype: [ascii, 64]
+          - name: float32_column_with_shape
+            datatype: float32
+            shape: [3, 2]
+          - name: float32_column_with_ndim
+            datatype: float32
+            ndim: 2
+...

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -167,6 +167,23 @@ def test_default_value_anyof_schema():
         assert dm.meta.foo is None
 
 
+def test_multivalued_default_table_schema():
+    """Test setting list-like default values in a table schema"""
+    with TableModel((10,)) as dm:
+        defaults = dm.schema["properties"]["table"]["default"]
+        columns = [col["name"] for col in dm.schema["properties"]["table"]["datatype"]]
+        for default, name in zip(defaults, columns):
+            print(dm.table[name])
+            if default == "NaN":
+                default = np.nan
+            elif isinstance(default, str):
+                # allclose has trouble with string comparisons
+                for elem in dm.table[name]:
+                    assert elem.decode("utf-8") == default
+                continue
+            assert np.allclose(dm.table[name], default, equal_nan=True)
+
+
 def test_secondary_shapes():
     """
     Confirm that a non-primary array takes on the shape

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from stdatamodels import DataModel
 
-from models import BasicModel, AnyOfModel, TableModel, TransformModel, FitsModel
+from models import BasicModel, AnyOfModel, TableModel, TableModelBad, TransformModel, FitsModel
 from stdatamodels.exceptions import ValidationWarning
 
 
@@ -173,7 +173,6 @@ def test_multivalued_default_table_schema():
         defaults = dm.schema["properties"]["table"]["default"]
         columns = [col["name"] for col in dm.schema["properties"]["table"]["datatype"]]
         for default, name in zip(defaults, columns):
-            print(dm.table[name])
             if default == "NaN":
                 default = np.nan
             elif isinstance(default, str):
@@ -182,6 +181,12 @@ def test_multivalued_default_table_schema():
                     assert elem.decode("utf-8") == default
                 continue
             assert np.allclose(dm.table[name], default, equal_nan=True)
+
+
+def test_multivalued_default_table_schema_bad():
+    """Test error raise if the default does not match the array type"""
+    with pytest.raises(ValueError):
+        TableModelBad((10,))
 
 
 def test_secondary_shapes():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Relates to [JP-3931](https://jira.stsci.edu/browse/JP-3931)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #468 

<!-- describe the changes comprising this PR here -->
This PR allows multi-valued defaults to be passed in for table-like schemas.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
