### PR TITLE
Remove excessive log message

### DIFF
--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -273,7 +273,6 @@ def get_envar_as_boolean(name, default=False):
             return value_lowcase in truths
         return value
 
-    log.debug(f'Environmental "{name}" cannot be found. Using default value of "{default}".')
     return default
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
With the recent changes to stpipe logging, there are log messages from downstream and external packages that were not picked up before, but now appear in the jwst log.

One debug message in particular from stdatamodels now appears dozens of times in the log for every step or pipeline run, making it difficult to read.  I propose we remove the message, since it just logs standard default fallback behavior.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
