### PR TITLE
JP-4005: Remove nsclean cal_step status keyword

### DIFF
--- a/changes/608.removal.rst
+++ b/changes/608.removal.rst
@@ -1,0 +1,1 @@
+Removed nsclean from cal_step status.

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2576,11 +2576,6 @@ properties:
             enum: [SKIPPED, COMPLETE]
             fits_keyword: S_MSAFLG
             blend_table: True
-          nsclean:
-            title: NIRSpec 1/f Noise Correction
-            type: string
-            enum: [SKIPPED, COMPLETE]
-            fits_keyword: S_NSCLEN
           outlier_detection:
             title: Outlier Detection
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4005](https://jira.stsci.edu/browse/JP-4005)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Remove the nsclean cal_step status keyword.  The step was removed in https://github.com/spacetelescope/jwst/pull/9981.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
