### PR TITLE
JP-4184: Relax t range for NIRCam WFSS grism transforms

### DIFF
--- a/changes/625.bugfix.rst
+++ b/changes/625.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect parametrization of trace models for NIRCam WFSS transforms

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1190,7 +1190,8 @@ class _NIRCAMForwardGrismDispersion(_ForwardGrismDispersionBase):
         if len(dx.shape) == 2:
             dx = dx[0, :]
 
-        t0 = np.linspace(0.0, 1.0, self.sampling)
+        # NIRCam t functions have been calibrated such that being just outside (0, 1) is okay
+        t0 = np.linspace(-0.1, 1.1, self.sampling)
 
         # handle multiple inverse model types
         if isinstance(model, (ListNode, list, tuple)):
@@ -1489,7 +1490,8 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
         t_out : float
             The inverse dispersion value for the given wavelength
         """
-        t0 = np.linspace(0.0, 1.0, int(self.sampling))
+        # NIRCam t functions have been calibrated such that being just outside (0, 1) is okay
+        t0 = np.linspace(-0.1, 1.1, int(self.sampling))
 
         if len(model) < 2:
             # Handle legacy versions of the trace model


### PR DESCRIPTION
Resolves [JP-4184](https://jira.stsci.edu/browse/JP-4184)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/jwst#10012

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where artifacts were present at the short-wavelength ends of NIRCam WFSS spectra.  This was caused by a mismatch between the stdatamodels definition of the model transforms for NIRCam and how they are calibrated when input into the specwcs.  Specifically, NIRCam's dispersion models are calibrated such that the `t` parameter can be slightly outside the range `[0,1]`.

Prior to this PR, when a best-fitting `t`-value was found outside the `[0,1]` range, it was clipped to the edge of that range.  This was causing many flux contributions from different wavelengths to end up in the same pixel, which appeared like the artifacts shown on the JIRA ticket.  The team has instructed us that the limits `[-0.1, 1.1]` are what should be used.  When those limits are used instead, the problem goes away - the different wavelengths are properly dispersed into different locations on the detector.

A side-effect of this change is that the bounding boxes for the cutouts in `extract_2d` as well as the background mask are longer by a few hundred pixels in the along-dispersion direction for NIRCam.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
