### PR TITLE
JP-3922: Add a regions array to NRS IFU models

### DIFF
--- a/changes/479.feature.rst
+++ b/changes/479.feature.rst
@@ -1,0 +1,1 @@
+Add a new data array in the ``regions`` attribute to IFUImageModel, to hold a pixel-to-slice map for NIRSpec IFU data.

--- a/src/stdatamodels/jwst/datamodels/schemas/ifuimage.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ifuimage.schema.yaml
@@ -33,6 +33,10 @@ allOf:
       title: Pixel area map array
       fits_hdu: AREA
       datatype: float32
+    regions:
+      title: Slice regions map
+      fits_hdu: REGIONS
+      datatype: int32
 - $ref: variance.schema
 - type: object
   properties:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3922](https://jira.stsci.edu/browse/JP-3922)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Add a new data array to IFUImageModel, to hold a pixel to slice map.  This is intended for NRS IFU data, for which there is no static regions reference file.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
