### PR TITLE
turn warnings into errors for jwst downstream tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,6 @@ commands =
     xdist: -n auto \
     cov: --cov=src --cov-report=term-missing --cov-report=xml \
     jwst: --pyargs jwst --ignore-glob=*/scripts/* -Werror \
-    # TODO: fix bug with `.finalize()` in `jwst.associations`
-    jwst: --ignore-glob=*/associations/tests/test_dms.py \
     nocrds: --no-crds
     {posargs}
 


### PR DESCRIPTION
Turn warnings into errors for jwst downstream tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
