### PR TITLE
Warn when history is used

### DIFF
--- a/changes/562.removal.rst
+++ b/changes/562.removal.rst
@@ -1,1 +1,1 @@
-Deprecate ``DataModel.history`` and add replacement ``DataModel.add_history_entry``.
+Warn when ``DataModel.history`` is used and add replacement ``DataModel.add_history_entry``.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1110,8 +1110,9 @@ class DataModel(properties.ObjectNode):
             A list of history entries.
         """
         warnings.warn(
-            "The history attribute is deprecated. Use add_history_entry to add history entries",
-            DeprecationWarning,
+            "The history attribute will soon be deprecated. "
+            "Use add_history_entry to add history entries",
+            UserWarning,
             stacklevel=2,
         )
         return HistoryList(self._asdf)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 from stdatamodels import DataModel
 
 
-@pytest.mark.filterwarnings("ignore:The history attribute is deprecated:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:The history attribute will soon be deprecated:UserWarning")
 def test_historylist_methods():
     m = DataModel()
     h1 = m.history
@@ -46,7 +46,7 @@ def test_historylist_methods():
     assert len(h1) == 0, "Clear history list"
 
 
-@pytest.mark.filterwarnings("ignore:The history attribute is deprecated:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:The history attribute will soon be deprecated:UserWarning")
 def test_history_from_model_to_fits(tmp_path):
     tmpfits = str(tmp_path / "tmp.fits")
     m = DataModel()
@@ -79,7 +79,7 @@ def test_history_from_model_to_fits(tmp_path):
         assert list(hdulist[0].header["HISTORY"]) == ["First entry", "Second entry"]
 
 
-@pytest.mark.filterwarnings("ignore:The history attribute is deprecated:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:The history attribute will soon be deprecated:UserWarning")
 def test_history_from_fits(tmp_path):
     tmpfits = str(tmp_path / "tmp.fits")
     header = fits.Header()
@@ -102,13 +102,13 @@ def test_history_from_fits(tmp_path):
 
 def test_history_get_deprecation():
     m = DataModel()
-    with pytest.warns(DeprecationWarning, match="The history attribute is deprecated"):
+    with pytest.warns(UserWarning, match="The history attribute will soon be deprecated"):
         m.history
 
 
 def test_history_set_deprecation():
     m = DataModel()
-    with pytest.warns(DeprecationWarning, match="The history attribute is deprecated"):
+    with pytest.warns(UserWarning, match="The history attribute will soon be deprecated"):
         m.history = []
 
 


### PR DESCRIPTION
Add `Datamodel.add_history_entry` (which wraps `AsdfFile.add_history_entry`) and warn when `Datamodel.history` is used.

See: https://github.com/spacetelescope/stdatamodels/issues/560 (I won't mark this as closed so we can use the same issue to track the removal of `Datamodel.history`).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
