### PR TITLE
Deprecate grating transforms

### DIFF
--- a/changes/614.removal.rst
+++ b/changes/614.removal.rst
@@ -1,0 +1,1 @@
+Deprecate AngleFromGratingEquation and WavelengthFromGratingEquation; use gwcs.spectroscopy.WavelengthFromGratingEquation and gwcs.spectroscopy.AnglesFromGratingEquation3D instead.

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -1,11 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-
 import asdf
 from asdf_astropy.converters.transform.core import TransformConverterBase
 from astropy.modeling import Model
-from astropy.modeling.models import Identity, Mapping, Scale
 
 from stdatamodels.properties import ListNode
 
@@ -375,15 +372,8 @@ class GratingEquationConverter(TransformConverterBase):
     ]
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-        warnings.warn(
-            "Encountered deprecated stdatamodels GratingEquation model. "
-            "An attempt will be made to convert to its equivalent replacement "
-            "using the transforms from the gwcs.spectroscopy module.",
-            UserWarning,
-            stacklevel=2,
-        )
-        from gwcs.spectroscopy import (
-            AnglesFromGratingEquation3D,
+        from stdatamodels.jwst.transforms.models import (
+            AngleFromGratingEquation,
             WavelengthFromGratingEquation,
         )
 
@@ -391,23 +381,11 @@ class GratingEquationConverter(TransformConverterBase):
         order = node["order"]
         output = node["output"]
         if output == "wavelength":
-            model = (
-                # Don't need beta angle so map it out
-                # alpha angle has opposite sign convention in gwcs
-                Mapping((0, 2), n_inputs=3)
-                | WavelengthFromGratingEquation(groove_density, order, name="lambda_from_gratingeq")
-                | Scale(-1)
-            )
+            model = WavelengthFromGratingEquation(groove_density, order)
         elif output == "angle":
-            # Don't need z coordinate for angle computation so map it out
-            # alpha angle has opposite sign convention in gwcs
-            model = (
-                Mapping((0, 1, 2), n_inputs=4)
-                | Identity(1) & Scale(-1) & Identity(1)
-                | AnglesFromGratingEquation3D(groove_density, order)
-            )
+            model = AngleFromGratingEquation(groove_density, order)
         else:
-            raise ValueError(f"Can't create a GratingEquation model with output {output}")
+            raise ValueError(f"Can't create a GratingEquation model withoutput {output}")
         return model
 
     def to_yaml_tree_transform(self, model, tag, ctx):

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -2376,6 +2376,12 @@ class AngleFromGratingEquation(Model):
         **kwargs
             Additional keyword arguments to pass to Model base class.
         """
+        warnings.warn(
+            "AngleFromGratingEquation is deprecated and will be removed in a future version. "
+            "Use gwcs.spectroscopy.AngleFromGratingEquation3D instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(groove_density=groove_density, order=order, **kwargs)
         self.inputs = ("lam", "alpha_in", "beta_in", "z")
         """ Wavelength and 3 angle coordinates going into the grating."""
@@ -2441,6 +2447,12 @@ class WavelengthFromGratingEquation(Model):
         **kwargs
             Additional keyword arguments to pass to Model base class.
         """
+        warnings.warn(
+            "WavelengthFromGratingEquation is deprecated and will be removed in a future version. "
+            "Use gwcs.spectroscopy.WavelengthFromGratingEquation instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(groove_density=groove_density, order=order, **kwargs)
         self.inputs = ("alpha_in", "beta_in", "alpha_out")
         """

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -2378,7 +2378,7 @@ class AngleFromGratingEquation(Model):
         """
         warnings.warn(
             "AngleFromGratingEquation is deprecated and will be removed in a future version. "
-            "Use gwcs.spectroscopy.AngleFromGratingEquation3D instead.",
+            "Use gwcs.spectroscopy.AnglesFromGratingEquation3D instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/jwst/transforms/test_models.py
+++ b/tests/jwst/transforms/test_models.py
@@ -28,8 +28,6 @@ test_models = [
     DirCos2Unitless(),
     Unitless2DirCos(),
     Rotation3DToGWA(angles=[12.1, 1.3, 0.5, 3.4], axes_order="xyzx"),
-    AngleFromGratingEquation(20000, -1),
-    WavelengthFromGratingEquation(25000, 2),
     Logical("GT", 5, 10),
     Logical("LT", np.ones((10,)) * 5, np.arange(10)),
     Snell(
@@ -48,6 +46,14 @@ test_models = [
 @pytest.mark.parametrize(("model"), test_models)
 def test_model(tmpdir, model, version=None):
     assert_model_roundtrip(model, tmpdir)
+
+
+# @pytest.mark.parametrize(("model"), test_models_deprecated)
+def test_model_deprecated(tmpdir, version=None):
+    for klass in [AngleFromGratingEquation, WavelengthFromGratingEquation]:
+        with pytest.warns(DeprecationWarning):
+            model = klass(20000, 1)
+            assert_model_roundtrip(model, tmpdir)
 
 
 def test_gwa_to_slit(tmpdir):

--- a/tests/jwst/transforms/test_models.py
+++ b/tests/jwst/transforms/test_models.py
@@ -5,7 +5,11 @@ import asdf
 import numpy as np
 import pytest
 from asdf_astropy.testing.helpers import assert_model_roundtrip
+from astropy.modeling import CompoundModel
 from astropy.modeling.models import Const1D, Rotation2D, Shift
+from gwcs.spectroscopy import AnglesFromGratingEquation3D
+from gwcs.spectroscopy import WavelengthFromGratingEquation as WavelengthGWCS
+from numpy.testing import assert_allclose
 
 from stdatamodels.jwst.transforms.models import (
     AngleFromGratingEquation,
@@ -44,16 +48,86 @@ test_models = [
 
 
 @pytest.mark.parametrize(("model"), test_models)
-def test_model(tmpdir, model, version=None):
+def test_model_roundtrip(tmpdir, model, version=None):
     assert_model_roundtrip(model, tmpdir)
 
 
-# @pytest.mark.parametrize(("model"), test_models_deprecated)
-def test_model_deprecated(tmpdir, version=None):
-    for klass in [AngleFromGratingEquation, WavelengthFromGratingEquation]:
-        with pytest.warns(DeprecationWarning):
-            model = klass(20000, 1)
-            assert_model_roundtrip(model, tmpdir)
+def test_anglefromgratingequation_replace(tmpdir, version=None):
+    """Ensure that replacement of deprecated AngleFromGratingEquation with gwcs equivalent works."""
+
+    # Create the deprecated model
+    groove_density = 20000.0
+    order = -1
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        deprecated_model = AngleFromGratingEquation(groove_density, order)
+
+    # Test serialization
+    path = str(tmpdir / "anglefromgrating.asdf")
+    with asdf.AsdfFile({"model": deprecated_model}) as af:
+        af.write_to(path)
+
+    # Test deserialization - should convert to gwcs model and raise UserWarning
+    with pytest.warns(UserWarning, match="deprecated stdatamodels GratingEquation"):
+        with asdf.open(path) as af:
+            loaded_model = af["model"]
+
+    assert isinstance(loaded_model, CompoundModel)
+    assert isinstance(loaded_model[4], AnglesFromGratingEquation3D)
+
+    # Test that the models produce equivalent results
+    lam = 2.0e-6
+    alpha_in = np.array([0.1, 0.2])
+    beta_in = np.array([0.05, 0.1])
+    z = np.array([0.9, 0.95])
+
+    # Evaluate both models in identical ways
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        alpha_out_old, beta_out_old, z_out_old = deprecated_model(lam, alpha_in, beta_in, z)
+    alpha_out_new, beta_out_new, z_out_new = loaded_model(lam, alpha_in, beta_in, z)
+
+    # Results should be equivalent
+    assert_allclose(alpha_out_new, alpha_out_old, rtol=1e-10)
+    assert_allclose(beta_out_new, beta_out_old, rtol=1e-10)
+    assert_allclose(z_out_new, z_out_old, rtol=1e-10)
+
+
+def test_wavelengthfromgratingequation_replace(tmpdir, version=None):
+    """Ensure that replacement of deprecated WavelengthFromGratingEquation with gwcs equivalent works."""
+    # Create the deprecated model
+    groove_density = 25000.0
+    order = 2
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        deprecated_model = WavelengthFromGratingEquation(groove_density, order)
+
+    # Test serialization
+    path = str(tmpdir / "wavelengthfromgrating.asdf")
+    with asdf.AsdfFile({"model": deprecated_model}) as af:
+        af.write_to(path)
+
+    # Test deserialization - should convert to gwcs model and raise UserWarning
+    with pytest.warns(UserWarning, match="deprecated stdatamodels GratingEquation"):
+        with asdf.open(path) as af:
+            loaded_model = af["model"]
+    assert isinstance(loaded_model, CompoundModel)
+    assert isinstance(loaded_model[1], WavelengthGWCS)
+
+    # Test that the models produce equivalent results
+    alpha_in = np.array([0.1, 0.2])
+    beta_in = np.array([0.05, 0.1])
+    alpha_out = np.array([0.15, 0.25])
+
+    # Evaluate both models in identical ways
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        lam_old = deprecated_model(alpha_in, beta_in, alpha_out)
+    lam_new = loaded_model(alpha_in, beta_in, alpha_out)
+
+    # Results should be equivalent
+    assert_allclose(lam_new, lam_old, rtol=1e-10)
 
 
 def test_gwa_to_slit(tmpdir):

--- a/tests/jwst/transforms/test_transforms.py
+++ b/tests/jwst/transforms/test_transforms.py
@@ -210,15 +210,27 @@ def test_grating_equation():
     beta_in = np.array([np.pi / 8, np.pi / 8])  # angle of incidence in radians
     z = np.array([0.0, 0.0])  # z-coordinate, not used in this model
 
-    angle_transform = models.AngleFromGratingEquation(groovedensity, order)
+    with pytest.warns(DeprecationWarning, match="AngleFromGratingEquation is deprecated"):
+        angle_transform = models.AngleFromGratingEquation(groovedensity, order)
     alpha_out, beta_out, _zout = angle_transform.evaluate(
         lam, alpha_in, beta_in, z, groovedensity, order
     )
     assert_allclose(beta_out, -beta_in)
 
-    wavelength_transform = models.WavelengthFromGratingEquation(groovedensity, order)
+    with pytest.warns(DeprecationWarning, match="WavelengthFromGratingEquation is deprecated"):
+        wavelength_transform = models.WavelengthFromGratingEquation(groovedensity, order)
     lam_out = wavelength_transform.evaluate(alpha_in, beta_in, alpha_out, groovedensity, order)
     assert_allclose(lam_out, lam)
+
+
+def test_angle_from_grating_equation_deprecation():
+    with pytest.warns(DeprecationWarning, match="AngleFromGratingEquation is deprecated"):
+        models.AngleFromGratingEquation(1000.0, 1)
+
+
+def test_wavelength_from_grating_equation_deprecation():
+    with pytest.warns(DeprecationWarning, match="WavelengthFromGratingEquation is deprecated"):
+        models.WavelengthFromGratingEquation(1000.0, 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Follow up from https://github.com/spacetelescope/jwst/pull/9995

<!-- describe the changes comprising this PR here -->
This PR deprecates the now-unused ``AngleFromGratingEquation`` and ``WavelengthFromGratingEquation`` transforms, which have replacements in ``gwcs.spectroscopy``.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
