### PR TITLE
Unit tests and small bugfixes for transform models

### DIFF
--- a/changes/519.bugfix.rst
+++ b/changes/519.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect trace function sampling in NIRCam forward grism dispersion models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "pytest-doctestplus",
     "crds>=11.17.1",
     "requests",
+    "scipy>=1.9.2", # same as astropy
 ]
 docs = [
     "sphinx",

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1197,7 +1197,7 @@ class NIRCAMForwardRowGrismDispersion(Model):
 
         return x0, y0, l_poly, order
 
-    def invdisp_interp(self, order, x0, y0, dx):
+    def invdisp_interp(self, order, x0, y0, dx, sampling=40):
         """
         Make a polynomial fit to xmodel and interpolate to find the wavelength.
 
@@ -1209,6 +1209,8 @@ class NIRCAMForwardRowGrismDispersion(Model):
             Source object x-center, y-center.
         dx : float
             The offset from x0 in the dispersion direction
+        sampling : int, optional
+            Number of points to sample for the interpolation (default is 40)
 
         Returns
         -------
@@ -1218,8 +1220,7 @@ class NIRCAMForwardRowGrismDispersion(Model):
         if len(dx.shape) == 2:
             dx = dx[0, :]
 
-        t_len = dx.shape[0]
-        t0 = np.linspace(0.0, 1.0, t_len)
+        t0 = np.linspace(0.0, 1.0, sampling)
 
         if isinstance(self.xmodels[order], (ListNode, list)):
             if len(self.xmodels[order]) == 2:
@@ -1372,7 +1373,7 @@ class NIRCAMForwardColumnGrismDispersion(Model):
 
         return x0, y0, l_poly, order
 
-    def invdisp_interp(self, model, order, x0, y0, dy):
+    def invdisp_interp(self, model, order, x0, y0, dy, sampling=40):
         """
         Make a polynomial fit to ymodel and interpolate to find the wavelength.
 
@@ -1386,6 +1387,8 @@ class NIRCAMForwardColumnGrismDispersion(Model):
             Source object x-center, y-center.
         dy : float
             The offset from y0 in the dispersion direction
+        sampling : int, optional
+            Number of points to sample for interpolation. Default is 40.
 
         Returns
         -------
@@ -1395,8 +1398,7 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         if len(dy.shape) == 2:
             dy = dy[0, :]
 
-        t_len = dy.shape[0]
-        t0 = np.linspace(0.0, 1.0, t_len)
+        t0 = np.linspace(0.0, 1.0, sampling)
 
         if isinstance(model, (ListNode, list)):
             if len(model[order]) == 2:
@@ -1804,6 +1806,9 @@ class NIRISSBackwardGrismDispersion(Model):
         usu. taken to be the different between fwcpos_ref in the specwcs
         reference file and fwcpos from the input image.
         """
+        wavelength = np.atleast_1d(wavelength)
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
         if (wavelength < 0).any():
             raise ValueError("Wavelength should be greater than zero")
         try:

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1226,12 +1226,17 @@ class NIRCAMForwardRowGrismDispersion(Model):
         t0 = np.linspace(0.0, 1.0, self.sampling)
 
         if isinstance(self.xmodels[order], (ListNode, list)):
+            # if len(self.xmodels[order]) == 2:
+            #     xr = self.xmodels[order][0](x0, y0) + t0 * self.xmodels[order][1](x0, y0)
             if len(self.xmodels[order]) == 3:
                 xr = (
                     self.xmodels[order][0](x0, y0)
                     + t0 * self.xmodels[order][1](x0, y0)
                     + t0**2 * self.xmodels[order][2](x0, y0)
                 )
+            elif len(self.xmodels[order][0].inputs) == 1:
+                xr = (dx - self.xmodels[order][0].c0.value) / self.xmodels[order][0].c1.value
+                return xr
             else:
                 raise Exception  # noqa: TRY002
         else:
@@ -1402,12 +1407,17 @@ class NIRCAMForwardColumnGrismDispersion(Model):
         t0 = np.linspace(0.0, 1.0, self.sampling)
 
         if isinstance(model, (ListNode, list)):
+            # if len(model[order]) == 2:
+            #     xr = model[order][0](x0, y0) + t0 * model[order][1](x0, y0)
             if len(model[order]) == 3:
                 xr = (
                     model[order][0](x0, y0)
                     + t0 * model[order][1](x0, y0)
                     + t0**2 * model[order][2](x0, y0)
                 )
+            elif len(model[order][0].inputs) == 1:
+                xr = (dy - model[order][0].c0.value) / model[order][0].c1.value
+                return xr
             else:
                 raise Exception  # noqa: TRY002
         else:


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #388 
Closes #517 

<!-- describe the changes comprising this PR here -->
This PR:

- Adds unit test coverage for the transforms in `jwst/transforms/models.py`.
- Improves the way that sampling the trace function is handled by WFSS transforms, including a bugfix for #517 
- Drops partial support for NIRCam models that have trace functions x(t), y(t) whose coefficients are 1st order polynomials in (x0, y0).  These are supported in the forward transform but fail to round-trip on main due to being unsupported by the backward transform.
- Adds scipy as a testing dependency, which is required for the use of certain Astropy models.

This PR is a prerequisite to handling #389 #390 and #520 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
