### PR TITLE
ignore shape deprecation warning from numpy triggered by astropy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ filterwarnings = [
   "error",
   # astropy table issues this warning on import so we ignore it here
   "ignore:numpy.ndarray size changed:RuntimeWarning",
+  # dev numpy deprecated shape assignment which astropy still uses
+  "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:astropy.*",
 ]
 asdf_schema_tests_enabled = true
 asdf_schema_xfail_tests = "v23tosky-0.7.0.yaml::test_example_0"


### PR DESCRIPTION
Astropy assigns to array shapes. This is deprecated in dev numpy and causing devdeps failures. This ignores the warning since we've fixed the instances where we assign to shape.

Example run with failures:
https://github.com/spacetelescope/stdatamodels/actions/runs/20922257132/job/60110642859?pr=649
The failed job (py3-devdeps-xdist) passes with this PR:
https://github.com/spacetelescope/stdatamodels/actions/runs/20929679668/job/60137045958?pr=651

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
