### PR TITLE
Fix extra_fits docs

### DIFF
--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -296,26 +296,37 @@ Extra FITS keywords
 
 When loading arbitrary FITS files, there may be keywords that are not
 listed in the schema for that data model.  These "extra" FITS keywords
-are put under the model in the `_extra_fits` namespace.
+are put into the model in the `extra_fits` namespace.
 
-Under the `_extra_fits` namespace is a section for each header data
-unit, and under those are the extra FITS keywords.  For example, if
-the FITS file contains a keyword `FOO` in the primary header, its
-value can be obtained using::
+Under the `extra_fits` namespace is a section for each FITS extension
+that contains schema-unmapped header information or data,
+and within those are the extra FITS keywords.  For example, if
+the FITS file contains a keyword `FOO` in the primary header that is
+undefined in the schema, its value can be obtained using::
 
-    model._extra_fits.PRIMARY.FOO
+    model.extra_fits.PRIMARY.FOO
 
-This feature is useful to retain any extra keywords from input files
-to output products.
+The `extra_fits` namespace may also hold entire hdus that are not
+mapped to a data model.  For example, if the FITS file contains an
+extension called `EXTRA`, it can be accessed using::
 
-To get a list of everything in `_extra_fits`::
+    model.extra_fits.EXTRA
 
-    model._extra_fits._instance
+and its data array can be accessed using::
 
-returns a dictionary of of the instance at the model._extra_fits node.
+    model.extra_fits.EXTRA.data
 
-`_instance` can be used at any node in the tree to return a dictionary
-of rest of the tree structure at that node.
+To get a list of everything in `extra_fits` as a dictionary, use::
+
+    model.extra_fits._instance
+
+(`_instance` can be used at any node in the tree, not just `extra_fits`,
+to return a dictionary of rest of the tree structure at that node.)
+
+Note to developers: the `jwst` pipeline never directly accesses information
+from `extra_fits`, as this would bypass the schema validation and partly defeat
+the purpose of the data model. It is strongly recommended to define any new
+(meta)data in the datamodel schema early on in the development process.
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #309 

<!-- describe the changes comprising this PR here -->
This PR addresses a mis-naming of `extra_fits` as `_extra_fits` in the documentation, and makes the explanation of `extra_fits` a bit clearer.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
