### PR TITLE
Removed mrs_imatch from cal_step status

### DIFF
--- a/changes/550.removal.rst
+++ b/changes/550.removal.rst
@@ -1,0 +1,1 @@
+Removed mrs_imatch from cal_step status.

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -988,7 +988,7 @@ properties:
                    SUB41STRIPE1_DHS, SUB82STRIPE2_DHS, SUB164STRIPE4_DHS, SUB260STRIPE4_DHS,
                    SUB160STRIPE4_DHS, SUB256STRIPE4_DHS, SUB40STRIPE1_DHS, SUB80STRIPE2_DHS,
                    SUB160, SUB160P, SUB320,
-                   SUB320A335R, SUB320A430R, 
+                   SUB320A335R, SUB320A430R,
                    SUB320B335R, SUB320B430R, SUB320BLWB,
                    SUB32TATS, SUB32TATSGRISM, SUB32TA_DHS,
                    SUB400P, SUB400X256ALWB, SUB640,
@@ -2528,12 +2528,6 @@ properties:
             type: string
             enum: [SKIPPED, COMPLETE]
             fits_keyword: S_MSBSUB
-            blend_table: True
-          mrs_imatch:
-            title: MIRI MRS background matching
-            type: string
-            enum: [SKIPPED, COMPLETE]
-            fits_keyword: S_MRSMAT
             blend_table: True
           msa_flagging:
             title: NIRSpec MSA Stuck Shutter Flagging


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR is a companion of

* https://github.com/spacetelescope/jwst/pull/9486

as requested by @melanieclarke in https://github.com/spacetelescope/jwst/pull/9486#issuecomment-3165662951

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`) https://github.com/spacetelescope/RegressionTests/actions/runs/16917292154

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
