### PR TITLE
Update handling of kwargs in datamodel init and asdf_in_fits.open

### DIFF
--- a/changes/533.misc.rst
+++ b/changes/533.misc.rst
@@ -1,1 +1,2 @@
-Update handling of kwargs in DataModel init and open
+Update DataModel init to make it so kwargs are exclusively used for initializing data arrays
+as model attributes, and other args are used to control how the model is opened and validated.  

--- a/changes/533.misc.rst
+++ b/changes/533.misc.rst
@@ -1,0 +1,1 @@
+Update handling of kwargs in DataModel init and open

--- a/changes/533.removal.rst
+++ b/changes/533.removal.rst
@@ -1,0 +1,1 @@
+Deprecate passing kwargs into asdf.open from asdf_in_fits.open

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -29,7 +29,7 @@ def write(filename, tree, hdulist=None, **kwargs):
     hdulist.writeto(filename, **kwargs)
 
 
-def open(filename_or_hdu, **kwargs):  # noqa: A001
+def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False):  # noqa: A001
     """
     Read ASDF data embedded in a fits file.
 
@@ -39,8 +39,12 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
         Filename of the FITS file or an open `astropy.io.fits.HDUList`
         containing the ASDF data. If a filename is provided it
         will be opened with :func:`astropy.io.fits.open`.
-    **kwargs
-        Additional keyword arguments to pass to :func:`asdf.open`
+    ignore_missing_extensions : bool, optional
+        If `True`, ignore missing extensions in the FITS file.
+        Defaults to `False`.
+    ignore_unrecognized_tag : bool, optional
+        If `True`, ignore unrecognized tags in the ASDF data.
+        Defaults to `False`.
 
     Returns
     -------
@@ -50,9 +54,11 @@ def open(filename_or_hdu, **kwargs):  # noqa: A001
     """
     is_hdu = isinstance(filename_or_hdu, fits.HDUList)
     hdulist = filename_or_hdu if is_hdu else fits.open(filename_or_hdu)
-    if "ignore_missing_extensions" not in kwargs:
-        kwargs["ignore_missing_extensions"] = False
-    af = fits_support.from_fits_asdf(hdulist, **kwargs)
+    af = fits_support.from_fits_asdf(
+        hdulist,
+        ignore_missing_extensions=ignore_missing_extensions,
+        ignore_unrecognized_tag=ignore_unrecognized_tag,
+    )
 
     if is_hdu:
         # no need to wrap close if input was an HDUList

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -1,5 +1,6 @@
 import asdf
 from astropy.io import fits
+import warnings
 
 from . import fits_support
 
@@ -29,7 +30,7 @@ def write(filename, tree, hdulist=None, **kwargs):
     hdulist.writeto(filename, **kwargs)
 
 
-def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False):  # noqa: A001
+def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False, **kwargs):  # noqa: A001
     """
     Read ASDF data embedded in a fits file.
 
@@ -45,6 +46,9 @@ def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_t
     ignore_unrecognized_tag : bool, optional
         If `True`, ignore unrecognized tags in the ASDF data.
         Defaults to `False`.
+    **kwargs
+        Additional keyword arguments to pass to asdf.open.
+        Usage of kwargs is deprecated and will be removed in a future version.
 
     Returns
     -------
@@ -52,12 +56,20 @@ def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_t
         :obj:`asdf.AsdfFile` created from ASDF data embedded in the opened
         FITS file.
     """
+    if kwargs:
+        warnings.warn(
+            "Passing additional keyword arguments from asdf_in_fits.open into asdf.open "
+            "is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     is_hdu = isinstance(filename_or_hdu, fits.HDUList)
     hdulist = filename_or_hdu if is_hdu else fits.open(filename_or_hdu)
     af = fits_support.from_fits_asdf(
         hdulist,
         ignore_missing_extensions=ignore_missing_extensions,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
+        **kwargs,
     )
 
     if is_hdu:

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -1,7 +1,6 @@
 import datetime
 from functools import partial
 import hashlib
-import inspect
 import io
 import re
 import warnings
@@ -778,7 +777,9 @@ def _load_history(hdulist, tree):
         history["entries"].append(HistoryEntry({"description": entry}))
 
 
-def from_fits(hdulist, schema, context, **kwargs):
+def from_fits(
+    hdulist, schema, context, ignore_unrecognized_tag=False, ignore_missing_extensions=False
+):
     """
     Read model information from a FITS HDU list.
 
@@ -790,8 +791,12 @@ def from_fits(hdulist, schema, context, **kwargs):
         The schema defining the ASDF > FITS_KEYWORD, FITS_HDU mapping.
     context : DataModel
         The `DataModel` to update
-    **kwargs
-        Additional arguments to pass to `from_fits_asdf`
+    ignore_unrecognized_tag : bool, optional
+        If `True`, ignore unrecognized tags in the ASDF file.
+        If `False`, raise an error when an unrecognized tag is found.
+    ignore_missing_extensions : bool, optional
+        If `True`, ignore missing extensions in the ASDF file.
+        If `False`, raise an error when an extension is missing.
 
     Returns
     -------
@@ -799,7 +804,11 @@ def from_fits(hdulist, schema, context, **kwargs):
         The ASDF file object
     """
     try:
-        ff = from_fits_asdf(hdulist, **kwargs)
+        ff = from_fits_asdf(
+            hdulist,
+            ignore_missing_extensions=ignore_missing_extensions,
+            ignore_unrecognized_tag=ignore_unrecognized_tag,
+        )
     except Exception as exc:
         raise exc.__class__("ERROR loading embedded ASDF: " + str(exc)) from exc
 
@@ -817,7 +826,7 @@ def from_fits(hdulist, schema, context, **kwargs):
     return ff
 
 
-def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
+def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, ignore_missing_extensions=False):
     """
     Open the ASDF extension from a FITS HDUlist.
 
@@ -828,19 +837,15 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
     ignore_unrecognized_tag : bool
         When `True`, ignore unrecognized tags in the ASDF file.
         When `False`, raise an error when an unrecognized tag is found.
-    **kwargs
-        Additional arguments to pass to `asdf.open`
-        - ignore_missing_extensions : bool
-          When `True`, ignore missing extensions in the ASDF file.
-          When `False`, raise an error when an extension is missing.
+    ignore_missing_extensions : bool
+        When `True`, ignore missing extensions in the ASDF file.
+        When `False`, raise an error when an extension is missing.
 
     Returns
     -------
     asdf.AsdfFile
         The ASDF file object
     """
-    ignore_missing_extensions = kwargs.pop("ignore_missing_extensions")
-
     try:
         asdf_extension = hdulist[_ASDF_EXTENSION_NAME]
     except (KeyError, IndexError, AttributeError):
@@ -850,15 +855,10 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, **kwargs):
         )
 
     generic_file = generic_io.get_file(io.BytesIO(asdf_extension.data), mode="rw")
-    # get kwargs supported by asdf, this will not pass along arbitrary kwargs
-    akwargs = {
-        k: kwargs[k] for k in inspect.getfullargspec(asdf.open).args if k[0] != "_" and k in kwargs
-    }
     af = asdf.open(
         generic_file,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         ignore_missing_extensions=ignore_missing_extensions,
-        **akwargs,
     )
     # map hdulist to blocks here
     _map_hdulist_to_arrays(hdulist, af)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -826,7 +826,9 @@ def from_fits(
     return ff
 
 
-def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, ignore_missing_extensions=False):
+def from_fits_asdf(
+    hdulist, ignore_unrecognized_tag=False, ignore_missing_extensions=False, **kwargs
+):
     """
     Open the ASDF extension from a FITS HDUlist.
 
@@ -840,6 +842,9 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, ignore_missing_extens
     ignore_missing_extensions : bool
         When `True`, ignore missing extensions in the ASDF file.
         When `False`, raise an error when an extension is missing.
+    **kwargs : dict
+        Additional keyword arguments to pass to `asdf.open`.
+        Usage of kwargs is deprecated and will be removed in a future version.
 
     Returns
     -------
@@ -859,6 +864,7 @@ def from_fits_asdf(hdulist, ignore_unrecognized_tag=False, ignore_missing_extens
         generic_file,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         ignore_missing_extensions=ignore_missing_extensions,
+        **kwargs,
     )
     # map hdulist to blocks here
     _map_hdulist_to_arrays(hdulist, af)

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -102,7 +102,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
 
         elif file_type == "asn":
             # Read the file as an association / model container
-            return _init_container(init, **kwargs)
+            return _init_container(init, akwargs, **kwargs)
 
         elif file_type == "asdf":
             asdffile = asdf.open(init, memmap=False)
@@ -116,6 +116,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
             else:
                 new_args = inspect.getfullargspec(new_class.__init__).args
                 new_kwargs = {k: kwargs[k] for k in new_args if k[0] != "_" and k in kwargs}
+                new_kwargs.update(akwargs)
                 model = new_class(asdffile, **new_kwargs)
 
             model._file_references.append(_FileReference(asdffile))
@@ -135,7 +136,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         hdulist = init
 
     elif is_association(init) or isinstance(init, Sequence) and not isinstance(init, bytes):
-        return _init_container(init, **kwargs)
+        return _init_container(init, akwargs, **kwargs)
 
     else:
         raise TypeError(f"Unsupported type for init argument to open {type(init)}")
@@ -192,6 +193,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
     try:
         new_args = inspect.getfullargspec(new_class.__init__).args
         new_kwargs = {k: kwargs[k] for k in new_args if k[0] != "_" and k in kwargs}
+        new_kwargs.update(akwargs)
         model = new_class(init, **new_kwargs)
     except Exception:
         if file_to_close is not None:
@@ -224,7 +226,7 @@ def _handle_missing_model_type(model, file_name):
         pass
 
 
-def _init_container(init, **kwargs):
+def _init_container(init, akwargs, **kwargs):
     """
     Initialize a ModelContainer from the given init and kwargs.
 
@@ -232,6 +234,9 @@ def _init_container(init, **kwargs):
     ----------
     init : dict or list
         The input data to initialize the container with.
+    akwargs : dict
+        Keyword arguments that are valid for DataModel.
+        These will be passed to the ModelContainer constructor.
     **kwargs : dict
         Additional keyword arguments to pass to the ModelContainer.
 
@@ -247,6 +252,7 @@ def _init_container(init, **kwargs):
 
     container_args = inspect.getfullargspec(ModelContainer).args
     container_kwargs = {k: kwargs[k] for k in container_args if k[0] != "_" and k in kwargs}
+    container_kwargs.update(akwargs)
     return ModelContainer(init, **container_kwargs)
 
 

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -1,6 +1,7 @@
 """Various utility functions and data types."""
 
 from collections.abc import Sequence
+import inspect
 import warnings
 from pathlib import Path
 import logging
@@ -51,13 +52,8 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         If not guess and the model type is not explicit, raise a TypeError.
     **kwargs
         Additional keyword arguments passed to the DataModel constructor.  Some arguments
-        are general, others are file format-specific.  Arguments of note are:
-
-        - General
-
-           validate_arrays : bool
-             If `True`, arrays will be validated against ndim, max_ndim, and datatype
-             validators in the schemas.
+        are general, others are file format-specific. See the documentation of DataModel
+        for details on the available arguments.
 
     Returns
     -------
@@ -76,21 +72,23 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         kwargs.pop("memmap")
 
     # Initialize variables used to select model class
-
     hdulist = {}
     shape = ()
     file_name = None
     file_to_close = None
 
+    # constrain kwargs to only those that are valid for DataModel
+    dm_args = inspect.getfullargspec(model_base.JwstDataModel.__init__).args
+    akwargs = {k: kwargs[k] for k in dm_args if k[0] != "_" and k in kwargs}
+
     # Get special cases for opening a model out of the way
     # all special cases return a model if they match
-
     if init is None:
-        return model_base.JwstDataModel(None, **kwargs)
+        return model_base.JwstDataModel(None, **akwargs)
 
     elif isinstance(init, model_base.JwstDataModel):
         # Copy the object so it knows not to close here
-        return init.__class__(init, **kwargs)
+        return init.__class__(init, **akwargs)
 
     elif isinstance(init, (str, Path)):
         # If given a string, presume its a file path.
@@ -104,14 +102,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
 
         elif file_type == "asn":
             # Read the file as an association / model container
-            try:
-                from jwst.datamodels import ModelContainer
-            except ImportError as err:
-                raise ValueError(
-                    "Cannot open an association file without the jwst package installed"
-                ) from err
-
-            return ModelContainer(init, **kwargs)
+            return _init_container(init, **kwargs)
 
         elif file_type == "asdf":
             asdffile = asdf.open(init, memmap=False)
@@ -120,10 +111,12 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
             new_class = _class_from_model_type(asdffile)
             if new_class is None:
                 # No model class found, so return generic DataModel.
-                model = model_base.JwstDataModel(asdffile, **kwargs)
+                model = model_base.JwstDataModel(asdffile, **akwargs)
                 _handle_missing_model_type(model, file_name)
             else:
-                model = new_class(asdffile, **kwargs)
+                new_args = inspect.getfullargspec(new_class.__init__).args
+                new_kwargs = {k: kwargs[k] for k in new_args if k[0] != "_" and k in kwargs}
+                model = new_class(asdffile, **new_kwargs)
 
             model._file_references.append(_FileReference(asdffile))
 
@@ -142,14 +135,7 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         hdulist = init
 
     elif is_association(init) or isinstance(init, Sequence) and not isinstance(init, bytes):
-        try:
-            from jwst.datamodels import ModelContainer
-        except ImportError as err:
-            raise ValueError(
-                "Cannot open an association without the jwst package installed"
-            ) from err
-
-        return ModelContainer(init, **kwargs)
+        return _init_container(init, **kwargs)
 
     else:
         raise TypeError(f"Unsupported type for init argument to open {type(init)}")
@@ -204,7 +190,9 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
 
     # Actually open the model
     try:
-        model = new_class(init, **kwargs)
+        new_args = inspect.getfullargspec(new_class.__init__).args
+        new_kwargs = {k: kwargs[k] for k in new_args if k[0] != "_" and k in kwargs}
+        model = new_class(init, **new_kwargs)
     except Exception:
         if file_to_close is not None:
             file_to_close.close()
@@ -234,6 +222,32 @@ def _handle_missing_model_type(model, file_name):
         delattr(model.meta, "model_type")
     except AttributeError:
         pass
+
+
+def _init_container(init, **kwargs):
+    """
+    Initialize a ModelContainer from the given init and kwargs.
+
+    Parameters
+    ----------
+    init : dict or list
+        The input data to initialize the container with.
+    **kwargs : dict
+        Additional keyword arguments to pass to the ModelContainer.
+
+    Returns
+    -------
+    ModelContainer
+        The initialized ModelContainer.
+    """
+    try:
+        from jwst.datamodels import ModelContainer
+    except ImportError as err:
+        raise ValueError("Cannot open an association without the jwst package installed") from err
+
+    container_args = inspect.getfullargspec(ModelContainer).args
+    container_kwargs = {k: kwargs[k] for k in container_args if k[0] != "_" and k in kwargs}
+    return ModelContainer(init, **container_kwargs)
 
 
 def _class_from_model_type(init):

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -165,3 +165,17 @@ def test_open_asdf_in_fits_hdu(saved_array_model, test_array):
             assert_array_almost_equal(af["data"], test_array)
         # make sure file was not closed with context
         assert not hdu.fileinfo(0)["file"].closed
+
+
+def test_deprecated_kwargs_warning(saved_array_model):
+    """
+    Test that a warning is raised when passing additional
+    keyword arguments to asdf_in_fits.open.
+    """
+    with pytest.warns(
+        DeprecationWarning,
+        match="Passing additional keyword arguments from asdf_in_fits.open into asdf.open "
+        "is deprecated and will be removed in a future version.",
+    ):
+        with asdf_in_fits.open(saved_array_model, lazy_load=True) as af:
+            assert af is not None


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #239 
Partially addresses #398 

<!-- describe the changes comprising this PR here -->
This PR addresses a few related issues with kwargs handling in datamodel init and `asdf_in_fits.open`:

- Document array assignment during `DataModel.__init__`
- Make array assignment the only usage of `**kwargs` in `DataModel.__init__`
- Remove `**kwargs` in `asdf_in_fits.open`, `from_fits`, and `from_fits_asdf`, making `ignore_unrecognized_tag` and `ignore_missing_extensions` into args instead

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
