### PR TITLE
Remove Romancal from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
 for example JP-1234: <Fix a bug> -->
 Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)
-Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)
 
 <!-- If this PR closes a GitHub issue, reference it here by its number -->
 Closes #


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR removes the RCAL tag from the PR template.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
