### PR TITLE
DOC: Remove unrendered ref that looks ugly

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -137,7 +137,7 @@ class DataModel(properties.ObjectNode):
             are defined in the schema and the schema expects an array-like value.
             Kwargs are only allowed when `init` is `None`, a tuple, or a numpy array.
             Example usage::
-            
+
                 model = ImageModel(data=np.ones((10, 10)), dq=np.zeros((10, 10)))
         """
         if "memmap" in kwargs:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses ugly rendered doc because the ref linking failed for some reason when docstring inherited.

Example: https://stdatamodels.readthedocs.io/en/latest/api/stdatamodels.jwst.datamodels.NRMModel.html

<img width="620" height="223" alt="Screenshot 2025-12-18 154826" src="https://github.com/user-attachments/assets/dd984166-927f-40d0-989d-5c61b13e2b44" />

Also fixed a formatting error for a code snippet. No need for RT.

With this patch: https://stdatamodels--640.org.readthedocs.build/en/640/api/stdatamodels.jwst.datamodels.NRMModel.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
