### PR TITLE
Remove commented lines from init of converters

### DIFF
--- a/src/stdatamodels/jwst/transforms/converters/__init__.py
+++ b/src/stdatamodels/jwst/transforms/converters/__init__.py
@@ -1,13 +1,1 @@
 """Convert models to and from YAML tree structures."""
-# from .jwst_models import (Gwa2SlitConverter, Slit2MsaConverter, LogicalConverter,
-#                           NirissSOSSConverter, RefractionIndexConverter,
-#                           MIRI_AB2SliceConverter, NIRCAMGrismDispersionConverter,
-#                           NIRISSGrismDispersionConverter, GratingEquationConverter,
-#                           V23ToSkyConverter, SnellConverter, CoordsConverter,
-#                           Rotation3DToGWAConverter)
-#
-# __all__ = ['CoordsConverter', 'GratingEquationConverter', 'Gwa2SlitConverter',
-#            'LogicalConverter', 'MIRI_AB2SliceConverter', 'NIRCAMGrismDispersionConverter',
-#            'NIRISSGrismDispersionConverter', 'NirissSOSSConverter', 'RefractionIndexConverter',
-#            'Rotation3DToGWAConverter', 'Slit2MsaConverter', 'SnellConverter',
-#            'V23ToSkyConverter']


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #411 

<!-- describe the changes comprising this PR here -->
This PR removes commented lines from `transforms.converters.__init__.py`.  The models that the commented-out `__all__` point to are included in `extensions.py` and I believe that's how they're accessed when used.  So I think the correct course of action is just to remove the commented lines, not un-comment them.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
