### PR TITLE
Vectorize evaluation of NIRCAMBackwardGrismDispersion

### DIFF
--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1588,23 +1588,7 @@ class NIRCAMBackwardGrismDispersion(Model):
             return f
 
         def _optimize_function(t, x0, y0, wavelength):
-            """
-            Find the value of the trace function that matches the wavelength.
-
-            Parameters
-            ----------
-            t : float
-                The pixel offset value to optimize
-            x0, y0 : float
-                Source object x-center, y-center
-            wavelength : float
-                The target wavelength to match
-
-            Returns
-            -------
-            float
-                The squared difference between the trace function output and the wavelength
-            """
+            """Find value of trace function that matches the wavelength."""  # numpydoc ignore=RT01
             xr = trace_function(t, x0, y0)
             return (xr - wavelength) ** 2
 

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1576,7 +1576,7 @@ class NIRCAMBackwardGrismDispersion(Model):
             trace_function = partial(_trace_quadratic, model=model)
 
         else:
-            # Handle legacy versions of the trace mode
+            # Handle legacy versions of the trace model
             t0 = np.linspace(0.0, 1.0, 40)
             if isinstance(model, (ListNode, list)):
                 xr = model[0](t0)
@@ -1595,7 +1595,7 @@ class NIRCAMBackwardGrismDispersion(Model):
         f = newton(
             partial(_optimize_function, x0=x0, y0=y0, wavelength=wavelength),
             np.zeros_like(wavelength),
-            tol=1e-6,
+            tol=1e-3,
             maxiter=100,
             full_output=False,
         )

--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -6,6 +6,7 @@ Test jwst.transforms
 import asdf
 import pytest
 from astropy.modeling.models import Identity
+import numpy as np
 from numpy.testing import assert_allclose
 
 from stdatamodels.jwst.transforms import models
@@ -208,3 +209,31 @@ def test_slit_to_msa_legacy(tmp_path):
         with asdf.open(tmp_file) as af:
             assert af["model"].slits == slits
             assert af["model"].slit_ids == list(range(len(slits)))
+
+
+@pytest.mark.parametrize("n_coeffs", [2, 3])
+def test_nircam_backward_grism_dispersion(n_coeffs):
+    """Smoke test and regression test for NIRCAM backward grism dispersion model."""
+    # lmodel output needs to be the coefficients of a quadratic fit
+    # "derived" from input x, y
+    def _mock_coeff(x,y):
+        return 1.0
+    lmodel = [_mock_coeff]*n_coeffs
+
+    orders = [1,2]
+    lmodels = [lmodel] * len(orders)
+    xmodels = [Identity(1)] * len(orders)
+    ymodels = [Identity(1)] * len(orders)
+
+    order = np.array([1])
+    x0 = np.linspace(100, 200, 11)
+    y0 = np.linspace(100, 200, 11)
+    wl = np.linspace(1.5e-6, 1.5e-6, 11)  # 2 microns
+    model = models.NIRCAMBackwardGrismDispersion(orders, lmodels, xmodels, ymodels)
+    xr, yr, x, y, order_out = model.evaluate(x0, y0, wl, order)
+    assert_allclose(x, x0)
+    assert_allclose(y, y0)
+    assert order == order_out
+    if n_coeffs == 3:
+        assert np.isclose(xr[0], 99.54216276)
+        assert np.isclose(yr[-1], 199.54216276)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially Resolves [JP-4023](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #496 

<!-- describe the changes comprising this PR here -->
This PR vectorizes the computation of the inverse dispersion.  In the old version of the code, the forward transform was evaluated at several points `t0`, then an interpolation function was used to find the 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
