### PR TITLE
minor change to fix resource warning

### DIFF
--- a/src/stdatamodels/jwst/transforms/tests/test_transforms.py
+++ b/src/stdatamodels/jwst/transforms/tests/test_transforms.py
@@ -903,5 +903,5 @@ def test_v23tosky_deprecated(tmp_path):
     tmp_file = tmp_path / "v23tosky.asdf"
     asdf.AsdfFile({"model": model}).write_to(tmp_file)
 
-    with pytest.warns(DeprecationWarning, match="V23ToSky is deprecated"):
-        asdf.open(tmp_file)
+    with pytest.warns(DeprecationWarning, match="V23ToSky is deprecated"), asdf.open(tmp_file):
+        pass


### PR DESCRIPTION
Minor change to a unit test to avoid a resource warning due to an unclosed file due to an `asdf.open` usage outside of a `with`.

Failure seen during asdf downstream testing (on an unrelated PR):
https://github.com/asdf-format/asdf/actions/runs/16890123647/job/47847547397?pr=1953

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
