### PR TITLE
readd 3.13 ci jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,17 +57,11 @@ jobs:
       envs: |
         - linux: py311-xdist
         - linux: py312-xdist
-        # `tox` does not currently use the `requires-python` versions 
-        # defined in pyproject.toml. This means even if we set an upper limit
-        # for python in that file the `py3` below will try to use the newest
-        # python even if it's above that limit.
-        # If we don't support the latest stable python, update `py3` below
-        # to use only the latest supported version (matching what is set
-        # for `requires-python` in `pyproject.toml`)
-        - linux: py3-cov-xdist
+        - linux: py313-xdist
+        - linux: py314-cov-xdist
           coverage: codecov
-        - macos: py3-xdist
-        - windows: py3-xdist-nocrds
+        - macos: py314-xdist
+        - windows: py314-xdist-nocrds
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d9b81a07e789d1b1921ab5fe33de2ddcbbd02c3f  # v2.3.0
     needs: [ data ]


### PR DESCRIPTION
With the change of `py3` from meaning 3.13 to 3.14 we lost testing for 3.13. This updates the CI jobs to test against 3.13.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
