### PR TITLE
Remove code that attempts to handle opening datamodels from buffer

### DIFF
--- a/changes/487.removal.rst
+++ b/changes/487.removal.rst
@@ -1,1 +1,2 @@
 Drop support for initializing datamodels from buffer (was already raising errors)
+Drop support for initializing datamodels from byte strings

--- a/changes/487.removal.rst
+++ b/changes/487.removal.rst
@@ -1,0 +1,1 @@
+Drop support for initializing datamodels from buffer (was already raising errors)

--- a/src/stdatamodels/filetype.py
+++ b/src/stdatamodels/filetype.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 
 
 def check(init):
@@ -8,7 +7,7 @@ def check(init):
 
     Parameters
     ----------
-    init : str, Path, or bytes
+    init : str or Path
         The input file path.
 
     Returns
@@ -16,12 +15,10 @@ def check(init):
     file_type : str
         A string representing the file type ("asdf", "asn", or "fits")
     """
-    if isinstance(init, bytes):
-        init = init.decode(sys.getfilesystemencoding())
     if isinstance(init, str):
         init = Path(init)
     if not isinstance(init, Path):
-        raise TypeError(f"Input must be a str, Path, or bytes, not {type(init)}")
+        raise TypeError(f"Input must be a str or Path, not {type(init)}")
 
     # Could be the file is zipped; consider last 2 suffixes
     suffixes = init.suffixes[-2:]

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -59,38 +59,35 @@ def test_open_from_pathlib():
 
 
 def test_open_from_buffer():
-    """Test opening a model from buffer"""
-    # fits_file = t_path("test.fits")
-    # with open(fits_file, "rb") as f:
-    #     data = f.read()
+    """
+    Test opening a model from buffer.
+    
+    Should raise a TypeError in datamodel __init__
+    """
     buff = io.BytesIO()
     hdul = fits.HDUList(fits.PrimaryHDU())
     hdul.writeto(buff)
     buff.seek(0)
     assert isinstance(buff, io.BytesIO)
-    with pytest.raises(ValueError):
-        # ValueError: Can't initialize datamodel using <class '_io.BytesIO'>
-        # in ModelBase.__init__()
+    with pytest.raises(TypeError):
         JwstDataModel(buff)
     with pytest.raises(TypeError):
-        # TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'BytesIO'
-        # in open, just before filetype.check(), when attempting to cast to Path
         datamodels.open(buff)
 
 
 def test_open_from_bytes():
-    """Test opening a model from bytes"""
+    """
+    Test opening a model from bytes.
+    
+    Should raise ValueError: Unrecognized file type since the bytes do not represent a file path.
+    """
     fits_file = t_path("test.fits")
     with open(fits_file, "rb") as f:
         data = f.read()
     assert isinstance(data, bytes)
     with pytest.raises(ValueError):
-        # ValueError: Unrecognized file type for: SIMPLE  =                    T / Data conform to FITS standard
-        # in filetype.check()
         datamodels.open(data)
     with pytest.raises(ValueError):
-        # ValueError: Unrecognized file type for: SIMPLE  =                    T / Data conform to FITS standard
-        # in filetype.check()
         JwstDataModel(data)
 
 
@@ -128,7 +125,7 @@ def test_open_shape():
 
 
 def test_open_illegal():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         init = 5
         datamodels.open(init)
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -85,9 +85,9 @@ def test_open_from_bytes():
     with open(fits_file, "rb") as f:
         data = f.read()
     assert isinstance(data, bytes)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         datamodels.open(data)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         JwstDataModel(data)
 
 
@@ -95,12 +95,10 @@ def test_open_from_filename_as_bytes():
     """Test opening a model where the filename is passed as a byte string"""
     fname = t_path("test.fits").as_posix().encode("utf-8")
     assert isinstance(fname, bytes)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "model_type not found")
-        with datamodels.open(fname) as model:
-            assert isinstance(model, JwstDataModel)
-        model = JwstDataModel(fname)
-        model.close()
+    with pytest.raises(TypeError):
+        datamodels.open(fname)
+    with pytest.raises(TypeError):
+        JwstDataModel(fname)
 
 
 def test_open_fits():

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -31,16 +31,13 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
 
     Parameters
     ----------
-    init : shape tuple, file path, file object, astropy.io.fits.HDUList,
-           numpy array, dict, None
+    init : shape tuple, file path, astropy.io.fits.HDUList, numpy array, dict, None
 
         - None: A default data model with no shape
 
         - shape tuple: Initialize with empty data of the given shape
 
         - file path: Initialize from the given file (FITS, JSON or ASDF)
-
-        - readable file object: Initialize from the given file object
 
         - astropy.io.fits.HDUList: Initialize from the given
           `~astropy.io.fits.HDUList`
@@ -82,9 +79,6 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
     # Get special cases for opening a model out of the way
     # all special cases return a model if they match
 
-    if isinstance(init, Path):
-        init = str(init)
-
     if init is None:
         return model_base.JwstDataModel(None, **kwargs)
 
@@ -92,7 +86,7 @@ def open(init=None, guess=True, memmap=False, **kwargs):  # noqa: A001
         # Copy the object so it knows not to close here
         return init.__class__(init, **kwargs)
 
-    elif isinstance(init, (str, bytes)) or hasattr(init, "read"):
+    elif isinstance(init, (str, bytes, Path)):
         # If given a string, presume its a file path.
         # if it has a read method, assume a file descriptor
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -227,7 +227,7 @@ class DataModel(properties.ObjectNode):
             init = self._migrate_hdulist(init)
             asdffile = fits_support.from_fits(init, self._schema, self._ctx, **kwargs)
 
-        elif isinstance(init, (str, bytes, PurePath)):
+        elif isinstance(init, (str, PurePath)):
             file_type = filetype.check(init)
 
             if file_type == "fits":

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -244,7 +244,7 @@ class DataModel(properties.ObjectNode):
                 raise OSError("File does not appear to be a FITS or ASDF file.")
 
         else:
-            raise ValueError(f"Can't initialize datamodel using {str(type(init))}")
+            raise TypeError(f"Can't initialize datamodel using {str(type(init))}")
 
         # Initialize object fields as determined from the code above
         self._shape = shape

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -228,10 +228,6 @@ class DataModel(properties.ObjectNode):
             asdffile = fits_support.from_fits(init, self._schema, self._ctx, **kwargs)
 
         elif isinstance(init, (str, bytes, PurePath)):
-            if isinstance(init, PurePath):
-                init = str(init)
-            if isinstance(init, bytes):
-                init = init.decode(sys.getfilesystemencoding())
             file_type = filetype.check(init)
 
             if file_type == "fits":

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -33,29 +33,15 @@ def test_unsupported_filename(filename):
 
 
 def test_seekable_file_object():
+    """Not a supported init type for a datamodel."""
     buff = io.BytesIO()
     with asdf.AsdfFile() as af:
         af.write_to(buff)
     buff.seek(0)
-    assert check(buff) == "asdf"
-
-    buff = io.BytesIO()
-    hdul = fits.HDUList(fits.PrimaryHDU())
-    hdul.writeto(buff)
-    buff.seek(0)
-    assert check(buff) == "fits"
-
-    buff = io.BytesIO()
-    buff.write(json.dumps({"foo": "bar"}).encode("utf-8"))
-    buff.seek(0)
-    assert check(buff) == "asn"
-
-    # Too short
-    buff = io.BytesIO(b"FOO")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         check(buff)
 
 
 def test_non_seekable_object():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         check(object())


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #423 

<!-- describe the changes comprising this PR here -->
This PR addresses the above-linked issue by making `filetype.check()` accept `Path` as input, and removing handling of `BytesIO` type.

It was discovered that reading datamodels from a `BytesIO` or `bytes`  representation already does not work on main.  This PR removes all code that attempted to handle that case.

This PR also changes an instance of `ValueError` to `TypeError` in `DataModel.__init__()`.  This is probably a slightly risky change and it's important to be careful with it.  (I could also be convinced to revert this if reviewers dislike it.)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
