### PR TITLE
Change bare Except to ValueError in grism dispersion models

### DIFF
--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1238,7 +1238,7 @@ class NIRCAMForwardRowGrismDispersion(Model):
                 xr = (dx - self.xmodels[order][0].c0.value) / self.xmodels[order][0].c1.value
                 return xr
             else:
-                raise Exception  # noqa: TRY002
+                raise ValueError(f"Unexpected model coefficients: {self.xmodels[order]}")
         else:
             xr = (dx - self.xmodels[order].c0.value) / self.xmodels[order].c1.value
             return xr
@@ -1419,7 +1419,7 @@ class NIRCAMForwardColumnGrismDispersion(Model):
                 xr = (dy - model[order][0].c0.value) / model[order][0].c1.value
                 return xr
             else:
-                raise Exception  # noqa: TRY002
+                raise ValueError(f"Unexpected model coefficients: {model[order]}")
         else:
             xr = (dy - model[order].c0.value) / model[order].c1.value
             return xr

--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -555,7 +555,7 @@ def test_nircam_grism_raise_unsupported(direction):
         ForwardModel = models.NIRCAMForwardRowGrismDispersion
     elif direction == "column":
         ForwardModel = models.NIRCAMForwardColumnGrismDispersion
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="Unexpected model coefficients"):
         ForwardModel(
             orders,
             lmodels=lmodels,


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #389 

<!-- describe the changes comprising this PR here -->
This PR allows for the removal of some `noqa: TRY002` tags by removing the use of bare `Except`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
