### PR TITLE
JP-3837: Allow extra columns in NrcImgPhotomModel phot_table

### DIFF
--- a/changes/484.feature.rst
+++ b/changes/484.feature.rst
@@ -1,0 +1,1 @@
+Allow extra columns in the NrcImgPhotomModel phot_table, to support the ability to specify different values by subarray.

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -148,11 +148,14 @@ class NrcImgPhotomModel(ReferenceFileModel):
         A table-like object containing row selection criteria made up
         of instrument mode parameters and photometric conversion
         factors associated with those modes.
+        The subarray column may appear in newer versions of the photom
+        files: it is allowed, but not specified by the schema.
 
         - filter: str[12]
         - pupil: str[12]
         - photmjsr: float32
         - uncertainty: float32
+        - subarray: str[12], optional
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/nrcimg_photom.schema"

--- a/src/stdatamodels/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrcimg_photom.schema.yaml
@@ -13,6 +13,7 @@ allOf:
     phot_table:
       title: Photometric flux conversion factors table
       fits_hdu: PHOTOM
+      allow_extra_columns: true
       datatype:
       - name: filter
         datatype: [ascii, 12]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3837](https://jira.stsci.edu/browse/JP-3837)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
NIRCam wants to allow matching by subarray to the photom table rows, for the imaging modes.  To allow both old and new files to work in the transition, I am updating the schema to allow extra columns in the reference file, rather than defining the subarray column specifically.  In future builds, this can be cleaned up to require the subarray column if desired.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
