### PR TITLE
Add `asdf_in_fits.to_hdulist` to add ASDF extension to an in memory or existing HDUList

### DIFF
--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -7,6 +7,12 @@ from . import fits_support
 
 __all__ = ["write", "open", "to_hdulist"]
 
+# This API is intended to replace the removed asdf.AsdfInFits
+# for community (non-pipeline) usage. When considering changes
+# a wider search for usage beyond pipeline code and documentation
+# is recommended as well as longer deprecation periods that
+# aren't as closely linked to pipeline releases.
+
 
 def to_hdulist(tree, hdulist=None):
     """

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -5,7 +5,28 @@ from astropy.io import fits
 
 from . import fits_support
 
-__all__ = ["write", "open"]
+__all__ = ["write", "open", "to_hdulist"]
+
+
+def to_hdulist(tree, hdulist=None):
+    """
+    Add ASDF data to an hdulist (or create one if needed).
+
+    Parameters
+    ----------
+    tree : ASDF tree or dict
+        ASDF data to add to the hdulist
+
+    hdulist : `astropy.io.fits.HDUList`
+        Optional HDUList to add the ASDF data to. If not provided,
+        a new HDUList will be created.
+
+    Returns
+    -------
+    `astropy.io.fits.HDUList` :
+        HDUList with added ASDF data.
+    """
+    return fits_support.to_fits(tree, None, hdulist=hdulist)  # no custom schema
 
 
 def write(filename, tree, hdulist=None, **kwargs):
@@ -26,8 +47,7 @@ def write(filename, tree, hdulist=None, **kwargs):
     **kwargs
         Additional keyword arguments to pass to :meth:`astropy.io.fits.HDUList.writeto`
     """
-    hdulist = fits_support.to_fits(tree, None, hdulist=hdulist)  # no custom schema
-    hdulist.writeto(filename, **kwargs)
+    to_hdulist(tree, hdulist=hdulist).writeto(filename, **kwargs)
 
 
 def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False, **kwargs):  # noqa: A001

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -124,6 +124,34 @@ def test_write_asdf_in_fits_partial_hdulist(tmp_path):
         assert len(block_offsets) == 2
 
 
+def test_to_hdulist():
+    sci = np.arange(512, dtype=float)
+    dq = np.arange(512, dtype=float) + 1
+    tree = {
+        "meta": {
+            "foo": "bar",
+        },
+        "model": {
+            "sci": {
+                "data": sci,
+            },
+            "dq": {
+                "data": dq,
+            },
+        },
+    }
+
+    hdulist = asdf_in_fits.to_hdulist(tree)
+
+    # hdu should have primary and ASDF
+    assert len(hdulist) == 2
+    # check asdf extension has blocks by looking at the block index
+    bs = hdulist["ASDF"].data["ASDF_METADATA"].tobytes()
+    block_index_bs = bs.split(b"BLOCK INDEX")[1].strip()
+    block_offsets = yaml.load(block_index_bs, yaml.SafeLoader)
+    assert len(block_offsets) == 2
+
+
 @pytest.fixture
 def test_array():
     return np.arange(1000, dtype="f4").reshape((100, 10))


### PR DESCRIPTION
I also added a note to `asdf_in_fits` describing the API is mainly for non-pipeline uses.

Closes #566

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
