### PR TITLE
JP-4205: Give SOSS wave grid its expected float64 datatype when saved

### DIFF
--- a/changes/642.bugfix.rst
+++ b/changes/642.bugfix.rst
@@ -1,0 +1,1 @@
+Change datatype of SossWaveGridModel wave_grid to float64 as expected by ATOCA code

--- a/src/stdatamodels/jwst/datamodels/schemas/sosswavegrid.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/sosswavegrid.schema.yaml
@@ -10,4 +10,4 @@ allOf:
       title: Wavelength grid
       fits_hdu: WAVEGRID
       ndim: 1
-      datatype: float32
+      datatype: float64


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Addresses [JP-4205](https://jira.stsci.edu/browse/JP-4205) along with corresponding JWST PR.

<!-- describe the changes comprising this PR here -->
This PR gives the SOSS `wave_grid` the expected float64 datatype.

See https://github.com/spacetelescope/jwst/pull/10105

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
