### PR TITLE
Update for crds 1406

### DIFF
--- a/changes/513.bugfix.rst
+++ b/changes/513.bugfix.rst
@@ -1,0 +1,1 @@
+Add channel and band keywords to specpsf schema.

--- a/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
@@ -4,6 +4,8 @@ $schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
 id: "http://stsci.edu/schemas/jwst_datamodel/specpsf.schema"
 allOf:
 - $ref: referencefile.schema
+- $ref: keyword_band.schema
+- $ref: keyword_channel.schema
 - $ref: keyword_exptype.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_psubarray.schema

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -243,6 +243,7 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                                 warnings.simplefilter(
                                     "ignore", asdf.exceptions.AsdfConversionWarning
                                 )
+
                             with dm.open(refs[reftype]) as model:
                                 try:
                                     ref_exptype = model.meta.exposure.type
@@ -264,6 +265,7 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                     if ref_model is None:
                         log.warning(f"No datamodel found for {reftype}: skipping...")
                         break
+
                     # No need to actually load the reference file into the datamodel!
                     with ref_model() as m:
                         for key in parkeys:

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -66,6 +66,7 @@ area_model_map = {
 }
 
 bkg_model_map = {
+    "NRC_WFSS": dm.WfssBkgModel,
     "NIS_WFSS": dm.WfssBkgModel,
     "NIS_SOSS": dm.SossBkgModel,
 }


### PR DESCRIPTION
CRDS context 1406 https://jwst-crds.stsci.edu/context_table/jwst_1406.pmap
has some updates that are causing test failures:
https://github.com/spacetelescope/stdatamodels/actions/runs/15968561775

The relevant changes are:
- miri psf reference files now using band and channel selectors (these keywords are added to the specpsf schema in this PR)
- a new NRC_WFSS exptype background (this exptype added to the bkg_model_map in this PR)


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
