### PR TITLE
add zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # stdatamodels
 
 [![CI](https://github.com/spacetelescope/stdatamodels/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/stdatamodels/actions/workflows/ci.yml)
-
 [![codecov](https://codecov.io/gh/spacetelescope/stdatamodels/branch/main/graph/badge.svg?token=TrmUKaTP2t)](https://codecov.io/gh/spacetelescope/stdatamodels)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16280288.svg)](https://doi.org/10.5281/zenodo.16280288)
 
 
 Provides JWST data model classes and schemas.


### PR DESCRIPTION
Add badge to readme pointing to auto-updated zenodo doi:
https://doi.org/10.5281/zenodo.16280288

Closes: https://github.com/spacetelescope/stdatamodels/issues/502
Closes: https://github.com/spacetelescope/stdatamodels/pull/504

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
