### PR TITLE
bump transform-1.3.0 to 1.4.0

### DIFF
--- a/changes/483.feature.rst
+++ b/changes/483.feature.rst
@@ -1,0 +1,1 @@
+Update transform schemas to use new asdf-transform-schemas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ classifiers = [
 ]
 dependencies = [
     "asdf>=3.3.0",
-    "asdf-transform-schemas>=0.5.0",
+    #"asdf-transform-schemas>=0.5.0",
+    "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
     "asdf-astropy>=0.6.0",
     "numpy>=1.25",
     "astropy>=6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ classifiers = [
 ]
 dependencies = [
     "asdf>=3.3.0",
-    #"asdf-transform-schemas>=0.5.0",
-    "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
+    "asdf-transform-schemas>=0.6.0",
     "asdf-astropy>=0.6.0",
     "numpy>=1.25",
     "astropy>=6.1",

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -36,6 +36,11 @@ _CONVERTERS = [
 # that occur earlier in the list.
 TRANSFORM_EXTENSIONS = [
     ManifestExtension.from_uri(
+        "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.2.0",
+        legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
+        converters=_CONVERTERS,
+    ),
+    ManifestExtension.from_uri(
         "asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.1.0",
         legacy_class_names=["jwst.transforms.jwextension.JWSTExtension"],
         converters=_CONVERTERS,

--- a/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/manifests/jwst_transforms-1.2.0.yaml
@@ -1,0 +1,94 @@
+id: asdf://stsci.edu/jwst_pipeline/manifests/jwst_transforms-1.2.0
+extension_uri: asdf://stsci.edu/jwst_pipeline/extensions/jwst_transforms-1.2.0
+title: JWST Transform extension
+description: |-
+  A set of tags for serializing data transforms for the JWST pipeline.
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+- tag_uri: "tag:stsci.edu:jwst_pipeline/nircam_grism_dispersion-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/nircam_grism_dispersion-1.2.0
+  title: NIRCAM Grism dispersion model
+  description: |-
+    Supports two models:
+    Given x, y, wave, order in effective direct image returns
+    x,y,wave,order in dispersed
+    Given x, y, x0, y0, order in dispersed image returns x, y, wave, order
+    in effective direct
+- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss_grism_dispersion-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_grism_dispersion-1.2.0
+  title: NIRISS Grism dispersion model
+  description: |-
+    Supports two models:
+    Given x, y, wave, order in effective direct image returns
+    x, y, wave, order in dispersed
+    Given x, y, x0, y0, order in dispersed image returns
+    x, y, wave, order in effective direct
+- tag_uri: "tag:stsci.edu:jwst_pipeline/gwa_to_slit-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/gwa_to_slit-1.2.0
+  title: NIRSPEC set of models from GWA to slit_frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It maps slit to the transform from the Grating Wheel Assembly (GWA)
+    to the coordinate frame of the slit, where (0, 0) is the center of
+    the slit.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/slit_to_msa-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.2.0
+  title: NIRSPEC set of models from slit_frame to the MSA frame.
+  description: |-
+    This model is used by the NIRSPEC WCS pipeline.
+    It maps a slit to its position in the MSA plane.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/logical-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/logical-1.2.0
+  title: A model performing logical operations on arrays.
+  description: |-
+    Implements the Numpy logical operators
+- tag_uri: "tag:stsci.edu:jwst_pipeline/niriss_soss-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/niriss_soss-1.2.0
+  title: NIRISS SOSS transforms.
+  description: |-
+    This model is used by the NIRISS SOSS WCS pipeline.
+    It maps spectral order to transform
+- tag_uri: "tag:stsci.edu:jwst_pipeline/refraction_index_from_prism-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/refraction_index_from_prism-1.2.0
+  title: Computes the refraction index for the NIRSpec prism.
+  description: |-
+    Given the prism angle and the incident and refracted angles, compute the
+    index of refraction.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/miri_ab2slice-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/miri_ab2slice-1.2.0
+  title: MIRI MRS (alpha, beta) to slice number transform.
+  description: |-
+    This model is used by the MIRI MRS WCS pipeline.
+    Given a (beta, ) coordinate it computes the slice number
+    that the coordinate belongs to in detector coordinates.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/rotation_sequence-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/rotation_sequence-1.2.0
+  title: A sequence of 3D rotations.
+  description: |-
+    A sequence of 3D rotations around different axes.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/snell-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/snell-1.2.0
+  title: NIRSpec transforms through the prism.
+  description: |-
+    This model does all transforms through the NIRSpec prism:
+    - computes the refraction index as a function of lambda.
+    - Applies Snell's law through front surface.
+    - Rotates to back surface.
+    - Applies reflection from back surface.
+    - Rotates to front surface
+    - Applies Snell's law through front surface.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/grating_equation-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/grating_equation-1.2.0
+  title: A grating equation model.
+  description: |-
+    Supports two models:
+    - Given incident angle and wavelength compute the refraction/diffraction angle.
+    - Given an incident angle and a refraction angle compute the wavelength.
+- tag_uri: "tag:stsci.edu:jwst_pipeline/coords-1.2.0"
+  schema_uri: http://stsci.edu/schemas/jwst_pipeline/coords-1.2.0
+  title: Convert coordinates between vector and directional cosine form.
+  description: |-
+    This schema is for representing any model that takes coordinates and does
+    some computation with them. Models have no parameters. Currently it supports
+    DirCos2Unitless, Unitless2DirCos.

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/coords-1.2.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/coords-1.2.0"
+
+title: >
+  Convert coordinates between vector and directional cosine form.
+
+description: |
+  This schema is for representing any model that takes coordinates and does
+  some computation with them. Models have no parameters. Currently it supports
+  DirCos2Unitless, Unitless2DirCos.
+
+examples:
+  -
+    - Convert directional cosines to vectors.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/coords-1.2.0>
+          model_type: directional2unitless
+
+  -
+    - Convert vectors to directional cosines.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/coords-1.2.0>
+          model_type: unitless2directional
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      model_type:
+        description: |
+          The type of class to initialize.
+        type: string
+    required: [model_type]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/grating_equation-1.2.0.yaml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/grating_equation-1.2.0"
+
+title: >
+  A grating equation model.
+description: |
+  Supports two models:
+   - Given incident angle and wavelength compute the refraction/diffraction angle.
+   - Given an incident angle and a refraction angle compute the wavelength.
+
+examples:
+  -
+    - AngleFromGratingEquation model.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/grating_equation-1.2.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: angle
+
+  -
+    - WavelengthFromGratingEquation model.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/grating_equation-1.2.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: wavelength
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      groove_density:
+        description: |
+          The groove density of the grating
+        type: number
+      order:
+        description: |
+          Spectral order
+        type: number
+
+    required: [groove_density, order]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/gwa_to_slit-1.2.0.yaml
@@ -1,0 +1,36 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/gwa_to_slit-1.2.0"
+title: >
+  NIRSPEC set of models from GWA to slit_frame.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It maps slit to the transform from the Grating Wheel Assembly (GWA)
+  to the coordinate frame of the slit, where (0, 0) is the center of
+  the slit.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      slits:
+        description: |
+          An array with slit numbers.
+          The slit number is computed from the quadrant and
+          the slit ID in this quadrant using
+
+          $P = quadrant * number_of_shutters_quadrant + slit_id$
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      models:
+        description: |
+          A compound model transferring positions at the GWA to
+          position in the slit frame.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/logical-1.2.0.yaml
@@ -1,0 +1,53 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/logical-1.2.0"
+title: >
+  A model performing logical operations on arrays.
+
+examples:
+  -
+    - If the input is less that 10, set its value to NaN.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/logical-1.2.0>
+          compareto: 10
+          condition: LT
+          value: .nan
+  -
+    - |
+        If the input is less that [1,2,3,4], set its value to [5,6,7,8].
+        The input array should have the same shape.
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/logical-1.2.0>
+          compareto: [1 ,2, 3, 4]
+          condition: LT
+          value: [5, 6, 7, 8]
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      condition:
+        description: |
+          A string representing the logical operation,
+          one of GT, LT, NE, EQ
+        type: string
+        enum: [GT, LT, NE, EQ]
+      compareto:
+        description: |
+          A number or ndarray to compare to using the condition.
+          If ndarray then the input array, compareto and value should have the same shape.
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - type: array
+          - type: number
+      value:
+        description: |
+          Value to substitute where condition is True.
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - type: array
+          - type: number

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/miri_ab2slice-1.2.0.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/miri_ab2slice-1.2.0"
+title: >
+  MIRI MRS (alpha, beta) to slice number transform.
+
+description: |
+  This model is used by the MIRI MRS WCS pipeline.
+  Given a (beta, ) coordinate it computes the slice number
+  that the coordinate belongs to in detector coordinates.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      beta_zero:
+        description: |
+          Beta coordinate of the center of slice 1 in the MIRI MRS.
+        type: number
+      beta_del:
+        description: |
+          Slice width.
+        type: number
+      channel:
+        description: |
+          MIRI channel number.
+        type:
+          number
+        enum: [1, 2, 3, 4]
+    required: [beta_zero, beta_del, channel]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/nircam_grism_dispersion-1.2.0.yaml
@@ -1,0 +1,64 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/nircam_grism_dispersion-1.2.0"
+title: >
+  NIRCAM Grism dispersion model
+description: |
+  Supports two models:
+   - given x,y,wave,order in effective direct image return x, y, wave, order in dispersed.
+   - given x,y,x0,y0,order in dispersed image returns x, y, wave, order in effective direct.
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      xmodels:
+        description: |
+         NIRCAM row dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      ymodels:
+        description: |
+          NIRCAM column dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      lmodels:
+        description: |
+          NIRCAM wavelength dispersion models
+        type: array
+        items:
+          oneOf:
+            - type: object
+              $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+            - type: array
+              items:
+                type: object
+                $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      orders:
+        description: |
+          NIRCAM available grism orders, in-sync with the model arrays
+        type: array
+        items:
+          type: integer
+      class_name:
+        description: |
+          The model class which should instantiate this data
+        type: string
+        items:
+          minItems: 1
+          maxItems: 1
+    required: [lmodels, xmodels, ymodels, orders]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_grism_dispersion-1.2.0.yaml
@@ -1,0 +1,52 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/niriss_grism_dispersion-1.2.0"
+title: >
+  NIRISS Grism dispersion model
+description: |
+  Supports two models:
+    - Given x,y,wave,order in effective direct image return x, y, wave, order in dispersed.
+    - Given x,y,x0,y0,order in dispersed image returns x, y, wave, order in effective direct.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      theta:
+        description: |
+          NIRISS filter wheel differential position in degrees
+        type: number
+      xmodels:
+        description: |
+          NIRISS Grism row dispersion model
+        type: array
+        items:
+          type: array
+          items:
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      ymodels:
+        description: |
+          NIRISS Grism column dispersion model
+        type: array
+        items:
+          type: array
+          items:
+            $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      lmodels:
+        description: |
+          NIRISS wavelength-models for dispersion
+        type: array
+        items:
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      orders:
+        description: |
+          NIRISS available grism orders, in-sync with the model arrays
+        type: array
+        items:
+          type: integer
+      class_name:
+        description: |
+          The model class which should instantiate this data
+        type: string
+    required: [lmodels, xmodels, ymodels, theta, orders]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/niriss_soss-1.2.0.yaml
@@ -1,0 +1,26 @@
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/niriss_soss-1.2.0"
+title: >
+  NIRISS SOSS transforms.
+
+description: |
+  This model is used by the NIRISS SOSS WCS pipeline.
+  It maps spectral order to transform.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      spectral_orders:
+        type: array
+        items:
+          type: integer
+        description: |
+          An array with spectral order numbers.
+      models:
+        description: |
+          A compound model transferring pixel to worlds coordinates.
+        type: array
+        items:
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+    required: [spectral_orders, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/refraction_index_from_prism-1.2.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/refraction_index_from_prism-1.2.0"
+title: >
+  Computes the refraction index for the NIRSpec prism.
+
+description: |
+  Given the prism angle and the incident and refracted angles, compute the
+  index of refraction.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      prism_angle:
+        description: |
+          The angle of the prism in deg.
+        type: number
+    required: [prism_angle]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/rotation_sequence-1.2.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/rotation_sequence-1.2.0"
+title: >
+  A sequence of 3D rotations.
+
+description: |
+  A sequence of 3D rotations around different axes.
+
+examples:
+  -
+    - Rotate by angles [45, -60, 60] about axes 'x', 'y', 'x'
+    - asdf-standard-1.6.0
+    - |
+        !<tag:stsci.edu:jwst_pipeline/rotation_sequence-1.2.0>
+          angles: [45.0, -60., 60.]
+          axes_order: xyx
+
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      angles:
+        description: |
+          The angles of rotation.
+        type: array
+        items:
+          type: number
+      axes_order:
+        description: |
+          A sequence of "x", "y" or "z" characters representing an axis of rotation.
+          The number of characters must equal the number of angles.
+        type: string
+
+    required: [angles, axes_order]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/slit_to_msa-1.2.0.yaml
@@ -1,0 +1,28 @@
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/slit_to_msa-1.2.0"
+title: >
+  NIRSPEC set of models from slit_frame to the MSA frame.
+
+description: |
+  This model is used by the NIRSPEC WCS pipeline.
+  It maps a slit to its position in the MSA plane.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      slits:
+        anyOf:
+          - type: array
+            items:
+              anyOf:
+                - type: array
+                - type: number
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      models:
+        description: |
+          A compound model transferring positions in the slit frame to
+          positions in the MSA frame.
+        type: array
+    required: [slits, models]

--- a/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-1.2.0.yaml
+++ b/src/stdatamodels/jwst/transforms/resources/schemas/stsci.edu/jwst_pipeline/snell-1.2.0.yaml
@@ -1,0 +1,65 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/snell-1.2.0"
+title: >
+  NIRSpec transforms through the prism.
+
+description: |
+  This model does all transforms through the NIRSpec prism:
+  - computes the refraction index as a function of lambda.
+  - Applies Snell's law through front surface.
+  - Rotates to back surface.
+  - Applies reflection from back surface.
+  - Rotates to front surface
+  - Applies Snell's law through front surface.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - type: object
+    properties:
+      prism_angle:
+        description: |
+          The angle of the prism in deg.
+        type: number
+      kcoef:
+        description: |
+          K coefficients in Sellmeier equation.
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      lcoef:
+        description: |
+          L coefficients in Sellmeier equation.
+        type: array
+        items:
+          type: number
+        minItems: 3
+        maxItems: 3
+      tcoef:
+        description: |
+          Thermal coefficients of the glass.
+        type: array
+        items:
+          type: number
+        minItems: 6
+        maxItems: 6
+      ref_temp:
+        description: |
+          Reference temperature of the glass in [K].
+        type: number
+      ref_pressure:
+        description: |
+          Reference pressure of the glass in [ATM].
+        type: number
+      temp:
+        description: |
+          System temperature in [K].
+        type: number
+      pressure:
+        description: |
+          System pressure in [ATM].
+        type: number
+    required: [prism_angle, kcoef, lcoef, tcoef, ref_temp, ref_pressure, temp, pressure]


### PR DESCRIPTION
This PR updates the transform schemas to use the new transform-1.4.0 schema in asdf-transform-schemas.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/15194045401

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
