### PR TITLE
add filter to mask model, add BkgModel for MIR_WFSS

### DIFF
--- a/changes/594.bugfix.rst
+++ b/changes/594.bugfix.rst
@@ -1,0 +1,1 @@
+Add filter keyword to mask schema.

--- a/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mask.schema.yaml
@@ -6,6 +6,7 @@ allOf:
 - $ref: referencefile.schema
 - $ref: subarray.schema
 - $ref: keyword_exptype.schema
+- $ref: keyword_filter.schema
 - $ref: keyword_readpatt.schema
 - $ref: keyword_preadpatt.schema
 - type: object

--- a/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
+++ b/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py
@@ -68,6 +68,7 @@ bkg_model_map = {
     "NRC_WFSS": dm.WfssBkgModel,
     "NIS_WFSS": dm.WfssBkgModel,
     "NIS_SOSS": dm.SossBkgModel,
+    "MIR_WFSS": dm.WfssBkgModel,
 }
 
 cubepar_model_map = {


### PR DESCRIPTION
The tests against crds test is failing on main with the new crds context:
https://github.com/spacetelescope/stdatamodels/actions/runs/18160115109/job/51688850979

https://jwst-crds.stsci.edu/context_table/jwst_1460.pmap

It is failing due to `MIR_WFSS` not being listed here:
https://github.com/spacetelescope/stdatamodels/blob/47a0d86770e90aa9ed8fee84767de64c3a34ab15/src/stdatamodels/jwst/datamodels/tests/test_schema_against_crds.py#L67-L71

and due to `filter` not being listed in the `mask` schema.

This PR adds `filter` to the `mask` schema and assigns the `WfssBkgModel` for `MIR_WFSS` to fix the two failures.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/18160951926
Failures look unrelated and due to some MAST/EngDB outage/change.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
