### PR TITLE
Map extrafits data

### DIFF
--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from astropy.io import fits
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 import asdf.schema
 
 from stdatamodels import DataModel
@@ -125,6 +125,10 @@ def test_asdf_extension_data_is_view(tmp_path):
         asdf_bytesize = asdf_bytes.size * asdf_bytes.itemsize
         extra_bytesize = extra_data.size * extra_data.itemsize
         assert asdf_bytesize < extra_bytesize
+    
+    # check that the ASDF extension contains a view of the extra_fits data
+    with FitsModel(file_path) as dm2:
+        assert_allclose(dm2._asdf.tree["extra_fits"]["EXTRA"]["data"], extra_data)
 
 
 def test_hdu_order(tmp_path):

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -106,13 +106,13 @@ def test_asdf_extension_data_is_view(tmp_path):
     """
     file_path = tmp_path / "test.fits"
 
-    # Make a fits hdulist, add an extra_fits extension with array-like data
+    # Make a fits hdulist, add a SCI extension and an extra_fits extension
+    # both with array-like data
     hdul = fits.HDUList()
     hdul.append(fits.PrimaryHDU())
-    hdul.append(fits.ImageHDU(data=np.zeros((100, 1000), dtype=np.float32), name="SCI"))
-    extra_data = np.ones((100, 1000), dtype=np.float32)
+    hdul.append(fits.ImageHDU(data=np.zeros((100, 100), dtype=np.float32), name="SCI"))
+    extra_data = np.ones((100, 100), dtype=np.float32)
     hdul.append(fits.ImageHDU(data=extra_data, name="EXTRA"))
-    hdul["EXTRA"].header["EXTNAME"] = "EXTRA"
     hdul.writeto(file_path, overwrite=True)
     
     # cycle through save/load to get the ASDF extension updated with extra fits

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -127,11 +127,13 @@ def test_asdf_extension_data_is_link(tmp_path):
         assert dm.data.shape == (10, 10)
         assert np.all(dm.data == 0.0)
 
-        # check that the extra_fits data is the same as the asdf extension data
-        assert dm._asdf.tree["extra_fits"]["EXTRA"]["data"] is dm.extra_fits.EXTRA.data
+        # check that the data in the file reference and the data in the model
+        # are the same object, not copies
+        assert dm._file_references[0]._file[1].data is dm.data
+        assert dm.data is dm._asdf.tree["data"]
 
-        # check the same for the schema-defined data
-        assert dm._asdf.tree["data"] is dm.data
+        assert dm._file_references[0]._file[-1].data is dm.extra_fits.EXTRA.data
+        assert dm.extra_fits.EXTRA.data is dm._asdf.tree["extra_fits"]["EXTRA"]["data"]
 
 
 def test_hdu_order(tmp_path):


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #490 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where array-like data that was not mapped to the schema (i.e. "extra fits" data) was duplicated in the ASDF extension.  This PR updates the methods for saving `extra_fits` to treat data arrays in the same way that schema-mapped data are already handled; that is, by replacing arrays with links to those same arrays in the main hdulist.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
