### PR TITLE
avoid array shape assignment

### DIFF
--- a/changes/648.bugfix.rst
+++ b/changes/648.bugfix.rst
@@ -1,0 +1,1 @@
+Replace array shape assignments with reshape to avoid upcoming deprecation warnings from numpy.

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -2211,7 +2211,7 @@ class Rotation3DToGWA(Model):
         orig_shape = x.shape or (1,)
         for ang, ax in zip(angles[0], self.axes_order, strict=False):
             x, y, z = self._func_map[ax](x, y, z, theta=ang)
-        x.shape = y.shape = z.shape = orig_shape
+        x, y, z = [np.reshape(arr, orig_shape) for arr in (x, y, z)]
 
         return x, y, z
 


### PR DESCRIPTION
Dev numpy has deprecated array shape assignment: https://github.com/numpy/numpy/pull/29536

Replace the direct array shape assignment with calls to `np.reshape`.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/20860533362 all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
