### PR TITLE
JP-3904 New Nirspec Dark model and added p_grating to superbias

### DIFF
--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -17,6 +17,7 @@ from .contrast import ContrastModel
 from .cube import CubeModel
 from .dark import DarkModel
 from .darkMIRI import DarkMIRIModel
+from .darkNIRSpec import DarkNIRSpecModel
 from .emi import EmiModel
 from .extract1d_spec import Extract1dIFUModel
 from .flat import FlatModel
@@ -145,6 +146,7 @@ __all__ = [
     "CubeModel",
     "DarkModel",
     "DarkMIRIModel",
+    "DarkNIRSpecModel",
     "DisperserModel",
     "DistortionModel",
     "DistortionMRSModel",

--- a/src/stdatamodels/jwst/datamodels/darkNIRSpec.py
+++ b/src/stdatamodels/jwst/datamodels/darkNIRSpec.py
@@ -1,0 +1,37 @@
+from stdatamodels.dynamicdq import dynamic_mask
+from .dqflags import pixel
+from .reference import ReferenceFileModel
+
+
+__all__ = ["DarkNIRSpecModel"]
+
+
+class DarkNIRSpecModel(ReferenceFileModel):
+    """
+    A data model for NIRSpec dark reference files.
+
+    Attributes
+    ----------
+    data : numpy float32 array
+         Dark current array
+    dq : numpy uint32 array
+         2-D data quality array for all planes
+    dq_def : numpy table
+         DQ flag definitions
+    average_dark_current: numpy float32 array
+         Average dark current for each pixel
+    dark_rate : numpy float32 array
+         Dark rate used by NIRSpec team
+    dark_rate_unc : numpy float32 array
+         Dark rate uncertainties
+    """
+
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/darkNIRSpec.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(DarkNIRSpecModel, self).__init__(init=init, **kwargs)
+
+        self.dq = dynamic_mask(self, pixel)
+
+        # Implicitly create arrays
+        self.dq = self.dq

--- a/src/stdatamodels/jwst/datamodels/schemas/darkNIRSpec.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/darkNIRSpec.schema.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/darkNIRSpec.schema"
+title: Dark current data model
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_readpatt.schema
+- $ref: keyword_preadpatt.schema
+- $ref: keyword_noutputs.schema
+- $ref: keyword_nframes.schema
+- $ref: keyword_ngroups.schema
+- $ref: keyword_groupgap.schema
+- $ref: keyword_gainfact.schema
+- $ref: keyword_psubarray.schema
+- $ref: keyword_darkcurrent.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_pgrating.schema
+- $ref: subarray.schema
+- type: object
+  properties:
+    data:
+      title: Dark current array
+      fits_hdu: SCI
+      default: 0.0
+      ndim: 3
+      datatype: float32
+    dq:
+      title: 2-D data quality array for all planes
+      fits_hdu: DQ
+      default: 0
+      ndim: 2
+      datatype: uint32
+    err:
+      title: Error array
+      fits_hdu: ERR
+      default: 0.0
+      ndim: 3
+      datatype: float32
+    average_dark_current:
+      title: Average dark current
+      fits_hdu: AVDRKCUR
+      default: 0.0
+      ndim: 2
+      datatype: float32
+    dark_rate:
+      title: Dark rate array
+      fits_hdu: DRK
+      default: 0.0
+      ndim: 2
+      datatype: float32
+    dark_rate_unc:
+      title: Dark rate uncertainity array
+      fits_hdu: UNC
+      default: 0.0
+      ndim: 2
+      datatype: float32
+- $ref: dq_def.schema

--- a/src/stdatamodels/jwst/datamodels/schemas/superbias.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/superbias.schema.yaml
@@ -10,6 +10,7 @@ allOf:
 - $ref: keyword_gainfact.schema
 - $ref: keyword_noutputs.schema
 - $ref: keyword_grating.schema
+- $ref: keyword_pgrating.schema
 - $ref: bunit.schema
 - type: object
   properties:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3004(https://jira.stsci.edu/browse/JP-3904)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR creates a new NIRSpec dark reference datamodel. In this new model, two extensions are added to the data model, DRK and UNC. These extensions are used by the NIRSpec team for their testing. 
In addition, the P_GRATTING was added to both the NIRSpec dark datamodel and super bias.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
