### PR TITLE
Bring ruff rules in line with recent jwst improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,13 @@ repos:
       # - id: end-of-file-fixer
       # - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.9.2'
+    rev: 'v0.12.3'
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/numpy/numpydoc
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: numpydoc-validation
         exclude: |
@@ -35,7 +35,7 @@ repos:
           src/__init__.py |
           )$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
     - id: codespell
       args: ["--write-changes"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,8 +9,6 @@ exclude = [
     "dist",
     ".tox",
     ".eggs",
-    "**/tests/test*.py",
-    "**/_tests/test*.py",
     "**/tests/**/__init__.py",
     "src/__init__.py",
 ]
@@ -30,9 +28,10 @@ select = [
     "D",      # docstrings, see also numpydoc_validation pre-commit action
     "N",      # pep8-naming (naming conventions)
     "A",      # flake8-builtins (prevent shadowing of builtins)
-    #"ARG",    # flake8-unused-arguments (prevent unused arguments)
+    "ARG",    # flake8-unused-arguments (prevent unused arguments)
     "B",      # flake8-bugbear (miscellaneous best practices to avoid bugs)
     "C4",     # flake8-comprehensions (best practices for comprehensions)
+    "I",      # isort    
     "ICN",    # flake8-import-conventions (enforce import conventions)
     "INP",    # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
     "ISC",    # flake8-implicit-str-concat (conventions for concatenating long strings)
@@ -44,6 +43,7 @@ select = [
     "SLF",    # flake8-self (prevent using private class members outside class)
     "SLOT",   # flake8-slots (require __slots__ for immutable classes)
     "T20",    # flake8-print (prevent print statements in code)
+    "TID252",  # Checks for relative imports
     "TRY",    # tryceratops (best practices for try/except blocks)
     "UP",     # pyupgrade (simplified syntax allowed by newer Python versions)
     "YTT",    # flake8-2020 (prevent some specific gotchas from sys.version)
@@ -75,3 +75,30 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "src/stdatamodels/jwst/datamodels/darkMIRI.py" = ["N999"]
 "src/stdatamodels/jwst/transforms/converters/jwst_models.py" = ["D"] # all converters have same standard docstrings
 "src/stdatamodels/jwst/datamodels/wcs_ref_models.py" = ["D102"] # all public methods are overriding base class, so are the same
+"**/tests/test_*.py" = [
+    "E",      # pycodestyle (part of default flake8)
+    "W",      # pycodestyle (part of default flake8)
+    "D",      # docstrings, see also numpydoc pre-commit action
+    "N",      # pep8-naming (naming conventions)
+    "A",      # flake8-builtins (prevent shadowing of builtins)
+    "ARG",    # flake8-unused-arguments (prevent unused arguments)
+    "B",      # flake8-bugbear (miscellaneous best practices to avoid bugs)
+    "C4",     # flake8-comprehensions (best practices for comprehensions)
+    "F841",   # Local variable `result` is assigned to but never used
+    "ICN",    # flake8-import-conventions (enforce import conventions)
+    "INP",    # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
+    "ISC",    # flake8-implicit-str-concat (conventions for concatenating long strings)
+    "LOG",    # flake8-logging
+    "NPY",    # numpy-specific rules
+    "PGH",    # pygrep-hooks (ensure appropriate usage of noqa and type-ignore)
+    "PTH",    # flake8-use-pathlib (enforce using Pathlib instead of os)
+    "S",      # flake8-bandit (security checks)
+    "SLF",    # flake8-self (prevent using private class members outside class)
+    "SLOT",   # flake8-slots (require __slots__ for immutable classes)
+    "TRY",    # tryceratops (best practices for try/except blocks)
+    "UP",     # pyupgrade (simplified syntax allowed by newer Python versions)
+    "YTT",    # flake8-2020 (prevent some specific gotchas from sys.version)
+]
+
+[lint.isort]
+known-first-party = ["stdatamodels"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -28,7 +28,7 @@ select = [
     "D",      # docstrings, see also numpydoc_validation pre-commit action
     "N",      # pep8-naming (naming conventions)
     "A",      # flake8-builtins (prevent shadowing of builtins)
-    "ARG",    # flake8-unused-arguments (prevent unused arguments)
+    # "ARG",    # flake8-unused-arguments (prevent unused arguments)
     "B",      # flake8-bugbear (miscellaneous best practices to avoid bugs)
     "C4",     # flake8-comprehensions (best practices for comprehensions)
     "I",      # isort    
@@ -75,7 +75,7 @@ ignore-fully-untyped = true  # Turn of annotation checking for fully untyped cod
 "src/stdatamodels/jwst/datamodels/darkMIRI.py" = ["N999"]
 "src/stdatamodels/jwst/transforms/converters/jwst_models.py" = ["D"] # all converters have same standard docstrings
 "src/stdatamodels/jwst/datamodels/wcs_ref_models.py" = ["D102"] # all public methods are overriding base class, so are the same
-"**/tests/test_*.py" = [
+"**/*tests/test_*.py" = [
     "E",      # pycodestyle (part of default flake8)
     "W",      # pycodestyle (part of default flake8)
     "D",      # docstrings, see also numpydoc pre-commit action

--- a/src/stdatamodels/__init__.py
+++ b/src/stdatamodels/__init__.py
@@ -1,8 +1,7 @@
 """Data models for JWST."""
 
-from .model_base import DataModel
 from . import _version
-
+from .model_base import DataModel
 
 __all__ = ["DataModel", "__version__"]
 

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -1,9 +1,9 @@
-import asdf
-from astropy.io import fits
 import warnings
 
-from . import fits_support
+import asdf
+from astropy.io import fits
 
+from . import fits_support
 
 __all__ = ["write", "open"]
 

--- a/src/stdatamodels/basic_utils.py
+++ b/src/stdatamodels/basic_utils.py
@@ -1,6 +1,5 @@
 import re
 
-
 __all__ = ["multiple_replace"]
 
 

--- a/src/stdatamodels/dqflags.py
+++ b/src/stdatamodels/dqflags.py
@@ -7,9 +7,10 @@ If a given bit is set, the flag assigned to that bit is interpreted as being set
 """
 
 import warnings
-from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
-from stdatamodels.basic_utils import multiple_replace
 
+from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
+
+from stdatamodels.basic_utils import multiple_replace
 
 __all__ = ["interpret_bit_flags", "dqflags_to_mnemonics"]
 

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -1,6 +1,6 @@
-import numpy as np
-
 import logging
+
+import numpy as np
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -1,30 +1,24 @@
 import datetime
-from functools import partial
 import hashlib
 import io
+import logging
 import re
 import warnings
 import weakref
+from functools import partial
 
-import numpy as np
-from astropy.io import fits
-from astropy import time
-from astropy.utils.exceptions import AstropyWarning
 import asdf
+import numpy as np
+from asdf import generic_io, tagged, treeutil
 from asdf import schema as asdf_schema
-from asdf.tags.core import NDArrayType
-from asdf.tags.core import ndarray, HistoryEntry
-from asdf import treeutil
+from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict
-from asdf import tagged
-from asdf import generic_io
+from astropy import time
+from astropy.io import fits
+from astropy.utils.exceptions import AstropyWarning
 
-from . import properties
+from . import properties, util, validate
 from . import schema as mschema
-from . import util
-from . import validate
-
-import logging
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/src/stdatamodels/jwst/_kwtool/__main__.py
+++ b/src/stdatamodels/jwst/_kwtool/__main__.py
@@ -1,4 +1,3 @@
 from .cli import _from_cmdline
 
-
 _from_cmdline()

--- a/src/stdatamodels/jwst/_kwtool/_tests/test_against_mast.py
+++ b/src/stdatamodels/jwst/_kwtool/_tests/test_against_mast.py
@@ -1,11 +1,11 @@
-from pathlib import Path
 import json
 import os
 import sys
+from pathlib import Path
+from urllib.parse import quote as urlencode
 
 import pytest
 import requests
-from urllib.parse import quote as urlencode
 
 from stdatamodels.jwst._kwtool import cli
 

--- a/src/stdatamodels/jwst/_kwtool/_tests/test_dmd.py
+++ b/src/stdatamodels/jwst/_kwtool/_tests/test_dmd.py
@@ -5,8 +5,8 @@ separately test _get_subclasses
 
 import pytest
 
-from stdatamodels.jwst.datamodels import DarkModel, JwstDataModel, ReferenceFileModel
 from stdatamodels.jwst._kwtool import dmd
+from stdatamodels.jwst.datamodels import DarkModel, JwstDataModel, ReferenceFileModel
 
 
 def test_get_subclasses():

--- a/src/stdatamodels/jwst/_kwtool/compare.py
+++ b/src/stdatamodels/jwst/_kwtool/compare.py
@@ -3,8 +3,7 @@ import re
 import stdatamodels.jwst.datamodels as dm
 from stdatamodels.schema import walk_schema
 
-from . import dmd
-from . import kwd
+from . import dmd, kwd
 
 
 class _MissingValue:

--- a/src/stdatamodels/jwst/_kwtool/dmd.py
+++ b/src/stdatamodels/jwst/_kwtool/dmd.py
@@ -3,7 +3,6 @@ import asdf
 import stdatamodels.jwst.datamodels as dm
 import stdatamodels.schema
 
-
 __all__ = ["load"]
 
 

--- a/src/stdatamodels/jwst/_kwtool/kwd.py
+++ b/src/stdatamodels/jwst/_kwtool/kwd.py
@@ -10,9 +10,8 @@ Since these aren't jsonschemas the usual tools won't work.
 This follows the behavior of ``keyword_dict.py`` used by SDP, archive, etc.
 """
 
-from pathlib import Path
 import json
-
+from pathlib import Path
 
 __all__ = ["load"]
 

--- a/src/stdatamodels/jwst/_tests/test_schemas.py
+++ b/src/stdatamodels/jwst/_tests/test_schemas.py
@@ -8,7 +8,6 @@ import yaml
 from stdatamodels.fits_support import _get_validators
 from stdatamodels.schema import walk_schema
 
-
 # relative paths to schema directories
 SCHEMA_RELATIVE_PATHS = [
     "../datamodels/schemas",

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -1,33 +1,39 @@
 """Datamodels for JWST pipeline."""
 
-from .model_base import JwstDataModel
 from .abvega_offset import ABVegaOffsetModel
 from .amilg import AmiLgModel
 from .amilgfitmodel import AmiLgFitModel
 from .amioi import AmiOIModel
-from .apcorr import FgsImgApcorrModel, MirImgApcorrModel
-from .apcorr import NrcImgApcorrModel, NisImgApcorrModel
-from .apcorr import MirLrsApcorrModel, MirMrsApcorrModel
-from .apcorr import NrcWfssApcorrModel, NisWfssApcorrModel
-from .apcorr import NrsMosApcorrModel, NrsIfuApcorrModel, NrsFsApcorrModel
+from .apcorr import (
+    FgsImgApcorrModel,
+    MirImgApcorrModel,
+    MirLrsApcorrModel,
+    MirMrsApcorrModel,
+    NisImgApcorrModel,
+    NisWfssApcorrModel,
+    NrcImgApcorrModel,
+    NrcWfssApcorrModel,
+    NrsFsApcorrModel,
+    NrsIfuApcorrModel,
+    NrsMosApcorrModel,
+)
 from .asn import AsnModel
 from .background import SossBkgModel, WfssBkgModel
 from .barshadow import BarshadowModel
 from .combinedspec import CombinedSpecModel, WFSSCombinedSpecModel
 from .contrast import ContrastModel
 from .cube import CubeModel
-from .dark import DarkModel, DarkMIRIModel, DarkNirspecModel
+from .dark import DarkMIRIModel, DarkModel, DarkNirspecModel
 from .emi import EmiModel
 from .extract1d_spec import Extract1dIFUModel
 from .flat import FlatModel
 from .fringe import FringeModel
 from .fringefreq import FringeFreqModel
 from .gain import GainModel
-from .guider import GuiderRawModel, GuiderCalModel
+from .guider import GuiderCalModel, GuiderRawModel
 from .ifucube import IFUCubeModel
-from .ifucubepars import NirspecIFUCubeParsModel, MiriIFUCubeParsModel
+from .ifucubepars import MiriIFUCubeParsModel, NirspecIFUCubeParsModel
 from .ifuimage import IFUImageModel
-from .mrsptcorr import MirMrsPtCorrModel
 from .image import ImageModel
 from .ipc import IPCModel
 from .irs2 import IRS2Model
@@ -35,26 +41,37 @@ from .lastframe import LastFrameModel
 from .level1b import Level1bModel
 from .linearity import LinearityModel
 from .mask import MaskModel
+from .model_base import JwstDataModel
+from .mrsptcorr import MirMrsPtCorrModel
 from .mrsxartcorr import MirMrsXArtCorrModel
 from .multicombinedspec import MultiCombinedSpecModel, WFSSMultiCombinedSpecModel
 from .multiexposure import MultiExposureModel
 from .multislit import MultiSlitModel
-from .multispec import MultiSpecModel, MRSMultiSpecModel, TSOMultiSpecModel, WFSSMultiSpecModel
+from .multispec import MRSMultiSpecModel, MultiSpecModel, TSOMultiSpecModel, WFSSMultiSpecModel
 from .nirspec_flat import NirspecFlatModel, NirspecQuadFlatModel
 from .nrm import NRMModel
 from .outlierifuoutput import OutlierIFUOutputModel
-from .pathloss import PathlossModel, MirLrsPathlossModel
+from .pastasossmodel import PastasossModel
+from .pathloss import MirLrsPathlossModel, PathlossModel
 from .persat import PersistenceSatModel
-from .photom import FgsImgPhotomModel
-from .photom import MirImgPhotomModel, MirLrsPhotomModel, MirMrsPhotomModel
-from .photom import NrcImgPhotomModel, NrcWfssPhotomModel
-from .photom import NisImgPhotomModel, NisSossPhotomModel, NisWfssPhotomModel
-from .photom import NrsFsPhotomModel, NrsMosPhotomModel
+from .photom import (
+    FgsImgPhotomModel,
+    MirImgPhotomModel,
+    MirLrsPhotomModel,
+    MirMrsPhotomModel,
+    NisImgPhotomModel,
+    NisSossPhotomModel,
+    NisWfssPhotomModel,
+    NrcImgPhotomModel,
+    NrcWfssPhotomModel,
+    NrsFsPhotomModel,
+    NrsMosPhotomModel,
+)
 from .pixelarea import (
-    PixelAreaModel,
-    NirspecSlitAreaModel,
-    NirspecMosAreaModel,
     NirspecIfuAreaModel,
+    NirspecMosAreaModel,
+    NirspecSlitAreaModel,
+    PixelAreaModel,
 )
 from .psfmask import PsfMaskModel
 from .quad import QuadModel
@@ -62,22 +79,21 @@ from .ramp import RampModel
 from .rampfitoutput import RampFitOutputModel
 from .readnoise import ReadnoiseModel
 from .reference import (
+    ReferenceCubeModel,
     ReferenceFileModel,
     ReferenceImageModel,
-    ReferenceCubeModel,
     ReferenceQuadModel,
 )
 from .reset import ResetModel
-from .resolution import ResolutionModel, MiriResolutionModel
+from .resolution import MiriResolutionModel, ResolutionModel
 from .rscd import RSCDModel
 from .saturation import SaturationModel
 from .segmap import SegmentationMapModel
 from .sirs_kernel import SIRSKernelModel
-from .slit import SlitModel, SlitDataModel
-from .pastasossmodel import PastasossModel
+from .slit import SlitDataModel, SlitModel
 from .sossextractmodel import SossExtractModel
 from .sosswavegrid import SossWaveGridModel
-from .spec import SpecModel, MRSSpecModel, TSOSpecModel, WFSSSpecModel
+from .spec import MRSSpecModel, SpecModel, TSOSpecModel, WFSSSpecModel
 from .speckernel import SpecKernelModel
 from .specprofile import SpecProfileModel, SpecProfileSingleModel
 from .specpsf import SpecPsfModel
@@ -89,31 +105,30 @@ from .trapdensity import TrapDensityModel
 from .trappars import TrapParsModel
 from .trapsfilled import TrapsFilledModel
 from .tsophot import TsoPhotModel
+from .util import open, read_metadata  # noqa: A004
 from .wavemap import WaveMapModel, WaveMapSingleModel
 from .wcs_ref_models import (
-    DistortionModel,
-    DistortionMRSModel,
-    SpecwcsModel,
-    RegionsModel,
-    WavelengthrangeModel,
     CameraModel,
     CollimatorModel,
-    OTEModel,
+    DisperserModel,
+    DistortionModel,
+    DistortionMRSModel,
+    FilteroffsetModel,
     FOREModel,
     FPAModel,
-    IFUPostModel,
     IFUFOREModel,
+    IFUPostModel,
     IFUSlicerModel,
+    MiriLRSSpecwcsModel,
     MSAModel,
-    FilteroffsetModel,
-    DisperserModel,
     NIRCAMGrismModel,
     NIRISSGrismModel,
-    MiriLRSSpecwcsModel,
+    OTEModel,
+    RegionsModel,
+    SpecwcsModel,
     WaveCorrModel,
+    WavelengthrangeModel,
 )
-from .util import open, read_metadata  # noqa: A004
-
 
 __all__ = [
     "open",

--- a/src/stdatamodels/jwst/datamodels/abvega_offset.py
+++ b/src/stdatamodels/jwst/datamodels/abvega_offset.py
@@ -1,6 +1,7 @@
 import warnings
 
 from stdatamodels.exceptions import ValidationWarning
+
 from .reference import ReferenceFileModel
 
 __all__ = ["ABVegaOffsetModel"]

--- a/src/stdatamodels/jwst/datamodels/amilg.py
+++ b/src/stdatamodels/jwst/datamodels/amilg.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["AmiLgModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/amilgfitmodel.py
+++ b/src/stdatamodels/jwst/datamodels/amilgfitmodel.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["AmiLgFitModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from .model_base import JwstDataModel
 
-
 __all__ = ["AsnModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["WfssBkgModel"]
 

--- a/src/stdatamodels/jwst/datamodels/combinedspec.py
+++ b/src/stdatamodels/jwst/datamodels/combinedspec.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["CombinedSpecModel", "WFSSCombinedSpecModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/conftest.py
+++ b/src/stdatamodels/jwst/datamodels/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 
 @pytest.fixture

--- a/src/stdatamodels/jwst/datamodels/contrast.py
+++ b/src/stdatamodels/jwst/datamodels/contrast.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["ContrastModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["CubeModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["DarkModel", "DarkMIRIModel", "DarkNirspecModel"]
 

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -16,8 +16,9 @@ the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 
 # These imports are here for backwards compatibility
 from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
-from stdatamodels.dqflags import interpret_bit_flags, dqflags_to_mnemonics
+
 from stdatamodels.basic_utils import multiple_replace
+from stdatamodels.dqflags import dqflags_to_mnemonics, interpret_bit_flags
 
 # Pixel-specific flags
 pixel = {

--- a/src/stdatamodels/jwst/datamodels/emi.py
+++ b/src/stdatamodels/jwst/datamodels/emi.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["EmiModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["FlatModel"]
 

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["FringeModel"]
 

--- a/src/stdatamodels/jwst/datamodels/gain.py
+++ b/src/stdatamodels/jwst/datamodels/gain.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["GainModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["GuiderRawModel", "GuiderCalModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["IFUCubeModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["IFUImageModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["ImageModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/integration.py
+++ b/src/stdatamodels/jwst/datamodels/integration.py
@@ -2,8 +2,8 @@
 
 import importlib.resources
 
-
 from asdf.resource import DirectoryResourceMapping
+
 from stdatamodels.jwst import datamodels
 
 

--- a/src/stdatamodels/jwst/datamodels/irs2.py
+++ b/src/stdatamodels/jwst/datamodels/irs2.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["IRS2Model"]
 
 

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["LastFrameModel"]
 

--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -1,6 +1,7 @@
-from .model_base import JwstDataModel
 import numpy as np
 from numpy.lib.recfunctions import merge_arrays
+
+from .model_base import JwstDataModel
 
 __all__ = ["Level1bModel"]
 

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["LinearityModel"]
 

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -1,6 +1,7 @@
-from .reference import ReferenceFileModel
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
+from .reference import ReferenceFileModel
 
 __all__ = ["MaskModel"]
 

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -2,7 +2,6 @@ from astropy.time import Time
 
 from stdatamodels import DataModel as _DataModel
 
-
 __all__ = ["JwstDataModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/multicombinedspec.py
+++ b/src/stdatamodels/jwst/datamodels/multicombinedspec.py
@@ -1,6 +1,5 @@
-from .model_base import JwstDataModel
 from .combinedspec import CombinedSpecModel
-
+from .model_base import JwstDataModel
 
 __all__ = ["MultiCombinedSpecModel", "WFSSMultiCombinedSpecModel"]
 

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -3,10 +3,9 @@ from copy import deepcopy
 from asdf import schema as asdf_schema
 from asdf import treeutil
 
-from .model_base import JwstDataModel
 from .image import ImageModel
-from .slit import SlitModel, SlitDataModel
-
+from .model_base import JwstDataModel
+from .slit import SlitDataModel, SlitModel
 
 __all__ = ["MultiExposureModel", "set_hdu", "remove_fits"]
 

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -1,7 +1,6 @@
-from .model_base import JwstDataModel
 from .image import ImageModel
-from .slit import SlitModel, SlitDataModel
-
+from .model_base import JwstDataModel
+from .slit import SlitDataModel, SlitModel
 
 __all__ = ["MultiSlitModel"]
 

--- a/src/stdatamodels/jwst/datamodels/multispec.py
+++ b/src/stdatamodels/jwst/datamodels/multispec.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
-from .spec import SpecModel, MRSSpecModel, TSOSpecModel, WFSSSpecModel
-
+from .spec import MRSSpecModel, SpecModel, TSOSpecModel, WFSSSpecModel
 
 __all__ = ["MultiSpecModel", "MRSMultiSpecModel", "TSOMultiSpecModel", "WFSSMultiSpecModel"]
 

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -3,9 +3,9 @@ from astropy.io import fits
 from numpy.lib.recfunctions import merge_arrays
 
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["NirspecFlatModel", "NirspecQuadFlatModel"]
 

--- a/src/stdatamodels/jwst/datamodels/nrm.py
+++ b/src/stdatamodels/jwst/datamodels/nrm.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["NRMModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/outlierifuoutput.py
+++ b/src/stdatamodels/jwst/datamodels/outlierifuoutput.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["OutlierIFUOutputModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/pastasossmodel.py
+++ b/src/stdatamodels/jwst/datamodels/pastasossmodel.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["PastasossModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/pathloss.py
+++ b/src/stdatamodels/jwst/datamodels/pathloss.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["PathlossModel", "MirLrsPathlossModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["PersistenceSatModel"]
 

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = [
     "FgsImgPhotomModel",

--- a/src/stdatamodels/jwst/datamodels/pixelarea.py
+++ b/src/stdatamodels/jwst/datamodels/pixelarea.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["PixelAreaModel", "NirspecSlitAreaModel", "NirspecMosAreaModel", "NirspecIfuAreaModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/psfmask.py
+++ b/src/stdatamodels/jwst/datamodels/psfmask.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["PsfMaskModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["QuadModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["RampModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/rampfitoutput.py
+++ b/src/stdatamodels/jwst/datamodels/rampfitoutput.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["RampFitOutputModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/readnoise.py
+++ b/src/stdatamodels/jwst/datamodels/readnoise.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["ReadnoiseModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -1,11 +1,10 @@
 import warnings
 
-from stdatamodels.exceptions import ValidationWarning
 from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.exceptions import ValidationWarning
 
-from .model_base import JwstDataModel
 from .dqflags import pixel
-
+from .model_base import JwstDataModel
 
 __all__ = ["ReferenceFileModel", "ReferenceImageModel", "ReferenceCubeModel", "ReferenceQuadModel"]
 

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["ResetModel"]
 

--- a/src/stdatamodels/jwst/datamodels/rscd.py
+++ b/src/stdatamodels/jwst/datamodels/rscd.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["RSCDModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["SaturationModel"]
 

--- a/src/stdatamodels/jwst/datamodels/segmap.py
+++ b/src/stdatamodels/jwst/datamodels/segmap.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["SegmentationMapModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/sirs_kernel.py
+++ b/src/stdatamodels/jwst/datamodels/sirs_kernel.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["SIRSKernelModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["SlitModel", "SlitDataModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/spec.py
+++ b/src/stdatamodels/jwst/datamodels/spec.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["SpecModel", "MRSSpecModel", "TSOSpecModel", "WFSSSpecModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/speckernel.py
+++ b/src/stdatamodels/jwst/datamodels/speckernel.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["SpecKernelModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/specprofile.py
+++ b/src/stdatamodels/jwst/datamodels/specprofile.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["SpecProfileModel", "SpecProfileSingleModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/specpsf.py
+++ b/src/stdatamodels/jwst/datamodels/specpsf.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["SpecPsfModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/spectrace.py
+++ b/src/stdatamodels/jwst/datamodels/spectrace.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["SpecTraceModel", "SpecTraceSingleModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/straylight.py
+++ b/src/stdatamodels/jwst/datamodels/straylight.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["StrayLightModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["SuperBiasModel"]
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_fits.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_fits.py
@@ -1,11 +1,11 @@
+import numpy as np
+import pytest
 from asdf import schema as mschema
 from astropy.io import fits
 from numpy.testing import assert_array_equal
-import numpy as np
-import pytest
 
 from stdatamodels.jwst import datamodels
-from stdatamodels.jwst.datamodels import ImageModel, JwstDataModel, RampModel, SpecModel, FlatModel
+from stdatamodels.jwst.datamodels import FlatModel, ImageModel, JwstDataModel, RampModel, SpecModel
 
 
 @pytest.fixture
@@ -108,7 +108,8 @@ def test_units_roundtrip(tmp_path):
 def test_flatmodel_dqdef_roundtrip(tmp_path):
     """Covers an old bug where this roundtrip would fail due to
     a mix-up between signed and unsigned integer data types, leading to flag values
-    like 2147483649 instead of 0"""
+    like 2147483649 instead of 0
+    """
     flatdata = [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
     flatflags = [
         (0, 1, "DO_NOT_USE", "Bad pixel. Do not use."),

--- a/src/stdatamodels/jwst/datamodels/tests/test_integration.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_integration.py
@@ -4,9 +4,8 @@ import asdf
 import pytest
 import yaml
 
-from stdatamodels.jwst.datamodels import JwstDataModel
 import stdatamodels.schema
-
+from stdatamodels.jwst.datamodels import JwstDataModel
 
 DATAMODEL_SCHEMAS = list(
     importlib.resources.files("stdatamodels.jwst.datamodels.schemas").glob("*.yaml")
@@ -84,7 +83,6 @@ def test_schema_refs_base(datamodel_schema_file):
         - http://stsci.edu/schemas/jwst_datamodel/referencefile.schema (for reference files)
     But not both
     """
-
     # these schemas don't reference either core.schema or referencefile.schema
     if datamodel_schema_file in [
         "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema",

--- a/src/stdatamodels/jwst/datamodels/tests/test_keyword_schemas.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_keyword_schemas.py
@@ -5,7 +5,6 @@ Test duplicated schema information is in sync.
 import asdf
 import pytest
 
-
 comparisons = {
     "band": {
         "keyword": ("keyword_band.schema", "meta.instrument.band"),

--- a/src/stdatamodels/jwst/datamodels/tests/test_models.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_models.py
@@ -1,36 +1,35 @@
 import warnings
 from pathlib import Path
 
+import numpy as np
+import pytest
 from asdf.exceptions import ValidationError
 from asdf.schema import load_schema
 from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
-from numpy.lib.recfunctions import merge_arrays
+from numpy.lib.recfunctions import drop_fields, merge_arrays
 from numpy.testing import assert_allclose, assert_array_equal
-import numpy as np
-from numpy.lib.recfunctions import drop_fields
-import pytest
 
+from stdatamodels.exceptions import ValidationWarning
+from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import (
-    JwstDataModel,
-    ImageModel,
-    MaskModel,
+    ABVegaOffsetModel,
     AsnModel,
+    CubeModel,
+    IFUImageModel,
+    ImageModel,
+    JwstDataModel,
+    Level1bModel,
+    MaskModel,
     MultiSlitModel,
-    SlitModel,
     NirspecFlatModel,
     NirspecQuadFlatModel,
     SlitDataModel,
-    IFUImageModel,
-    ABVegaOffsetModel,
-    Level1bModel,
-    CubeModel,
+    SlitModel,
 )
-from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import _defined_models as defined_models
 from stdatamodels.schema import walk_schema
-from stdatamodels.exceptions import ValidationWarning
 
 ROOT_DIR = Path(__file__).parent / "data"
 FITS_FILE = ROOT_DIR / "test.fits"
@@ -145,7 +144,8 @@ def test_image_with_extra_keyword_to_multislit(tmp_path):
 @pytest.fixture
 def datamodel_for_update(tmp_path):
     """Provide ImageModel with one keyword each defined in PRIMARY and SCI
-    extensions from the schema, and one each not in the schema"""
+    extensions from the schema, and one each not in the schema
+    """
     path = tmp_path / "old.fits"
     with ImageModel((5, 5)) as im:
         # Add schema keywords, one to each extension

--- a/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_multislit.py
@@ -1,11 +1,11 @@
+import numpy as np
+import pytest
+from asdf.exceptions import ValidationError
 from astropy.io import fits
 from astropy.time import Time
-from asdf.exceptions import ValidationError
-import numpy as np
 from numpy.testing import assert_array_equal
-import pytest
 
-from stdatamodels.jwst.datamodels import MultiSlitModel, ImageModel, SlitModel
+from stdatamodels.jwst.datamodels import ImageModel, MultiSlitModel, SlitModel
 
 
 def test_multislit_model():

--- a/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_nirspec_flat.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 from stdatamodels.jwst.datamodels import NirspecFlatModel, NirspecQuadFlatModel
 
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_open.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_open.py
@@ -2,34 +2,33 @@
 Test datamodel.open
 """
 
-import os
 import io
-from pathlib import Path, PurePath
+import os
 import warnings
-
-import pytest
-import numpy as np
-from astropy.io import fits
-from stdatamodels import DataModel
-from stdatamodels.validate import ValidationError
-
-from stdatamodels.jwst.datamodels import (
-    JwstDataModel,
-    ImageModel,
-    IFUImageModel,
-    RampModel,
-    CubeModel,
-    QuadModel,
-    ReferenceFileModel,
-    ReferenceImageModel,
-    ReferenceCubeModel,
-    ReferenceQuadModel,
-    SlitModel
-)
-from stdatamodels.jwst import datamodels
-from stdatamodels.exceptions import NoTypeWarning, ValidationWarning
+from pathlib import Path, PurePath
 
 import asdf
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from stdatamodels import DataModel
+from stdatamodels.exceptions import NoTypeWarning, ValidationWarning
+from stdatamodels.jwst import datamodels
+from stdatamodels.jwst.datamodels import (
+    CubeModel,
+    IFUImageModel,
+    ImageModel,
+    JwstDataModel,
+    QuadModel,
+    RampModel,
+    ReferenceCubeModel,
+    ReferenceFileModel,
+    ReferenceImageModel,
+    ReferenceQuadModel,
+    SlitModel,
+)
+from stdatamodels.validate import ValidationError
 
 
 @pytest.mark.parametrize("guess", [True, False])
@@ -64,7 +63,7 @@ def test_open_from_pathlib():
 def test_open_from_buffer():
     """
     Test opening a model from buffer.
-    
+
     Should raise a TypeError in datamodel __init__
     """
     buff = io.BytesIO()
@@ -81,7 +80,7 @@ def test_open_from_buffer():
 def test_open_from_bytes():
     """
     Test opening a model from bytes.
-    
+
     Should raise ValueError: Unrecognized file type since the bytes do not represent a file path.
     """
     fits_file = t_path("test.fits")
@@ -129,19 +128,19 @@ def test_open_shape():
 
 def test_open_array():
     """Test opening a model from a numpy array"""
-    data = np.ones((2, 2), dtype=np.float32)*3
+    data = np.ones((2, 2), dtype=np.float32) * 3
     with pytest.warns(DeprecationWarning, match="Passing np.ndarray to open is deprecated"):
         with datamodels.open(data) as model:
             assert isinstance(model, ImageModel)
             assert np.array_equal(model.data, data)
 
-    data = np.ones((2, 2, 2), dtype=np.float32)*3
+    data = np.ones((2, 2, 2), dtype=np.float32) * 3
     with pytest.warns(DeprecationWarning, match="Passing np.ndarray to open is deprecated"):
         with datamodels.open(data) as model:
             assert isinstance(model, CubeModel)
             assert np.array_equal(model.data, data)
 
-    data = np.ones((2, 2, 2, 2), dtype=np.float32)*3
+    data = np.ones((2, 2, 2, 2), dtype=np.float32) * 3
     with pytest.warns(DeprecationWarning, match="Passing np.ndarray to open is deprecated"):
         with datamodels.open(data) as model:
             assert isinstance(model, QuadModel)
@@ -151,19 +150,15 @@ def test_open_array():
 def test_open_dict():
     """
     Ensure failure when opening a dict as a model.
-    
+
     Only association-type dicts are allowed, so this should have a custom error message.
     """
     init = {
         "meta": {
             "telescope": "JWST",
-            "instrument": {
-                "name": "NIRCAM",
-                "detector": "NRCA4",
-                "channel": "SHORT"
-            }
+            "instrument": {"name": "NIRCAM", "detector": "NRCA4", "channel": "SHORT"},
         },
-        "data": np.zeros((10, 10), dtype=np.float32)
+        "data": np.zeros((10, 10), dtype=np.float32),
     }
     with pytest.raises(TypeError, match="Unsupported type for init argument to open"):
         # The open function expects a dict to be an association, not a model.
@@ -365,7 +360,7 @@ def test_open_does_not_clear_wht(InitClass):
 @pytest.mark.parametrize("InitClass", [IFUImageModel, ImageModel])
 def test_open_does_not_clear_zeroframe(InitClass):
     """Cover a bug where the open function cleared the zeroframe attribute in IFUImageModel."""
-    m0 = InitClass((10,10))
+    m0 = InitClass((10, 10))
     m0.zeroframe = np.ones((10, 10))
 
     m1 = datamodels.open(m0)

--- a/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
@@ -19,7 +19,6 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 @pytest.fixture
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
-
     w = {"inputs": "test"}
     w["outputs"] = w
     return w

--- a/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_read_metadata.py
@@ -1,13 +1,14 @@
 """Test utilities for loading metadata without loading entire model."""
 
-import pytest
-import numpy as np
 from pathlib import Path
-from astropy.time import Time
-import stdatamodels.jwst.datamodels as dm
-from stdatamodels.jwst.datamodels.util import read_metadata, _to_flat_dict
-from astropy.io import fits
 
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.time import Time
+
+import stdatamodels.jwst.datamodels as dm
+from stdatamodels.jwst.datamodels.util import _to_flat_dict, read_metadata
 
 IMAGEFILE_ROOT = "jwst_image."
 MULTISLITFILE_ROOT = "jwst_multislit."
@@ -177,7 +178,7 @@ def test_multislit_fits_update(multislit_path):
     with fits.open(multislit_path) as hdul:
         hdul[1].header["SLTNAME"] = new_slitname
         hdul.writeto(new_path)
-    
+
     # Load the metadata
     meta = read_metadata(new_path)
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema.py
@@ -1,5 +1,5 @@
-from asdf import schema as mschema
 import numpy as np
+from asdf import schema as mschema
 from numpy.testing import assert_array_almost_equal
 
 from stdatamodels.jwst._kwtool import dmd
@@ -104,7 +104,7 @@ def test_ami_wcsinfo():
     ami_def = ami_schema["allOf"][1]["properties"]["meta"]["properties"]["guidestar"]["properties"]
     wcsinfo_def = wcsinfo_schema["properties"]["meta"]["properties"]["wcsinfo"]["properties"]
     for keyword in ("roll_ref", "v3yangle", "vparity"):
-        ami = ami_def["fgs_"+keyword]
+        ami = ami_def["fgs_" + keyword]
         wcsinfo = wcsinfo_def[keyword]
         for key in (set(ami.keys()) | set(wcsinfo.keys())) - {"fits_hdu"}:
             assert ami[key] == wcsinfo[key]

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -1,14 +1,14 @@
-import os
 import logging
-from collections.abc import Iterable
+import os
 import warnings
+from collections.abc import Iterable
 from pathlib import Path
 
 import asdf
 import pytest
 
-from stdatamodels.jwst import datamodels as dm
 from stdatamodels.exceptions import NoTypeWarning
+from stdatamodels.jwst import datamodels as dm
 
 os.environ["CRDS_SERVER_URL"] = "https://jwst-crds.stsci.edu"
 
@@ -17,7 +17,6 @@ os.environ["CRDS_SERVER_URL"] = "https://jwst-crds.stsci.edu"
 import crds  # noqa: E402
 from crds.client.api import cache_references, dump_files  # noqa: E402
 from crds.core.exceptions import IrrelevantReferenceTypeError  # noqa: E402
-
 
 log = logging.getLogger(__name__)
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_specwcs_mirilrs_datamodel.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from stdatamodels.jwst import datamodels
 
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_validation.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_validation.py
@@ -1,7 +1,8 @@
-from astropy import time
 from datetime import datetime
-from asdf.exceptions import ValidationError
+
 import pytest
+from asdf.exceptions import ValidationError
+from astropy import time
 
 from stdatamodels.jwst.datamodels import JwstDataModel
 

--- a/src/stdatamodels/jwst/datamodels/tests/test_wcs.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_wcs.py
@@ -2,11 +2,10 @@ import warnings
 from pathlib import Path
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 from stdatamodels.jwst.datamodels import FilteroffsetModel, ImageModel
-
 
 FITS_FILE = Path(__file__).parent / "data" / "sip.fits"
 

--- a/src/stdatamodels/jwst/datamodels/throughput.py
+++ b/src/stdatamodels/jwst/datamodels/throughput.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["ThroughputModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -1,7 +1,7 @@
 from stdatamodels.dynamicdq import dynamic_mask
+
 from .dqflags import pixel
 from .reference import ReferenceFileModel
-
 
 __all__ = ["TrapDensityModel"]
 

--- a/src/stdatamodels/jwst/datamodels/trappars.py
+++ b/src/stdatamodels/jwst/datamodels/trappars.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["TrapParsModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/trapsfilled.py
+++ b/src/stdatamodels/jwst/datamodels/trapsfilled.py
@@ -1,6 +1,5 @@
 from .model_base import JwstDataModel
 
-
 __all__ = ["TrapsFilledModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/tsophot.py
+++ b/src/stdatamodels/jwst/datamodels/tsophot.py
@@ -1,11 +1,10 @@
-import warnings
 import sys
 import traceback
+import warnings
 
 from stdatamodels.exceptions import ValidationWarning
 
 from .reference import ReferenceFileModel
-
 
 __all__ = ["TsoPhotModel"]
 

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -1,21 +1,20 @@
 """Various utility functions and data types."""
 
-from collections.abc import Sequence
-import warnings
-from pathlib import Path
-import logging
-from asdf.tagged import TaggedString
-
 import io
+import logging
+import warnings
+from collections.abc import Sequence
+from pathlib import Path
+
 import asdf
-
 import numpy as np
+from asdf.tagged import TaggedString
 from astropy.io import fits
-from stdatamodels import filetype, fits_support
-from stdatamodels.model_base import _FileReference
-from stdatamodels.exceptions import NoTypeWarning
-import stdatamodels.jwst.datamodels as dm
 
+import stdatamodels.jwst.datamodels as dm
+from stdatamodels import filetype, fits_support
+from stdatamodels.exceptions import NoTypeWarning
+from stdatamodels.model_base import _FileReference
 
 __all__ = ["open", "is_association"]
 

--- a/src/stdatamodels/jwst/datamodels/validate.py
+++ b/src/stdatamodels/jwst/datamodels/validate.py
@@ -1,5 +1,4 @@
 from stdatamodels.exceptions import ValidationWarning
 
-
 # Keep this here for backwards compatibility
 __all__ = ["ValidationWarning"]

--- a/src/stdatamodels/jwst/datamodels/wavemap.py
+++ b/src/stdatamodels/jwst/datamodels/wavemap.py
@@ -1,6 +1,5 @@
 from .reference import ReferenceFileModel
 
-
 __all__ = ["WaveMapModel", "WaveMapSingleModel"]
 
 

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -1,10 +1,11 @@
 import traceback
 import warnings
 
-from asdf.tags.core import NDArrayType
 import numpy as np
-from astropy.modeling.core import Model
+from asdf.tags.core import NDArrayType
 from astropy import units as u
+from astropy.modeling.core import Model
+
 from stdatamodels.exceptions import ValidationWarning
 
 from .reference import ReferenceFileModel

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -2,7 +2,8 @@
 
 from asdf_astropy.converters.transform.core import TransformConverterBase
 from astropy.modeling import Model
-from ....properties import ListNode
+
+from stdatamodels.properties import ListNode
 
 __all__ = [
     "Gwa2SlitConverter",
@@ -288,8 +289,8 @@ class GratingEquationConverter(TransformConverterBase):
 
     def from_yaml_tree_transform(self, node, tag, ctx):
         from stdatamodels.jwst.transforms.models import (
-            WavelengthFromGratingEquation,
             AngleFromGratingEquation,
+            WavelengthFromGratingEquation,
         )
 
         groove_density = node["groove_density"]
@@ -305,8 +306,8 @@ class GratingEquationConverter(TransformConverterBase):
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         from stdatamodels.jwst.transforms.models import (
-            WavelengthFromGratingEquation,
             AngleFromGratingEquation,
+            WavelengthFromGratingEquation,
         )
 
         node = {"order": model.order.value, "groove_density": model.groove_density.value}
@@ -379,7 +380,7 @@ class CoordsConverter(TransformConverterBase):
     ]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-        from stdatamodels.jwst.transforms.models import Unitless2DirCos, DirCos2Unitless
+        from stdatamodels.jwst.transforms.models import DirCos2Unitless, Unitless2DirCos
 
         model_type = node["model_type"]
         if model_type in ("to_dircos", "unitless2directional"):
@@ -390,7 +391,7 @@ class CoordsConverter(TransformConverterBase):
             raise TypeError("Unknown model_type")
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        from stdatamodels.jwst.transforms.models import Unitless2DirCos, DirCos2Unitless
+        from stdatamodels.jwst.transforms.models import DirCos2Unitless, Unitless2DirCos
 
         if isinstance(model, DirCos2Unitless):
             model_type = "directional2unitless"

--- a/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/tests/test_models.py
@@ -2,27 +2,24 @@
 import warnings
 from pathlib import Path
 
+import asdf
 import numpy as np
-
-from astropy.modeling.models import Shift, Rotation2D, Const1D
-
+import pytest
 from asdf_astropy.testing.helpers import assert_model_roundtrip
+from astropy.modeling.models import Const1D, Rotation2D, Shift
 
 from stdatamodels.jwst.transforms.models import (
-    NirissSOSSModel,
-    Rotation3DToGWA,
+    AngleFromGratingEquation,
+    DirCos2Unitless,
     Gwa2Slit,
     Logical,
+    NirissSOSSModel,
+    Rotation3DToGWA,
     Slit,
-    DirCos2Unitless,
-    Unitless2DirCos,
     Snell,
-    AngleFromGratingEquation,
+    Unitless2DirCos,
     WavelengthFromGratingEquation,
 )
-import asdf
-import pytest
-
 
 m1 = Shift(1) & Shift(2) | Rotation2D(3.1)
 m2 = Shift(2) & Shift(2) | Rotation2D(23.1)

--- a/src/stdatamodels/jwst/transforms/extensions.py
+++ b/src/stdatamodels/jwst/transforms/extensions.py
@@ -1,23 +1,22 @@
 from asdf.extension import ManifestExtension
 
 from .converters.jwst_models import (
+    CoordsConverter,
+    GratingEquationConverter,
     Gwa2SlitConverter,
-    Slit2MsaConverter,
     LogicalConverter,
-    NirissSOSSConverter,
-    RefractionIndexConverter,
     MIRI_AB2SliceConverter,
+    Msa2SlitConverter,
     NIRCAMGrismDispersionConverter,
     NIRISSGrismDispersionConverter,
-    GratingEquationConverter,
-    SnellConverter,
+    NirissSOSSConverter,
+    RefractionIndexConverter,
     Rotation3DToGWAConverter,
-    CoordsConverter,
-    V23ToSkyConverter,
-    Msa2SlitConverter,
     Slit2GwaConverter,
+    Slit2MsaConverter,
+    SnellConverter,
+    V23ToSkyConverter,
 )
-
 
 _CONVERTERS = [
     CoordsConverter(),

--- a/src/stdatamodels/jwst/transforms/integration.py
+++ b/src/stdatamodels/jwst/transforms/integration.py
@@ -2,8 +2,8 @@
 
 import importlib.resources
 
-
 from asdf.resource import DirectoryResourceMapping
+
 from stdatamodels.jwst import transforms
 
 

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -11,15 +11,15 @@ registered with ASDF through entry points.
 import math
 import warnings
 from collections import namedtuple
+from functools import partial
 
 import numpy as np
 from astropy.modeling.core import Model
-from astropy.modeling.parameters import Parameter, InputParameterError
-from astropy.modeling.models import Rotation2D, Mapping, Tabular1D, Const1D
+from astropy.modeling.models import Const1D, Mapping, Rotation2D, Tabular1D
 from astropy.modeling.models import math as astmath
-from ...properties import ListNode
-from functools import partial
+from astropy.modeling.parameters import InputParameterError, Parameter
 
+from stdatamodels.properties import ListNode
 
 __all__ = [
     "Gwa2Slit",

--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -674,7 +674,6 @@ def test_grism_error_raises(direction, instrument):
 
 def test_error_raises_bad_transforms():
     """Test error raises for unsupported transform types."""
-
     x0 = 150
     y0 = 140
     t = 0.5

--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -4,12 +4,11 @@ Test jwst.transforms
 """
 
 import asdf
-import pytest
-from astropy.modeling.models import Identity, Mapping
 import numpy as np
+import pytest
+from astropy.modeling.models import Identity, Mapping, Polynomial1D, Polynomial2D
 from numpy.testing import assert_allclose
 
-from astropy.modeling.models import Polynomial2D, Polynomial1D
 from stdatamodels.jwst.transforms import models
 
 
@@ -18,7 +17,7 @@ from stdatamodels.jwst.transforms import models
     [
         (-1.77210143797, 0.177210143797, 1, 111),
         (-2.23774549066, 0.279718186333, 2, 209),
-    ]
+    ],
 )
 def test_miri_ab2slice(beta_zero, beta_del, channel, expected):
     model = models.MIRI_AB2Slice()
@@ -28,8 +27,7 @@ def test_miri_ab2slice(beta_zero, beta_del, channel, expected):
 
 
 def test_refractionindexfromprism():
-
-    prism_angle = -16.5 # degrees
+    prism_angle = -16.5  # degrees
     prism_angle_rad = np.deg2rad(prism_angle)
     alpha_in = np.pi / 8  # angle of incidence in radians
     beta_in = np.pi / 8  # angle of incidence in radians
@@ -43,7 +41,6 @@ def test_refractionindexfromprism():
 
 
 def test_nirisssossmodel():
-
     spectral_orders = [1, 2]
     # model is unphysical but does have 2 inputs and 3 outputs like NIRISS SOSS would expect
     order_models = [Identity(2) | Mapping((0, 1, 1))] * len(spectral_orders)
@@ -62,32 +59,31 @@ def test_nirisssossmodel():
 
 
 def test_logical():
-
     # model where if value is greater than 0.5, it is set to 10
-    l = models.Logical('GT', .5, 10)
+    l = models.Logical("GT", 0.5, 10)
 
     x = np.linspace(0, 1, 11)
     res = l(x)
-    assert_allclose(res, np.where(x > .5, 10, x))
+    assert_allclose(res, np.where(x > 0.5, 10, x))
 
     # model where if value is less than 0.5, it is set to 10
-    l = models.Logical('LT', .5, 10)
+    l = models.Logical("LT", 0.5, 10)
     res = l(x)
-    assert_allclose(res, np.where(x < .5, 10, x))
+    assert_allclose(res, np.where(x < 0.5, 10, x))
 
     # model where if value is equal to 0.5, it is set to 10
-    l = models.Logical('EQ', .5, 10)
+    l = models.Logical("EQ", 0.5, 10)
     res = l(x)
-    assert_allclose(res, np.where(x == .5, 10, x))
+    assert_allclose(res, np.where(x == 0.5, 10, x))
 
     # model where if value is not equal to 0.5, it is set to 10
-    l = models.Logical('NE', .5, 10)
+    l = models.Logical("NE", 0.5, 10)
     res = l(x)
-    assert_allclose(res, np.where(x != .5, 10, x))
+    assert_allclose(res, np.where(x != 0.5, 10, x))
 
     # test comparing to array
     compareto = x[::-1]
-    l = models.Logical('GT', compareto, compareto)
+    l = models.Logical("GT", compareto, compareto)
     res = l(x)
     assert_allclose(res, np.where(x > compareto, compareto, x))
 
@@ -103,10 +99,11 @@ def test_ideal_to_v23_roundtrip():
 
 @pytest.mark.parametrize(
     ("wavelength", "n", "xval", "zval"),
-    [(1e-6, 1.43079543, 0.08197709799990752, 0.9160061062222742),
-     (2e-6, 1.42575377, 0.08010546703309275, 0.916171678990564),
-     (5e-6, 1.40061966, 0.07075688081985915, 0.9169410532033251),
-    ]
+    [
+        (1e-6, 1.43079543, 0.08197709799990752, 0.9160061062222742),
+        (2e-6, 1.42575377, 0.08010546703309275, 0.916171678990564),
+        (5e-6, 1.40061966, 0.07075688081985915, 0.9169410532033251),
+    ],
 )
 def test_refraction_index_and_snell(wavelength, n, xval, zval):
     """
@@ -130,8 +127,8 @@ def test_refraction_index_and_snell(wavelength, n, xval, zval):
 
     # Test Snell's Law model
     angle = 10.0  # prism angle in degrees
-    alpha_in = np.pi/8  # angle of incidence in radians
-    beta_in = np.pi/8  # angle of incidence in radians
+    alpha_in = np.pi / 8  # angle of incidence in radians
+    beta_in = np.pi / 8  # angle of incidence in radians
     z = 0.0  # z-coordinate, not used in this model
     model = models.Snell(angle, kcoef, lcoef, tcoef, tref, pref, temp_sys, pressure_sys)
     xout, yout, zout = model.evaluate(wavelength, alpha_in, beta_in, z)
@@ -143,11 +140,11 @@ def test_refraction_index_and_snell(wavelength, n, xval, zval):
 def test_refraction_index_large_delt():
     """
     Test the case where the temperature difference is large.
-    
+
     If delta T is larger than 20, the refraction index of the air will be recomputed.
     """
     wavelength = 2e-6
-    temp_sys = 65. # in K
+    temp_sys = 65.0  # in K
     tref = 35  # in K
     pref = 0  # in atm
     pressure_sys = 0  # in atm
@@ -165,12 +162,14 @@ def test_grating_equation():
     lam = 2.0e-6  # wavelength in meters
     groovedensity = 1000.0  # grooves per meter
     order = 1  # diffraction order
-    alpha_in = np.array([np.pi/8, np.pi/8])  # angle of incidence in radians
-    beta_in = np.array([np.pi/8, np.pi/8])  # angle of incidence in radians
+    alpha_in = np.array([np.pi / 8, np.pi / 8])  # angle of incidence in radians
+    beta_in = np.array([np.pi / 8, np.pi / 8])  # angle of incidence in radians
     z = np.array([0.0, 0.0])  # z-coordinate, not used in this model
 
     angle_transform = models.AngleFromGratingEquation(groovedensity, order)
-    alpha_out, beta_out, _zout = angle_transform.evaluate(lam, alpha_in, beta_in, z, groovedensity, order)
+    alpha_out, beta_out, _zout = angle_transform.evaluate(
+        lam, alpha_in, beta_in, z, groovedensity, order
+    )
     np.testing.assert_allclose(beta_out, -beta_in)
 
     wavelength_transform = models.WavelengthFromGratingEquation(groovedensity, order)
@@ -298,7 +297,7 @@ def test_slit_to_msa_legacy(tmp_path):
         slits.append(models.Slit(i))
     transforms = [Identity(2)] * 3
 
-    with pytest.warns(DeprecationWarning, match='WCS pipeline may be incomplete'):
+    with pytest.warns(DeprecationWarning, match="WCS pipeline may be incomplete"):
         slit2msa = models.Slit2MsaLegacy(slits, transforms)
 
     assert slit2msa.slits == slits
@@ -315,7 +314,7 @@ def test_slit_to_msa_legacy(tmp_path):
     # test roundtrip to file
     tmp_file = tmp_path / "slit2msa_legacy.asdf"
     asdf.AsdfFile({"model": slit2msa}).write_to(tmp_file)
-    with pytest.warns(DeprecationWarning, match='WCS pipeline may be incomplete'):
+    with pytest.warns(DeprecationWarning, match="WCS pipeline may be incomplete"):
         with asdf.open(tmp_file) as af:
             assert af["model"].slits == slits
             assert af["model"].slit_ids == list(range(len(slits)))
@@ -349,7 +348,7 @@ def _invdisp_interp_old(model, x0, y0, wavelength):
 def test_nircam_backward_grism_dispersion(n_coeffs):
     """Ensure algorithm change works similarly to legacy code."""
 
-    def _mock_coeff(x,y):
+    def _mock_coeff(x, y):
         """
         Simulate dependence of the polynomial coefficients on the detector position.
 
@@ -357,11 +356,11 @@ def test_nircam_backward_grism_dispersion(n_coeffs):
         a polynomial function of x and y. The output should be scaled to return values
         that are in the range of wavelengths in microns.
         """
-        return (x/100)*1e-6
+        return (x / 100) * 1e-6
 
-    lmodel = [_mock_coeff]*n_coeffs
+    lmodel = [_mock_coeff] * n_coeffs
 
-    orders = [1,2]
+    orders = [1, 2]
     lmodels = [lmodel] * len(orders)
     xmodels = [Identity(1)] * len(orders)
     ymodels = [Identity(1)] * len(orders)
@@ -373,12 +372,14 @@ def test_nircam_backward_grism_dispersion(n_coeffs):
     # but x0 or y0 itself can and usually will have repeated values
     x = np.linspace(100, 200, 5)
     y = np.linspace(90, 190, 5)
-    x0, y0 = np.meshgrid(x, y, indexing='ij')
+    x0, y0 = np.meshgrid(x, y, indexing="ij")
     x0 = x0.flatten()
     y0 = y0.flatten()
 
     wl = np.linspace(1.5e-6, 2.5e-6, 21)  # 2 microns
-    model = models.NIRCAMBackwardGrismDispersion(orders, lmodels, xmodels, ymodels, sampling=sampling)
+    model = models.NIRCAMBackwardGrismDispersion(
+        orders, lmodels, xmodels, ymodels, sampling=sampling
+    )
     t_out = model.invdisp_interp(lmodels[0], x0, y0, wl)
 
     # for this version we need to make x0, y0, wl all have same shape
@@ -393,10 +394,11 @@ def test_nircam_backward_grism_dispersion(n_coeffs):
 
 def test_nircam_backward_grism_dispersion_single():
     """Smoke test to ensure works on single-valued inputs as well."""
-    def _mock_coeff(x,y):
-        return (x/100)*1e-6
 
-    lmodel = [_mock_coeff]*2
+    def _mock_coeff(x, y):
+        return (x / 100) * 1e-6
+
+    lmodel = [_mock_coeff] * 2
 
     orders = np.array([1])
     lmodels = [lmodel] * len(orders)
@@ -441,9 +443,15 @@ def test_nircam_grism_roundtrip(direction):
     # identity models.
     mock_x = Polynomial2D(degree=2, c0_0=0.1, c1_0=0.01)
 
-    lmodel = [mock_l,] * 2
-    xmodel = [mock_x,] * 3
-    ymodel = [mock_x,] * 3
+    lmodel = [
+        mock_l,
+    ] * 2
+    xmodel = [
+        mock_x,
+    ] * 3
+    ymodel = [
+        mock_x,
+    ] * 3
     orders = np.array([1])
     lmodels = [lmodel] * len(orders)
     xmodels = [xmodel] * len(orders)
@@ -495,8 +503,12 @@ def test_legacy_nircam_grism_roundtrip(direction):
     mock_l = Polynomial1D(degree=1, c0=0.75, c1=1.55)
     # mock_invl = Polynomial1D(degree=1, c0=-0.48387097, c1=0.64516129)
     mock_x = Polynomial2D(degree=2, c0_0=0.1, c1_0=0.01)
-    xmodel = [mock_x,] * 3
-    ymodel = [mock_x,] * 3
+    xmodel = [
+        mock_x,
+    ] * 3
+    ymodel = [
+        mock_x,
+    ] * 3
     orders = np.array([1])
     lmodels = [mock_l] * len(orders)
     # invlmodels = [mock_invl] * len(orders)
@@ -510,19 +522,11 @@ def test_legacy_nircam_grism_roundtrip(direction):
 
     if direction == "row":
         forward = models.NIRCAMForwardRowGrismDispersion(
-            orders,
-            lmodels=lmodels,
-            xmodels=xmodels,
-            ymodels=ymodels,
-            sampling=40
+            orders, lmodels=lmodels, xmodels=xmodels, ymodels=ymodels, sampling=40
         )
     elif direction == "column":
         forward = models.NIRCAMForwardColumnGrismDispersion(
-            orders,
-            lmodels=lmodels,
-            xmodels=xmodels,
-            ymodels=ymodels,
-            sampling=40
+            orders, lmodels=lmodels, xmodels=xmodels, ymodels=ymodels, sampling=40
         )
     backward = models.NIRCAMBackwardGrismDispersion(
         orders,
@@ -542,24 +546,24 @@ def test_legacy_nircam_grism_roundtrip(direction):
 def test_nircam_grism_1d_linear():
     """
     Test case where model coeffs do NOT have dependence on x0, y0.
-    
+
     This is used in the pipeline for at least some versions of dispy.
     """
     mock_l = Polynomial1D(degree=1, c0=0.75, c1=1.55)
     mock_x = Polynomial1D(degree=1, c0=0.1, c1=0.01)
-    xmodel = [mock_x,] * 1
-    ymodel = [mock_x,] * 1
+    xmodel = [
+        mock_x,
+    ] * 1
+    ymodel = [
+        mock_x,
+    ] * 1
     orders = np.array([1])
     lmodels = [mock_l] * len(orders)
     xmodels = [xmodel] * len(orders)
     ymodels = [ymodel] * len(orders)
 
     forward = models.NIRCAMForwardRowGrismDispersion(
-        orders,
-        lmodels=lmodels,
-        xmodels=xmodels,
-        ymodels=ymodels,
-        sampling=40
+        orders, lmodels=lmodels, xmodels=xmodels, ymodels=ymodels, sampling=40
     )
     backward = models.NIRCAMBackwardGrismDispersion(
         orders,
@@ -574,7 +578,7 @@ def test_nircam_grism_1d_linear():
     np.testing.assert_allclose(yi, 140)
     np.testing.assert_allclose(wli, 2.0)
     np.testing.assert_allclose(ordersi, orders)
-    
+
 
 @pytest.mark.parametrize("direction", ["row", "column"])
 def test_niriss_grism_roundtrip(direction):
@@ -594,8 +598,12 @@ def test_niriss_grism_roundtrip(direction):
     # identity models.
     mock_x = Polynomial2D(degree=2, c0_0=0.1, c1_0=0.01)
 
-    xmodel = [mock_x,] * 3
-    ymodel = [mock_x,] * 3
+    xmodel = [
+        mock_x,
+    ] * 3
+    ymodel = [
+        mock_x,
+    ] * 3
     orders = np.array([1])
     lmodels = [mock_l] * len(orders)
     invlmodels = [mock_invl] * len(orders)
@@ -610,19 +618,11 @@ def test_niriss_grism_roundtrip(direction):
     # now create the appropriate model for the grism[R/C]
     if direction == "row":
         forward = models.NIRISSForwardRowGrismDispersion(
-            orders,
-            lmodels=lmodels,
-            xmodels=xmodels,
-            ymodels=ymodels,
-            sampling=40
+            orders, lmodels=lmodels, xmodels=xmodels, ymodels=ymodels, sampling=40
         )
     elif direction == "column":
         forward = models.NIRISSForwardColumnGrismDispersion(
-            orders,
-            lmodels=lmodels,
-            xmodels=xmodels,
-            ymodels=ymodels,
-            sampling=40
+            orders, lmodels=lmodels, xmodels=xmodels, ymodels=ymodels, sampling=40
         )
     backward = models.NIRISSBackwardGrismDispersion(
         orders,
@@ -642,7 +642,6 @@ def test_niriss_grism_roundtrip(direction):
 @pytest.mark.parametrize("direction", ["row", "column"])
 @pytest.mark.parametrize("instrument", ["nircam", "niriss"])
 def test_grism_error_raises(direction, instrument):
-
     if instrument == "nircam" and direction == "row":
         ForwardModel = models.NIRCAMForwardRowGrismDispersion
     elif instrument == "nircam" and direction == "column":
@@ -690,23 +689,36 @@ def test_error_raises_bad_transforms():
     # Is a list, but not all models are valid
     with pytest.raises(
         TypeError,
-        match="Expected a model or list of models, but got a list containing non-model elements."
+        match="Expected a model or list of models, but got a list containing non-model elements.",
     ):
         models._evaluate_transform_guess_form([poly1d, "bad_model_type"], x=x0, y=y0, t=t)
-    
+
     # Is a single-element list, but takes in more than one input
     with pytest.raises(
-        ValueError,
-        match="Received a transform with an unexpected number of inputs"
+        ValueError, match="Received a transform with an unexpected number of inputs"
     ):
-        models._evaluate_transform_guess_form([poly2d,], x=x0, y=y0, t=t)
+        models._evaluate_transform_guess_form(
+            [
+                poly2d,
+            ],
+            x=x0,
+            y=y0,
+            t=t,
+        )
 
     # Is a multi-element list, but takes in only one input
     with pytest.raises(
-        ValueError,
-        match="Received a transform with an unexpected number of inputs"
+        ValueError, match="Received a transform with an unexpected number of inputs"
     ):
-        models._evaluate_transform_guess_form([poly1d,]*3, x=x0, y=y0, t=t)
+        models._evaluate_transform_guess_form(
+            [
+                poly1d,
+            ]
+            * 3,
+            x=x0,
+            y=y0,
+            t=t,
+        )
 
 
 def test_v23tosky():
@@ -723,5 +735,5 @@ def test_dircos2unitless_roundtrip():
     Test DirCos2Unitless transform model.
     """
     tr = models.Unitless2DirCos()
-    x, y = np.sqrt(2)/2, np.sqrt(2)/2
+    x, y = np.sqrt(2) / 2, np.sqrt(2) / 2
     assert_allclose(tr.inverse(*tr(x, y)), (x, y))

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -2,32 +2,25 @@
 
 import copy
 import datetime
+import functools
 import os
-from pathlib import Path, PurePath
 import sys
 import warnings
-import functools
+from pathlib import Path, PurePath
 
+import asdf
 import numpy as np
-
+from asdf import AsdfFile
+from asdf import schema as asdf_schema
+from asdf.tags.core import NDArrayType
 from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
 
-import asdf
-from asdf.tags.core import NDArrayType
-from asdf import AsdfFile
-from asdf import schema as asdf_schema
-
-from . import filetype
-from . import fits_support
-from . import properties
+from . import filetype, fits_support, properties, validate
 from . import schema as mschema
-from . import validate
-from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
-
 from .history import HistoryList
-
+from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
 
 # This minimal schema creates metadata fields that
 # are accessed to be available by the core DataModel code.

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -1,17 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import copy
-import numpy as np
+import logging
 from collections.abc import Mapping
+
+import numpy as np
+from asdf.tags.core import ndarray
 from astropy.io import fits
 
-from asdf.tags.core import ndarray
-
-from . import util
-from . import validate
 from . import schema as mschema
-
-import logging
+from . import util, validate
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -3,11 +3,11 @@
 import copy
 import os
 
-import numpy as np
-from numpy.lib.recfunctions import merge_arrays
-from astropy.io import fits
 import asdf
+import numpy as np
 from asdf import treeutil
+from astropy.io import fits
+from numpy.lib.recfunctions import merge_arrays
 
 try:
     from asdf.treeutil import RemoveNode
@@ -221,8 +221,9 @@ def create_history_entry(description, software=None):
                 'homepage': 'https://github.com/spacetelescope/jwreftools', 'version': "0.7"}
     >>> entry = create_history_entry(description="HISTORY of this file", software=soft)
     """
-    from asdf.tags.core import Software, HistoryEntry
     import datetime
+
+    from asdf.tags.core import HistoryEntry, Software
 
     if isinstance(software, list):
         software = [Software(x) for x in software]

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -1,17 +1,18 @@
 """Functions that support validation of model changes."""
 
 import warnings
+
+import numpy as np
 from asdf import schema as asdf_schema
 from asdf import yamlutil
 from asdf.exceptions import ValidationError
-from asdf.tags.core import ndarray
 from asdf.schema import YAML_VALIDATORS
+from asdf.tags.core import ndarray
 from asdf.util import HashableDict
-import numpy as np
 
-from .util import convert_fitsrec_to_array_in_tree, remove_none_from_tree
 from stdatamodels.exceptions import ValidationWarning
 
+from .util import convert_fitsrec_to_array_in_tree, remove_none_from_tree
 
 # always show validation warnings unless another filter was added that
 # matches these warnings (by passing append=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,8 @@
 
 from pathlib import Path
 
-import pytest
-
 import asdf
+import pytest
 
 
 def pytest_addoption(parser):

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -1,12 +1,11 @@
-import pytest
-from astropy.io import fits
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+import pytest
 import yaml
+from astropy.io import fits
+from models import FitsModel
+from numpy.testing import assert_array_almost_equal
 
 from stdatamodels import asdf_in_fits
-
-from models import FitsModel
 
 
 def test_write_linked(tmp_path):

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -1,5 +1,6 @@
 import pytest
 from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
+
 from stdatamodels import dqflags
 from stdatamodels.jwst.datamodels.dqflags import pixel
 

--- a/tests/test_embedded_asdf.py
+++ b/tests/test_embedded_asdf.py
@@ -1,14 +1,14 @@
-from io import BytesIO
 import sys
+from io import BytesIO
 
 import asdf
-from asdf.constants import ASDF_MAGIC
 import numpy as np
-from numpy.testing import assert_array_equal
-from astropy.io import fits
 import pytest
-
+from asdf.constants import ASDF_MAGIC
+from astropy.io import fits
 from models import FitsModel
+from numpy.testing import assert_array_equal
+
 from stdatamodels.fits_support import _NDARRAY_TAG
 
 

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -1,9 +1,7 @@
 import io
-import json
 
-import pytest
 import asdf
-from astropy.io import fits
+import pytest
 
 from stdatamodels.filetype import check
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,10 +1,9 @@
 import datetime
 
 import numpy as np
+from asdf.tags.core import HistoryEntry
 from astropy.io import fits
 from astropy.time import Time
-
-from asdf.tags.core import HistoryEntry
 
 from stdatamodels import DataModel
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,7 +11,6 @@ from stdatamodels.exceptions import ValidationWarning
 
 def test_init_from_pathlib(tmp_path):
     """Test initializing model from a PurePath object"""
-
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:
         af["meta"] = {"telescope": "crystal ball"}
@@ -171,7 +170,7 @@ def test_multivalued_default_table_schema():
     with TableModel((10,)) as dm:
         defaults = dm.schema["properties"]["table"]["default"]
         columns = [col["name"] for col in dm.schema["properties"]["table"]["datatype"]]
-        for default, name in zip(defaults, columns):
+        for default, name in zip(defaults, columns, strict=False):
             if default == "NaN":
                 default = np.nan
             elif isinstance(default, str):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,12 +1,11 @@
 import gc
 
 import asdf
-import pytest
 import numpy as np
+import pytest
+from models import AnyOfModel, BasicModel, FitsModel, TableModel, TableModelBad, TransformModel
 
 from stdatamodels import DataModel
-
-from models import BasicModel, AnyOfModel, TableModel, TableModelBad, TransformModel, FitsModel
 from stdatamodels.exceptions import ValidationWarning
 
 
@@ -413,7 +412,7 @@ def test_memmap_deprecation():
 def test_open_from_file_with_kwargs_deprecation(tmp_path):
     """
     Test that combining init types is not allowed.
-    
+
     Passing keyword arguments to the open method, which are assumed to initialize data arrays,
     raises a deprecation warning if the input type is file-like.
     """

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2,12 +2,11 @@
 
 import gc
 
-import pytest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 import psutil
-
+import pytest
 from models import FitsModel
+from numpy.testing import assert_array_almost_equal
 
 
 @pytest.mark.parametrize("extension", ["asdf", "fits"])
@@ -149,7 +148,8 @@ def test_multiple_close(extension, tmp_path):
 @pytest.mark.parametrize("extension", ["asdf", "fits"])
 def test_delete(extension, tmp_path):
     """Deleting the model should also not close files
-    until the last model has been deleted."""
+    until the last model has been deleted.
+    """
     original_path = tmp_path / f"original.{extension}"
     new_path = tmp_path / f"new.{extension}"
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,16 +1,14 @@
-import pytest
-import numpy as np
-from numpy.testing import assert_array_equal
-
 import asdf
+import numpy as np
+import pytest
 from asdf.exceptions import ValidationError
 from asdf.tags.core import NDArrayType
 from astropy.modeling import models
+from models import BasicModel, FitsModel, TableModel, TransformModel, ValidationModel
+from numpy.testing import assert_array_equal
 
-from stdatamodels.schema import merge_property_trees, build_docstring
 from stdatamodels import DataModel
-
-from models import FitsModel, TransformModel, BasicModel, ValidationModel, TableModel
+from stdatamodels.schema import build_docstring, merge_property_trees
 
 
 @pytest.mark.parametrize("filename", ["test.asdf", "test.fits"])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,12 +1,11 @@
-from datetime import datetime, timedelta, UTC
-
-import pytest
+from datetime import UTC, datetime, timedelta
 
 import asdf
-from astropy.io import fits
 import numpy as np
+import pytest
+from asdf.tags.core import HistoryEntry, Software
+from astropy.io import fits
 from numpy.testing import assert_array_equal
-from asdf.tags.core import Software, HistoryEntry
 
 from stdatamodels import util
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,13 +2,13 @@ import gc
 import warnings
 import weakref
 
-import pytest
 import asdf
-from asdf.exceptions import ValidationError
 import numpy as np
+import pytest
+from asdf.exceptions import ValidationError
+from models import BasicModel, FitsModel, RequiredModel, ValidationModel
 
 from stdatamodels.exceptions import ValidationWarning
-from models import BasicModel, FitsModel, ValidationModel, RequiredModel
 
 
 class _DoesNotRaiseContext:


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #543 

<!-- describe the changes comprising this PR here -->
This PR adds a few ruff rules:

- tidy imports are enabled
- isort is enabled and autofixed
- flake8 is added to tests and autofixed
- T20, preventing print statements in code, is added to tests (zero fixes required at this time)

The only "unsafe" fixes required here were two fixes to tidy imports, so the changes should all be relatively safe.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
