### PR TITLE
enable release-branch-semver setuptools_scm configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ norecursedirs = ["build", ".tox", ".eggs", "venv"]
 
 [tool.setuptools_scm]
 write_to = "src/stdatamodels/_version.py"
+version_scheme = "release-branch-semver"
 
 [tool.coverage.run]
 omit = ['*/tests/*']


### PR DESCRIPTION
Enables `release-branch-semver` option for setuptools_scm to allow picking up named release branches when determining the dev version.

See https://setuptools-scm.readthedocs.io/en/latest/config/ for documentation.

All credit to @tapastro for finding this option.

We will want to drop the 4.1.0.dev tag on main before we merge this PR (with this setting and that tag the version will be 4.2.0.dev..., without that tag the version will be 4.1.0.dev...).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
