### PR TITLE
Close hdulist during datamodel init and remove from file references

### DIFF
--- a/changes/552.misc.rst
+++ b/changes/552.misc.rst
@@ -1,0 +1,1 @@
+When opening models from a .fits file, close the FITS HDUList on init instead of retaining a FileReference to it

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -235,15 +235,18 @@ class DataModel(properties.ObjectNode):
 
             if file_type == "fits":
                 hdulist = fits.open(init, memmap=False)
-                hdulist = self._migrate_hdulist(hdulist)
-                asdffile = fits_support.from_fits(
-                    hdulist,
-                    self._schema,
-                    self._ctx,
-                    ignore_unrecognized_tag=ignore_unrecognized_tag,
-                    ignore_missing_extensions=ignore_missing_extensions,
-                )
-                hdulist.close()
+                try:
+                    hdulist = self._migrate_hdulist(hdulist)
+                    asdffile = fits_support.from_fits(
+                        hdulist,
+                        self._schema,
+                        self._ctx,
+                        ignore_unrecognized_tag=ignore_unrecognized_tag,
+                        ignore_missing_extensions=ignore_missing_extensions,
+                    )
+                finally:
+                    # close the hdulist even if there's a validation error
+                    hdulist.close()
 
             elif file_type == "asdf":
                 asdffile = asdf.open(

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -234,8 +234,7 @@ class DataModel(properties.ObjectNode):
             file_type = filetype.check(init)
 
             if file_type == "fits":
-                hdulist = fits.open(init, memmap=False)
-                try:
+                with fits.open(init, memmap=False) as hdulist:
                     hdulist = self._migrate_hdulist(hdulist)
                     asdffile = fits_support.from_fits(
                         hdulist,
@@ -244,9 +243,6 @@ class DataModel(properties.ObjectNode):
                         ignore_unrecognized_tag=ignore_unrecognized_tag,
                         ignore_missing_extensions=ignore_missing_extensions,
                     )
-                finally:
-                    # close the hdulist even if there's a validation error
-                    hdulist.close()
 
             elif file_type == "asdf":
                 asdffile = asdf.open(

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -235,7 +235,6 @@ class DataModel(properties.ObjectNode):
 
             if file_type == "fits":
                 hdulist = fits.open(init, memmap=False)
-                self._file_references.append(_FileReference(hdulist))
                 hdulist = self._migrate_hdulist(hdulist)
                 asdffile = fits_support.from_fits(
                     hdulist,
@@ -244,6 +243,7 @@ class DataModel(properties.ObjectNode):
                     ignore_unrecognized_tag=ignore_unrecognized_tag,
                     ignore_missing_extensions=ignore_missing_extensions,
                 )
+                hdulist.close()
 
             elif file_type == "asdf":
                 asdffile = asdf.open(

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -29,9 +29,13 @@ def test_context_management(extension, tmp_path):
     assert len(process.open_files()) == base_count
 
     with FitsModel(original_path) as model:
-        # Count should be higher due to opening the file:
         model_count = len(process.open_files())
-        assert model_count > base_count
+        if extension == "asdf":
+            # Count should be higher due to opening the file
+            assert model_count > base_count
+        else:
+            # FITS hdulists get closed on init
+            assert model_count == base_count
 
         new_model = FitsModel(model)
 
@@ -76,9 +80,12 @@ def test_close(extension, tmp_path):
     assert len(process.open_files()) == base_count
 
     model = FitsModel(original_path)
-    # Count should be higher due to opening the file:
     model_count = len(process.open_files())
-    assert model_count > base_count
+    if extension == "asdf":
+        assert model_count > base_count
+    else:
+        # FITS hdulists get closed on init
+        assert model_count == base_count
 
     new_model = FitsModel(model)
     model.close()
@@ -122,9 +129,13 @@ def test_multiple_close(extension, tmp_path):
     assert len(process.open_files()) == base_count
 
     model = FitsModel(file_path)
-    # Count should be higher due to opening the file:
     model_count = len(process.open_files())
-    assert model_count > base_count
+    if extension == "asdf":
+        # Count should be higher due to opening the file
+        assert model_count > base_count
+    else:
+        # FITS hdulists get closed on init
+        assert model_count == base_count
 
     new_model = FitsModel(model)
     model.close()
@@ -169,9 +180,13 @@ def test_delete(extension, tmp_path):
     assert len(process.open_files()) == base_count
 
     model = FitsModel(original_path)
-    # Count should be higher due to opening the file:
     model_count = len(process.open_files())
-    assert model_count > base_count
+    if extension == "asdf":
+        # Count should be higher due to opening the file
+        assert model_count > base_count
+    else:
+        # FITS hdulists get closed on init
+        assert model_count == base_count
 
     new_model = FitsModel(model)
     del model


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #300 

<!-- describe the changes comprising this PR here -->
This PR makes it so that that when a model is initialized or opened from .fits, the `hdulist` is closed during `DataModel.__init__` instead of being left open until datamodel close.

There is no good reason to keep the hdulist around, since converting the hdulist to asdf handles all fits-related quirks during init anyway.

Regression tests show that there are no pipeline failures, and that the memory usage of many pipelines is modestly but nontrivially lower with these changes for many of the memory-tracked tests: https://github.com/spacetelescope/RegressionTests/actions/runs/16886681733

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
