### PR TITLE
Fix ResourceWarnings in py314 tests due to failed model closes

### DIFF
--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -196,8 +196,8 @@ def test_equivalent_to_get_crds_parameters(multislit_path):
     meta = read_metadata(multislit_path)
 
     # load the model and get the CRDS parameters
-    model = dm.open(multislit_path)
-    crds_meta = model.get_crds_parameters()
+    with dm.open(multislit_path) as model:
+        crds_meta = model.get_crds_parameters()
 
     # ensure all keys in crds_meta are in meta and have the same values
     for key, val in crds_meta.items():
@@ -233,9 +233,9 @@ def test_error_read_json():
 
 def test_error_read_open_model(model_path):
     """Attempting to read_metadata on an open datamodel should raise an error."""
-    model = dm.open(model_path)
-    with pytest.raises(TypeError):
-        read_metadata(model)
+    with dm.open(model_path) as model:
+        with pytest.raises(TypeError):
+            read_metadata(model)
 
 
 def test_error_schema_not_found(model_path):


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses failing unit tests like https://github.com/spacetelescope/stdatamodels/actions/runs/20022649722/job/57412837878

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
