### PR TITLE
JP-4219: Avoid changing array shape in-place

### DIFF
--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -2409,10 +2409,9 @@ class AngleFromGratingEquation(Model):
         if alpha_in.shape != beta_in.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
         orig_shape = alpha_in.shape or (1,)
-        xout = -alpha_in - groove_density * order * lam
-        yout = -beta_in
+        xout = (-alpha_in - groove_density * order * lam).reshape(orig_shape)
+        yout = (-beta_in).reshape(orig_shape)
         zout = np.sqrt(1 - xout**2 - yout**2)
-        xout.shape = yout.shape = zout.shape = orig_shape
         return xout, yout, zout
 
 


### PR DESCRIPTION
Resolves [JP-4219](https://jira.stsci.edu/browse/JP-4219)

This PR addresses the issue of deprecation of changing array shape in-place via setting `np.ndarray.shape` attribute, see https://numpy.org/devdocs/release/notes-towncrier.html#setting-the-shape-attribute-is-deprecated. It is a continuation of https://github.com/spacetelescope/stdatamodels/pull/648

Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/20892638752

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
