### PR TITLE
Fix SlitModel init bugs

### DIFF
--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,5 +1,4 @@
 from .model_base import JwstDataModel
-from .image import ImageModel
 
 
 __all__ = ["SlitModel", "SlitDataModel"]
@@ -46,33 +45,10 @@ class SlitDataModel(JwstDataModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
 
     def __init__(self, init=None, **kwargs):
-        if isinstance(init, (SlitModel, ImageModel)):
-            super(SlitDataModel, self).__init__(init=None, **kwargs)
-            self.data = init.data
-            self.dq = init.dq
-            self.err = init.err
-            if init.hasattr("area"):
-                self.area = init.area
-            if init.hasattr("var_poisson"):
-                self.var_poisson = init.var_poisson
-            if init.hasattr("var_rnoise"):
-                self.var_rnoise = init.var_rnoise
-            if init.hasattr("var_flat"):
-                self.var_flat = init.var_flat
-            if init.hasattr("wavelength"):
-                self.wavelength = init.wavelength
+        super(SlitDataModel, self).__init__(init=init, **kwargs)
+        if kwargs:
             for key in kwargs:
                 setattr(self, key, kwargs[key])
-
-            if init.meta.hasattr("wcs"):
-                self.meta.wcs = init.meta.wcs
-            else:
-                self.meta.wcs = None
-        else:
-            super(SlitDataModel, self).__init__(init=init, **kwargs)
-            if kwargs:
-                for key in kwargs:
-                    setattr(self, key, kwargs[key])
 
 
 class SlitModel(JwstDataModel):
@@ -118,30 +94,7 @@ class SlitModel(JwstDataModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slit.schema"
 
     def __init__(self, init=None, **kwargs):
-        if isinstance(init, (SlitModel, ImageModel)):
-            super(SlitModel, self).__init__(init=None, **kwargs)
-            self.update(init)
-            self.data = init.data
-            self.dq = init.dq
-            self.err = init.err
-            if init.hasattr("area"):
-                self.area = init.area
-            if init.hasattr("var_poisson"):
-                self.var_poisson = init.var_poisson
-            if init.hasattr("var_rnoise"):
-                self.var_rnoise = init.var_rnoise
-            if init.hasattr("var_flat"):
-                self.var_flat = init.var_flat
-            if init.hasattr("wavelength"):
-                self.wavelength = init.wavelength
-            if init.hasattr("int_times"):
-                self.int_times = init.int_times
-            if init.meta.hasattr("wcs"):
-                self.meta.wcs = init.meta.wcs
-            else:
-                self.meta.wcs = None
-        else:
-            super(SlitModel, self).__init__(init=init, **kwargs)
-            if kwargs:
-                for key in kwargs:
-                    setattr(self, key, kwargs[key])
+        super(SlitModel, self).__init__(init=init, **kwargs)
+        if kwargs:
+            for key in kwargs:
+                setattr(self, key, kwargs[key])

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -124,7 +124,8 @@ class SlitModel(JwstDataModel):
             self.data = init.data
             self.dq = init.dq
             self.err = init.err
-            self.area = init.area
+            if init.hasattr("area"):
+                self.area = init.area
             if init.hasattr("var_poisson"):
                 self.var_poisson = init.var_poisson
             if init.hasattr("var_rnoise"):

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -51,7 +51,8 @@ class SlitDataModel(JwstDataModel):
             self.data = init.data
             self.dq = init.dq
             self.err = init.err
-            self.area = init.area
+            if init.hasattr("area"):
+                self.area = init.area
             if init.hasattr("var_poisson"):
                 self.var_poisson = init.var_poisson
             if init.hasattr("var_rnoise"):

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -258,16 +258,17 @@ def test_slit_from_image():
     # assert not hasattr(slit_dm, 'meta')
 
     slit = SlitModel(im)
+    assert isinstance(slit, SlitModel)
     assert_allclose(im.data, slit.data)
     assert_allclose(im.err, slit.err)
     assert hasattr(slit, "wavelength")
     assert slit.meta.instrument.name == "MIRI"
 
     im = ImageModel(slit)
-    assert type(im) is ImageModel
+    assert isinstance(im, ImageModel)
 
     im = ImageModel(slit_dm)
-    assert type(im) is ImageModel
+    assert isinstance(im, ImageModel)
 
 
 def test_ifuimage():

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -294,7 +294,7 @@ def test_open_kwargs_fits(tmp_path):
 
 
 def test_open_does_not_clear_wht():
-    """Coverage for a bug where the open function cleared the wht attribute."""
+    """Cover a bug where the open function cleared the wht attribute in SlitModel."""
     m0 = SlitModel((27, 1299))
     m0.wht[:] = 1
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -22,6 +22,7 @@ from stdatamodels.jwst.datamodels import (
     ReferenceImageModel,
     ReferenceCubeModel,
     ReferenceQuadModel,
+    SlitModel
 )
 from stdatamodels.jwst import datamodels
 from stdatamodels.exceptions import NoTypeWarning, ValidationWarning
@@ -290,3 +291,15 @@ def test_open_kwargs_fits(tmp_path):
     with pytest.raises(ValidationError):
         with datamodels.open(file_path, strict_validation=True) as model:
             model.validate()
+
+
+def test_open_does_not_clear_wht():
+    """Coverage for a bug where the open function cleared the wht attribute."""
+    m0 = SlitModel((27, 1299))
+    m0.wht[:] = 1
+
+    m1 = datamodels.open(m0)
+    np.testing.assert_equal(m1.wht, 1)
+
+    m2 = datamodels.SlitModel(m0)
+    np.testing.assert_equal(m2.wht, 1)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3709](https://jira.stsci.edu/browse/JP-3709)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/8712
Closes #296 

<!-- describe the changes comprising this PR here -->
This PR simplifies the `__init__` of `SlitModel` to fix two bugs caused by the unnecessary custom handling there.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
