### PR TITLE
Add docstrings for opening or initializing from an already-open datamodel

### DIFF
--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -192,12 +192,6 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
 
         return ModelContainer(init, **kwargs)
 
-    elif isinstance(init, (dict, asdf.AsdfFile)):
-        raise TypeError(
-            f"Unsupported type for init argument to open {type(init)}. "
-            "To initialize a datamodel from a model tree, use the DataModel constructor directly."
-        )
-
     else:
         raise TypeError(f"Unsupported type for init argument to open {type(init)}")
 

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -192,6 +192,12 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
 
         return ModelContainer(init, **kwargs)
 
+    elif isinstance(init, (dict, asdf.AsdfFile)):
+        raise TypeError(
+            f"Unsupported type for init argument to open {type(init)}. "
+            "To initialize a datamodel from a model tree, use the DataModel constructor directly."
+        )
+
     else:
         raise TypeError(f"Unsupported type for init argument to open {type(init)}")
 

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -74,16 +74,17 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
     DataModel
         A new model instance.
 
-    .. warning::
-      The ``open`` function is primarily intended for opening files and creating models from them,
-      and is not intended for creating models from scratch.
-      Init types of None, shape tuple, and numpy array
-      are deprecated and will raise a TypeError in the future.
-      Use the DataModel constructors directly instead,
-      i.e. :class:`JwstDataModel` for a generic model
-      or one of the many model subclasses (e.g. :class:`ImageModel`, :class:`MultiSlitModel`)
-      for specific applications. None, shape tuple, and numpy array are all valid inputs to those
-      constructors. See the documentation for each model class for details on how to use them.
+    Warnings
+    --------
+    The ``open`` function is primarily intended for opening files and creating models from them,
+    and is not intended for creating models from scratch.
+    Init types of None, shape tuple, and numpy array
+    are deprecated and will raise a TypeError in the future.
+    Use the DataModel constructors directly instead,
+    i.e. :class:`JwstDataModel` for a generic model
+    or one of the many model subclasses (e.g. :class:`ImageModel`, :class:`MultiSlitModel`)
+    for specific applications. None, shape tuple, and numpy array are all valid inputs to those
+    constructors. See the documentation for each model class for details on how to use them.
     """
     if "memmap" in kwargs:
         warnings.warn(

--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -40,9 +40,9 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         - list[str]: Initialize from a list of files. The list will be returned as a
           ModelContainer with the models loaded from the specified files.
 
-        - :class:`JwstDataModel`: Initialize from an existing model. This is supported
-          for pipeline code convenience, and is not recommended for general use as it
-          may cause unexpected behavior.
+        - :class:`JwstDataModel`: Initialize from an existing model. The output model will
+          be a shallow copy of the input model. This is supported for pipeline code convenience,
+          but is not recommended for general use as it may cause unexpected behavior.
 
         - None: Deprecated; use the DataModel constructor directly instead.
           A default data model with no shape.
@@ -74,16 +74,16 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
     DataModel
         A new model instance.
 
-    Notes
-    -----
-    The ``open`` function is primarily intended for opening files and creating models from them,
-    and is not intended for creating models from scratch.
-    Init types of None, shape tuple, and numpy array
-    are deprecated and will raise a TypeError in the future.
-    Use the DataModel constructors directly instead, i.e. :class:`JwstDataModel` for a generic model
-    or one of the many model subclasses (e.g. :class:`ImageModel`, :class:`MultiSlitModel`)
-    for specific applications. None, shape tuple, and numpy array are all valid inputs to those
-    constructors. See the documentation for each model class for details on how to use them.
+    .. warning::
+      The ``open`` function is primarily intended for opening files and creating models from them,
+      and is not intended for creating models from scratch.
+      Init types of None, shape tuple, and numpy array
+      are deprecated and will raise a TypeError in the future.
+      Use the DataModel constructors directly instead,
+      i.e. :class:`JwstDataModel` for a generic model
+      or one of the many model subclasses (e.g. :class:`ImageModel`, :class:`MultiSlitModel`)
+      for specific applications. None, shape tuple, and numpy array are all valid inputs to those
+      constructors. See the documentation for each model class for details on how to use them.
     """
     if "memmap" in kwargs:
         warnings.warn(

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -214,10 +214,13 @@ class DataModel(properties.ObjectNode):
         elif isinstance(init, DataModel):
             asdffile = None
             if not isinstance(init, self.__class__):
+                self.clone(self, init, deepcopy=True)
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True
                 self.validate()
                 self._validate_arrays = current_validate_arrays
+            else:
+                self.clone(self, init)
             return
 
         elif isinstance(init, AsdfFile):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -214,13 +214,10 @@ class DataModel(properties.ObjectNode):
         elif isinstance(init, DataModel):
             asdffile = None
             if not isinstance(init, self.__class__):
-                self.clone(self, init, deepcopy=True)
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True
                 self.validate()
                 self._validate_arrays = current_validate_arrays
-            else:
-                self.clone(self, init)
             return
 
         elif isinstance(init, AsdfFile):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -213,6 +213,7 @@ class DataModel(properties.ObjectNode):
 
         elif isinstance(init, DataModel):
             asdffile = None
+            self.clone(self, init)
             if not isinstance(init, self.__class__):
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -87,6 +87,10 @@ class DataModel(properties.ObjectNode):
 
             - dict: The object model tree for the data model
 
+            - DataModel: Initialize from an existing DataModel instance.
+              This will perform a shallow copy, and will convert between model subtypes
+              as long as their schemas are compatible.
+
         schema : dict, str (optional)
             Tree of objects representing a JSON schema, or string naming a schema.
             The schema to use to understand the elements on the model.
@@ -209,7 +213,6 @@ class DataModel(properties.ObjectNode):
 
         elif isinstance(init, DataModel):
             asdffile = None
-            self.clone(self, init)
             if not isinstance(init, self.__class__):
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4045](https://jira.stsci.edu/browse/JP-4045)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/9589

<!-- describe the changes comprising this PR here -->
This PR adds documentation of what happens when an already-open datamodel is opened.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
