### PR TITLE
JP-4048: Restore time keywords for backward compatibility

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
@@ -159,6 +159,36 @@ properties:
     default: 's'
     fits_keyword: TIMEUNIT
     fits_hdu: EXTRACT1D
+  start_time_mjd:
+    title: "[d] integration start time in MJD"
+    type: number
+    fits_keyword: MJD-BEG
+    fits_hdu: EXTRACT1D
+  mid_time_mjd:
+    title: "[d] integration mid-point in MJD"
+    type: number
+    fits_keyword: MJD-AVG
+    fits_hdu: EXTRACT1D
+  end_time_mjd:
+    title: "[d] integration end time in MJD"
+    type: number
+    fits_keyword: MJD-END
+    fits_hdu: EXTRACT1D
+  start_tdb:
+    title: "TDB at start of integration [MJD]"
+    type: number
+    fits_keyword: TDB-BEG
+    fits_hdu: EXTRACT1D
+  mid_tdb:
+    title: "TDB at middle of integration [MJD]"
+    type: number
+    fits_keyword: TDB-MID
+    fits_hdu: EXTRACT1D
+  end_tdb:
+    title: "TDB at end of integration [MJD]"
+    type: number
+    fits_keyword: TDB-END
+    fits_hdu: EXTRACT1D
   wavelength_corrected:
     title: Wavelength corrected (T/F)
     type: boolean


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4048](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
#477 removed time-related keywords from the spectral metadata, since they would no longer be populated or required after implementing the TSOMultiSpecModel.  For backwards compatibility, this PR restores these keywords, so that existing x1dints products will still have access to them when read in as MultiSpecModel.

These keywords are not required to be present and will not be populated by the upcoming version of the pipeline code for any data.  After the transition to TSOMultiSpecModel is complete, we can consider removing them from the specmeta schema again.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
