### PR TITLE
Refactor to_flat_dict to handle nested lists

### DIFF
--- a/changes/476.bugfix.rst
+++ b/changes/476.bugfix.rst
@@ -1,0 +1,1 @@
+Allow read_metadata to handle nested lists from extra_fits

--- a/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
@@ -247,3 +247,25 @@ def test_error_schema_not_found(model_path):
     if model_path.suffix == ".fits":
         with pytest.raises(ValueError):
             read_metadata(model_path, model_type="foo")
+
+
+def test_nested_list_to_flat_dict():
+    """Test that nested lists are flattened correctly."""
+    # Create a nested list
+    nested_list = [
+        {"a": 1, "b": [2, 3]},
+        {"c": 4, "d": [5, 6]},
+    ]
+
+    # Flatten the list
+    flat_dict = _to_flat_dict(nested_list)
+
+    # Check that the keys are flattened correctly
+    assert flat_dict == {
+        "0.a": 1,
+        "0.b.0": 2,
+        "0.b.1": 3,
+        "1.c": 4,
+        "1.d.0": 5,
+        "1.d.1": 6,
+    }

--- a/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
@@ -249,13 +249,21 @@ def test_error_schema_not_found(model_path):
             read_metadata(model_path, model_type="foo")
 
 
-def test_nested_list_to_flat_dict():
+@pytest.mark.parametrize("is_tuple", [True, False])
+def test_nested_list_to_flat_dict(is_tuple):
     """Test that nested lists are flattened correctly."""
     # Create a nested list
-    nested_list = [
-        {"a": 1, "b": [2, 3]},
-        {"c": 4, "d": [5, 6]},
-    ]
+    if is_tuple:
+        nested_list = (
+            {"a": 1, "b": (2, 3)},
+            {"c": 4, "d": (5, 6)},
+        )
+    else:
+        # Use a list of dictionaries instead
+        nested_list = [
+            {"a": 1, "b": [2, 3]},
+            {"c": 4, "d": [5, 6]},
+        ]
 
     # Flatten the list
     flat_dict = _to_flat_dict(nested_list)

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -461,7 +461,7 @@ def _to_flat_dict(tree):
                     continue
                 current_path = path + [key]
                 recurse(val, current_path)
-        elif isinstance(subtree, list):
+        elif isinstance(subtree, (list, tuple)):
             for i, item in enumerate(subtree):
                 indexed_key = f"{path[-1]}.{i}" if path else str(i)
                 recurse(item, path[:-1] + [indexed_key])

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -454,22 +454,19 @@ def _to_flat_dict(tree):
     flat_dict = {}
 
     def recurse(subtree, path):
-        for key, val in subtree.items():
-            if key == "wcs":
-                # Skip the WCS object because it is recursive
-                continue
-            current_path = path + [key]
-            if isinstance(val, dict):
+        if isinstance(subtree, dict):
+            for key, val in subtree.items():
+                if key == "wcs":
+                    # Skip the WCS object because it is recursive
+                    continue
+                current_path = path + [key]
                 recurse(val, current_path)
-            elif isinstance(val, (list, tuple)):
-                for i, item in enumerate(val):
-                    indexed_key = f"{key}.{i}"
-                    if isinstance(item, (dict, list, tuple)):
-                        recurse(item, path + [indexed_key])
-                    else:
-                        flat_dict[".".join(path + [indexed_key])] = item
-            else:
-                flat_dict[".".join(current_path)] = val
+        elif isinstance(subtree, list):
+            for i, item in enumerate(subtree):
+                indexed_key = f"{path[-1]}.{i}" if path else str(i)
+                recurse(item, path[:-1] + [indexed_key])
+        else:
+            flat_dict[".".join(path)] = subtree
 
     recurse(tree, [])
     return flat_dict


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #475 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug that the initial implementation of `_to_flat_dict` failed to handle nested lists.

That was causing the failures discussed on the issue thanks to our favorite piece of stdatamodels, `extra_fits`, which apparently represents headers as nested lists.  The fact that this only occurred inside `extra_fits` was one reason we didn't catch this initially.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
