### PR TITLE
Update minimum supported version of asdf-astropy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dependencies = [
     "asdf>=3.3.0",
     "asdf-transform-schemas>=0.6.0",
-    "asdf-astropy>=0.6.0",
+    "asdf-astropy>=0.8.0",
     "numpy>=1.25",
     "astropy>=6.1",
 ]


### PR DESCRIPTION
This should fix the error thrown by  `jwst`'s `oldtestdeps` job:

```
INFO: pip is looking at multiple versions of gwcs to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements-min.txt (line 6) and asdf-astropy==0.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested asdf-astropy==0.6.0
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    gwcs 0.25.1 depends on asdf-astropy>=0.8.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

py311-oldestdeps-xdist-cov: exit 1 (24.24 seconds) /home/runner/work/jwst/jwst> pip install -r requirements-min.txt pid=3354
```

ref: https://github.com/spacetelescope/jwst/pull/9582 https://github.com/spacetelescope/jwst/pull/9583