### PR TITLE
JP-3825: Add SossBkgModel 

### DIFF
--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -11,6 +11,7 @@ from .apcorr import MirLrsApcorrModel, MirMrsApcorrModel
 from .apcorr import NrcWfssApcorrModel, NisWfssApcorrModel
 from .apcorr import NrsMosApcorrModel, NrsIfuApcorrModel, NrsFsApcorrModel
 from .asn import AsnModel
+from .background import SossBkgModel, WfssBkgModel
 from .barshadow import BarshadowModel
 from .combinedspec import CombinedSpecModel
 from .contrast import ContrastModel
@@ -112,7 +113,6 @@ from .wcs_ref_models import (
     MiriLRSSpecwcsModel,
     WaveCorrModel,
 )
-from .wfssbkg import WfssBkgModel
 from .util import open, read_metadata  # noqa: A004
 
 
@@ -230,6 +230,7 @@ __all__ = [
     "MRSSpecModel",
     "TSOSpecModel",
     "SegmentationMapModel",
+    "SossBkgModel",
     "SossExtractModel",
     "SossWaveGridModel",
     "SpecKernelModel",

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -6,6 +6,26 @@ from .reference import ReferenceFileModel
 __all__ = ["WfssBkgModel"]
 
 
+class SossBkgModel(ReferenceFileModel):
+    """
+    A data model of 2D background reference templates for NIRISS SOSS data.
+
+    Attributes
+    ----------
+    data : float32 ndarray
+        The background flux array templates.
+    dq : uint32 ndarray
+        The dq arrays for the background templates.
+    err : float32 ndarray
+        The error arrays associated with the background templates.
+    """
+
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(SossBkgModel, self).__init__(init=init, **kwargs)
+
+
 class WfssBkgModel(ReferenceFileModel):
     """
     A data model for 2D WFSS master background reference files.

--- a/src/stdatamodels/jwst/datamodels/schemas/sossbkg.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/sossbkg.schema.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
+id: "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
+allOf:
+- $ref: referencefile.schema
+- $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
+- $ref: keyword_pupil.schema
+- $ref: subarray.schema
+- $ref: bunit.schema
+- type: object
+  properties:
+    data:
+      title: The science data
+      fits_hdu: SCI
+      default: 0.0
+      ndim: 3
+      datatype: float32
+    dq:
+      title: Data quality array
+      fits_hdu: DQ
+      default: 0
+      ndim: 3
+      datatype: uint32
+    err:
+      title: Error array
+      fits_hdu: ERR
+      default: 0.0
+      ndim: 3
+      datatype: float32


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-3825](https://jira.stsci.edu/browse/JP-3825)

<!-- describe the changes comprising this PR here -->
This PR adds a new datamodel for NIRISS SOSS background reference files. The file stores multiple 2-D background templates, from which the pipeline will select the best-fit template and apply to the science.

The addition of this reftype will at some point be accompanied with a move from the wfssbkg reftype to the generalized `bkg` reftype.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
