### PR TITLE
JP-4077: Add cal_logs to JwstDataModel update handling

### DIFF
--- a/changes/579.feature.rst
+++ b/changes/579.feature.rst
@@ -1,0 +1,1 @@
+Add ``cal_logs`` handling to the ``update`` method for JWST datamodels.

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -1,3 +1,5 @@
+import copy
+
 from astropy.time import Time
 
 from stdatamodels import DataModel as _DataModel
@@ -63,3 +65,50 @@ class JwstDataModel(_DataModel):
         super().on_save(init)
 
         self.meta.date = Time.now().isot
+
+    def update(self, d, only=None, extra_fits=False, cal_logs=True):
+        """
+        Update this model with the metadata elements from another model.
+
+        Note: The ``update`` method skips a WCS object, if present.
+
+        Parameters
+        ----------
+        d : `~stdatamodels.jwst.datamodels.JwstDataModel` or dictionary-like object
+            The model to copy the metadata elements from. Can also be a
+            dictionary or dictionary of dictionaries or lists.
+        only : str, list of str, or None
+            Update only the named hdu, e.g. ``only='PRIMARY'``. Can either be
+            a string or list of hdu names. If None, all hdus will be updated.
+        extra_fits : bool
+            Update from ``extra_fits`` as well as ``meta``.
+        cal_logs : bool
+            Update from ``cal_logs`` as well as ``meta``.
+        """
+        # Get the cal logs first
+        if isinstance(d, _DataModel):
+            # Get cal logs if present
+            if d.hasattr("cal_logs"):
+                logs = copy.deepcopy(d.cal_logs._instance)
+            else:
+                logs = {}
+        else:
+            # Dictionary-like input: get cal_logs from the updates
+            # and remove them before calling the parent method.
+            # NOTE: If cal_logs is not removed in the input dictionary,
+            # it will cause an inscrutable crash in the parent update.
+            # It has non-meta handling for extra_fits only.
+            d = copy.deepcopy(d)
+            logs = d.pop("cal_logs", {})
+
+        # Update logs if needed
+        if cal_logs and logs:
+            if not self.hasattr("cal_logs"):
+                # Set logs from other model if not present yet
+                self.cal_logs = logs
+            else:
+                # Update the logs dictionary from the other model
+                self.cal_logs._instance.update(logs)
+
+        # Call the parent update
+        super().update(d, only=only, extra_fits=extra_fits)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4077](https://jira.stsci.edu/browse/JP-4077)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
When new models are created within the pipeline (e.g. resampling), any previous log messages recorded in `cal_logs` are lost.  In order to preserve them, this PR adds `cal_logs` handling to the update method for JwstDataModels.  When metadata is copied from the input models to the new model, the log messages will be copied too.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
