### PR TITLE
add gc.collect prior to base count for open files tests

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -17,6 +17,7 @@ def test_context_management(extension, tmp_path):
     new_path = tmp_path / f"new.{extension}"
 
     process = psutil.Process()
+    gc.collect(2)
     base_count = len(process.open_files())
 
     rng = np.random.default_rng(42)
@@ -67,6 +68,7 @@ def test_close(extension, tmp_path):
     new_path = tmp_path / f"new.{extension}"
 
     process = psutil.Process()
+    gc.collect(2)
     base_count = len(process.open_files())
 
     rng = np.random.default_rng(42)
@@ -116,6 +118,7 @@ def test_multiple_close(extension, tmp_path):
     file_path = tmp_path / f"test.{extension}"
 
     process = psutil.Process()
+    gc.collect(2)
     base_count = len(process.open_files())
 
     rng = np.random.default_rng(42)
@@ -166,6 +169,7 @@ def test_delete(extension, tmp_path):
     new_path = tmp_path / f"new.{extension}"
 
     process = psutil.Process()
+    gc.collect(2)
     base_count = len(process.open_files())
 
     rng = np.random.default_rng(42)


### PR DESCRIPTION
3.14 tests are showing some test failures possibly due to a change in garbage collection revealing some inadequacies in our tests.

This forces garbage collection prior to polling the number of open files to get the "base count" for tests checking the number of open files.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
