### PR TITLE
Hasattr bug

### DIFF
--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -27,9 +27,9 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
         A Numpy array
     """
     if not hasattr(input_model, "dq_def"):
-        input_model.dq_def = input_model.set_default("dq_def")
+        input_model.set_default("dq_def")
     if not hasattr(input_model, "dq"):
-        input_model.dq = input_model.set_default("dq")
+        input_model.set_default("dq")
     dq_table = input_model.dq_def
     # Get the DQ array and the flag definitions
     if (

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -26,6 +26,10 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     dqmask : ndarray
         A Numpy array
     """
+    if not hasattr(input_model, "dq_def"):
+        input_model.dq_def = input_model.set_default("dq_def")
+    if not hasattr(input_model, "dq"):
+        input_model.dq = input_model.set_default("dq")
     dq_table = input_model.dq_def
     # Get the DQ array and the flag definitions
     if (

--- a/src/stdatamodels/jwst/datamodels/amioi.py
+++ b/src/stdatamodels/jwst/datamodels/amioi.py
@@ -18,22 +18,22 @@ class AmiOIModel(JwstDataModel):
         # (and defined) metadata, copy the data to the OIFITS compatible
         # locations
 
-        self.meta.oifits.derived.observer = self.meta.program.pi_name
-        self.meta.oifits.derived.object = (
-            self.meta.target.proposer_name or self.meta.target.catalog_name
-        )
+        self.meta.oifits.derived.observer = getattr(self.meta.program, "pi_name", None)
+        self.meta.oifits.derived.object = getattr(
+            self.meta.target, "proposer_name", None
+        ) or getattr(self.meta.target, "catalog_name", None)
 
         # This file contains OIFITS2 content
         self.meta.oifits.derived.content = "OIFITS2"
 
         # each OIFITS data table needs specific cross-referencing keywords
-        array_name = self.meta.oifits.array_name
+        array_name = getattr(self.meta.oifits, "array_name", None)
         self.meta.oifits.derived.t3.array_name = array_name
         self.meta.oifits.derived.vis.array_name = array_name
         self.meta.oifits.derived.vis2.array_name = array_name
         self.meta.oifits.derived.q4.array_name = array_name
 
-        insname = self.meta.instrument.name
+        insname = getattr(self.meta.instrument, "name", None)
         self.meta.oifits.derived.wavelength.instrument_name = insname
         self.meta.oifits.derived.t3.instrument_name = insname
         self.meta.oifits.derived.vis.instrument_name = insname
@@ -49,7 +49,7 @@ class AmiOIModel(JwstDataModel):
         # Currently this code leaves the value as-is (expressed
         # as a date only) to avoid complications for other JWST
         # code.
-        date_obs = self.meta.observation.date
+        date_obs = getattr(self.meta.observation, "date", None)
         self.meta.oifits.derived.t3.date_obs = date_obs
         self.meta.oifits.derived.vis.date_obs = date_obs
         self.meta.oifits.derived.vis2.date_obs = date_obs
@@ -64,13 +64,13 @@ class AmiOIModel(JwstDataModel):
         self.meta.oifits.derived.wavelength.revn = 2
 
         # fill in possibly missing OI_ARRAY meta data
-        if self.meta.oifits.derived.array.frame is None:
+        if getattr(self.meta.oifits.derived.array, "frame", None) is None:
             self.meta.oifits.derived.array.frame = "SKY"
-        if self.meta.oifits.derived.array.x is None:
+        if getattr(self.meta.oifits.derived.array, "x", None) is None:
             self.meta.oifits.derived.array.x = 0.0
-        if self.meta.oifits.derived.array.y is None:
+        if getattr(self.meta.oifits.derived.array, "y", None) is None:
             self.meta.oifits.derived.array.y = 0.0
-        if self.meta.oifits.derived.array.z is None:
+        if getattr(self.meta.oifits.derived.array, "z", None) is None:
             self.meta.oifits.derived.array.z = 0.0
 
     def on_save(self, path=None):  # noqa: D102

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -25,6 +25,8 @@ class AsnModel(JwstDataModel):
         self.input_rootnames = []
         self.num_inputs = 0
 
+        if not hasattr(self, "asn_table"):
+            self.asn_table = []
         if not len(self.asn_table):
             return
 

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -49,6 +49,5 @@ class WfssBkgModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -34,6 +34,8 @@ class CubeModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(CubeModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        # Set required arrays to defaults
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -29,5 +29,5 @@ class FlatModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -29,6 +29,5 @@ class FringeModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -32,9 +32,10 @@ class GuiderRawModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(GuiderRawModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")
 
 
 class GuiderCalModel(JwstDataModel):
@@ -66,6 +67,7 @@ class GuiderCalModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(GuiderCalModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -26,6 +26,7 @@ class IFUCubeModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(IFUCubeModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -36,6 +36,7 @@ class IFUImageModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(IFUImageModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -29,6 +29,5 @@ class LastFrameModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -23,11 +23,8 @@ class MaskModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(MaskModel, self).__init__(init=init, **kwargs)
 
-        if self.dq is not None or self.dq_def is not None:
+        if hasattr(self, "dq") or hasattr(self, "dq_def"):
             self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
 
     def get_primary_array_name(self):  # noqa: D102
         return "dq"

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -63,12 +63,13 @@ class NirspecFlatModel(ReferenceFileModel):
 
         super(NirspecFlatModel, self).__init__(init=init, **kwargs)
 
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")
+
         if self.dq is not None or self.dq_def is not None:
             self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
 
     def _migrate_hdulist(self, hdulist):
         return _migrate_fast_variation_table(hdulist)

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -107,12 +107,16 @@ class NirspecQuadFlatModel(ReferenceFileModel):
             super(NirspecQuadFlatModel, self).__init__(init=None, **kwargs)
             self.update(init)
             self.quadrants.append(self.quadrants.item())
-            self.quadrants[0].data = init.data
-            self.quadrants[0].dq = init.dq
-            self.quadrants[0].err = init.err
-            self.quadrants[0].wavelength = init.wavelength
-            self.quadrants[0].flat_table = init.flat_table
-            self.quadrants[0].dq_def = init.dq_def
+            for att in [
+                "data",
+                "dq",
+                "err",
+                "wavelength",
+                "flat_table",
+                "dq_def",
+            ]:
+                init.set_default(att)
+                setattr(self.quadrants[0], att, getattr(init, att, None))
             self.quadrants[0].dq = dynamic_mask(self.quadrants[0], pixel)
             return
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -22,6 +22,7 @@ class QuadModel(JwstDataModel):
     def __init__(self, init=None, **kwargs):
         super(QuadModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -29,5 +29,7 @@ class RampModel(JwstDataModel):
         super(RampModel, self).__init__(init=init, **kwargs)
 
         # Implicitly create arrays
-        self.pixeldq = self.pixeldq
-        self.groupdq = self.groupdq
+        if not hasattr(self, "pixeldq"):
+            self.set_default("pixeldq")
+        if not hasattr(self, "groupdq"):
+            self.set_default("groupdq")

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -24,11 +24,11 @@ class ReferenceFileModel(JwstDataModel):
         to_fix = []
         to_check = ["description", "reftype", "author", "pedigree", "useafter"]
         for field in to_check:
-            if getattr(self.meta, field) is None:
+            if getattr(self.meta, field, None) is None:
                 to_fix.append(field)
-        if self.meta.instrument.name is None:
+        if getattr(self.meta.instrument, "name", None) is None:
             to_fix.append("instrument.name")
-        if self.meta.telescope != "JWST":
+        if getattr(self.meta, "telescope", None) != "JWST":
             to_fix.append("telescope")
         if to_fix:
             self.print_err(f"Model.meta is missing values for {to_fix}")

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -103,9 +103,10 @@ class ReferenceImageModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(ReferenceImageModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")
 
         if self.hasattr("dq_def"):
             self.dq = dynamic_mask(self, pixel)
@@ -130,9 +131,10 @@ class ReferenceCubeModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(ReferenceCubeModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")
 
 
 class ReferenceQuadModel(ReferenceFileModel):
@@ -154,6 +156,7 @@ class ReferenceQuadModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(ReferenceQuadModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "dq"):
+            self.set_default("dq")
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -29,6 +29,5 @@ class ResetModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -53,6 +53,7 @@ class SlitDataModel(JwstDataModel):
         if kwargs:
             for key in kwargs:
                 setattr(self, key, kwargs[key])
+        self.set_default("wavelength")
 
 
 class SlitModel(JwstDataModel):

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -29,6 +29,5 @@ class SuperBiasModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if not hasattr(self, "err"):
+            self.set_default("err")

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -109,7 +109,7 @@ class _SimpleModel(ReferenceFileModel):
                 "FGS",
                 "NIRISS",
             ]
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -131,7 +131,7 @@ class DistortionModel(_SimpleModel):
                 assert self.meta.instrument.module is not None
                 assert self.meta.instrument.channel is not None
                 assert self.meta.instrument.p_pupil is not None
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -247,7 +247,7 @@ class DistortionMRSModel(ReferenceFileModel):
             assert all(isinstance(m, Model) for m in self.beta_model)
             assert len(self.abv2v3_model.model) == 2
             assert len(self.abv2v3_model.channel_band) == 2
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -281,7 +281,7 @@ class SpecwcsModel(_SimpleModel):
                 "FGS",
                 "NIRISS",
             ]
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -368,7 +368,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
             assert self.meta.instrument.name == "NIRCAM"
             assert self.meta.exposure.type == "NRC_WFSS"
             assert self.meta.reftype == self.reftype
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -450,7 +450,7 @@ class NIRISSGrismModel(ReferenceFileModel):
             assert self.meta.exposure.type == "NIS_WFSS"
             assert self.meta.instrument.detector == "NIS"
             assert self.meta.reftype == self.reftype
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -532,7 +532,7 @@ class MiriWFSSSpecwcsModel(ReferenceFileModel):
             assert len(self.displ) == n_orders
             assert len(self.dispx) == n_orders
             assert len(self.dispy) == n_orders
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -650,7 +650,7 @@ class MiriLRSSpecwcsModel(ReferenceFileModel):
             assert self.meta.instrument.name == "MIRI"
             assert self.meta.instrument.detector == "MIRIMAGE"
             assert self.meta.reftype.lower() == self.reftype
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -711,7 +711,7 @@ class RegionsModel(ReferenceFileModel):
                 "LONG-MEDIUM",
             )
             assert self.meta.instrument.detector in ("MIRIFUSHORT", "MIRIFULONG")
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -778,7 +778,7 @@ class WavelengthrangeModel(ReferenceFileModel):
         super().validate()
         try:
             assert self.meta.instrument.name in ("MIRI", "NIRSPEC", "NIRCAM", "NIRISS")
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -859,7 +859,7 @@ class FPAModel(ReferenceFileModel):
         try:
             assert isinstance(self.nrs1_model, Model)
             assert isinstance(self.nrs2_model, Model)
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -1131,7 +1131,7 @@ class DisperserModel(ReferenceFileModel):
                 "MIRROR",
                 "PRISM",
             ]
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -1184,7 +1184,7 @@ class FilteroffsetModel(ReferenceFileModel):
     def validate(self):
         super().validate()
 
-        instrument_name = self.meta.instrument.name
+        instrument_name = getattr(self.meta.instrument, "name", None)
         nircam_channels = ["SHORT", "LONG"]
         nircam_module = ["A", "B"]
         if instrument_name not in ["MIRI", "NIRCAM", "NIRISS"]:
@@ -1194,12 +1194,12 @@ class FilteroffsetModel(ReferenceFileModel):
         if instrument_name == "MIRI" and self.meta.instrument.detector != "MIRIMAGE":
             self.print_err("Expected detector to be MIRIMAGE for instrument MIRI")
         elif instrument_name == "NIRCAM":
-            if self.meta.instrument.channel not in nircam_channels:
+            if getattr(self.meta.instrument, "channel", None) not in nircam_channels:
                 self.print_err(
                     "Expected meta.instrument.channel for instrument "
                     f"NIRCAM to be one of {nircam_channels}"
                 )
-            if self.meta.instrument.module not in nircam_module:
+            if getattr(self.meta.instrument, "module", None) not in nircam_module:
                 self.print_err(
                     "Expected meta.instrument.module for instrument "
                     f"NIRCAM to be one of {nircam_module}"
@@ -1299,7 +1299,7 @@ class FOREModel(_SimpleModel):
                 "F170LP",
                 "F290LP",
             ]
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:
@@ -1358,7 +1358,7 @@ class WaveCorrModel(ReferenceFileModel):
         try:
             assert self.aperture_names is not None
             assert self.apertures is not None
-        except AssertionError:
+        except (AssertionError, AttributeError):
             if self._strict_validation:
                 raise
             else:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1254,9 +1254,11 @@ class DataModel(properties.ObjectNode):
         ----------
         attr : str
             Attribute to set to its default value. Can be a dotted path
-            to a sub-object, e.g. "meta.foo".
+            to a sub-object, e.g. "meta.foo" or "quadrants.0.flat_table"
+            where numeric parts refer to list indices. If a list index
+            doesn't exist, empty items will be created up to that index.
         """
-        # Handle dotted paths like "meta.foo"
+        # Handle dotted paths like "meta.foo" or "quadrants.0.flat_table"
         parts = attr.split(".")
 
         if len(parts) == 1:
@@ -1270,20 +1272,44 @@ class DataModel(properties.ObjectNode):
             parent_schema = self._schema
 
             for part in parts[:-1]:
-                # Get the parent object
+                # Try to convert part to an integer (for list indexing)
                 try:
-                    parent = getattr(parent, part)
-                except AttributeError as err:
-                    raise KeyError(repr(attr)) from err
-
-                # Get the schema for the parent
-                parent_schema = properties._get_schema_for_property(parent_schema, part)
+                    index = int(part)
+                except ValueError:
+                    # Not an integer, treat as attribute name
+                    try:
+                        parent = getattr(parent, part)
+                    except AttributeError as err:
+                        raise KeyError(repr(attr)) from err
+                    # Get the schema for the parent
+                    parent_schema = properties._get_schema_for_property(parent_schema, part)
+                else:
+                    # It's an integer, use list indexing
+                    # If the list doesn't have enough items, add empty items
+                    while len(parent) <= index:
+                        parent.append(parent.item())
+                    parent = parent[index]
+                    # Get the schema for the indexed item
+                    parent_schema = properties._get_schema_for_index(parent_schema, index)
 
             # Get schema and create default for the final attribute
             final_attr = parts[-1]
-            subschema = properties._get_schema_for_property(parent_schema, final_attr)
-            default_arr = properties._make_default(final_attr, subschema, self._ctx)
-            setattr(parent, final_attr, default_arr)
+            # Try to convert final part to an integer
+            try:
+                final_index = int(final_attr)
+            except ValueError:
+                # Not an integer, treat as attribute name
+                subschema = properties._get_schema_for_property(parent_schema, final_attr)
+                default_arr = properties._make_default(final_attr, subschema, self._ctx)
+                setattr(parent, final_attr, default_arr)
+            else:
+                # Final part is an integer index
+                # If the list doesn't have enough items, add empty items
+                while len(parent) <= final_index:
+                    parent.append(parent.item())
+                subschema = properties._get_schema_for_index(parent_schema, final_index)
+                default_arr = properties._make_default(final_index, subschema, self._ctx)
+                parent[final_index] = default_arr
 
 
 class _FileReference:

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -377,6 +377,11 @@ class ObjectNode(Node):
             if schema == {}:
                 raise AttributeError(f"No attribute '{attr}'") from err
 
+            # only make default if the attribute's schema has subschema
+            # otherwise raise AttributeError
+            if "properties" not in schema.keys() and "items" not in schema.keys():
+                raise AttributeError(f"No attribute '{attr}'") from err
+
             val = _make_default(attr, schema, self._ctx)
             if val is not None:
                 self._instance[attr] = val

--- a/tests/jwst/datamodels/test_fits.py
+++ b/tests/jwst/datamodels/test_fits.py
@@ -35,7 +35,7 @@ def test_delete(fits_file):
         dm.meta.instrument.name = "NIRCAM"
         assert dm.meta.instrument.name == "NIRCAM"
         del dm.meta.instrument.name
-        assert dm.meta.instrument.name is None
+        assert not hasattr(dm.meta.instrument, "name")
 
 
 def test_fits_without_sci():
@@ -95,7 +95,7 @@ def test_units_roundtrip(tmp_path):
     # this next line is required for stdatamodels to cast
     # spec_table to a FITS_rec (similar to having data assigned
     # to the attribute)
-    m.spec_table = m.spec_table
+    m.set_default("spec_table")
     m.spec_table.columns["WAVELENGTH"].unit = "nm"
 
     fn = tmp_path / "test1.fits"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -90,16 +90,17 @@ def test_asnmodel_table_size_zero():
 def test_imagemodel():
     shape = (10, 10)
     with ImageModel(shape) as dm:
+        dm.set_default("err")
+        dm.set_default("dq")
         assert dm.data.shape == shape
         assert dm.err.shape == shape
         assert dm.dq.shape == shape
         assert dm.data.mean() == 0.0
         assert dm.err.mean() == 0.0
         assert dm.dq.mean() == 0.0
-        assert dm.zeroframe.shape == shape
-        assert dm.area.shape == shape
-        assert dm.pathloss_point.shape == shape
-        assert dm.pathloss_uniform.shape == shape
+        for attr in ["zeroframe", "area", "pathloss_point", "pathloss_uniform"]:
+            dm.set_default(attr)
+            assert getattr(dm, attr).shape == shape
 
 
 def test_model_with_nonstandard_primary_array(test_data_path):
@@ -462,6 +463,7 @@ def test_ramp_model_zero_frame_by_dimensions():
     zdims = (nints, nrows, ncols)
 
     with datamodels.RampModel(dims) as ramp:
+        ramp.set_default("zeroframe")
         assert ramp.zeroframe.shape == zdims
 
 
@@ -768,6 +770,7 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
         m.quadrants.append(m.quadrants.item())
         m.quadrants[0].flat_table = make_data(m.quadrants[0].flat_table.dtype)
     else:
+        m.set_default("flat_table")
         m.flat_table = make_data(m.flat_table.dtype)
     m.save(fn)
     fn2 = tmp_path / "test2.fits"
@@ -804,6 +807,7 @@ def test_moving_target_table_migration(tmp_path):
         return np.array(fake_data, dtype=dtype)
 
     m = Level1bModel()
+    m.set_default("moving_target")
     m.moving_target = make_data(m.moving_target.dtype)
     m.save(fn)
     fn2 = tmp_path / "test_mt2.fits"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -767,6 +767,7 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
 
     m = model()
     if model == NirspecQuadFlatModel:
+        m.set_default("quadrants.0.flat_table")
         m.quadrants.append(m.quadrants.item())
         m.quadrants[0].flat_table = make_data(m.quadrants[0].flat_table.dtype)
     else:

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -60,6 +60,8 @@ def test_multislit():
     rng = np.random.default_rng(42)
     with MultiSlitModel() as dm:
         dm.slits.append(dm.slits.item())
+        for attr in ["wavelength", "pathloss_point", "pathloss_uniform", "barshadow"]:
+            dm.set_default(f"slits.-1.{attr}")
         slit = dm.slits[-1]
         slit.data = rng.random((5, 5))
         slit.dm = rng.random((5, 5))

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -163,6 +163,6 @@ def test_slit_from_multislit():
     model = MultiSlitModel()
     slit = SlitModel()
     # access int_times so it's created
-    slit.int_times = slit.int_times
+    slit.set_default("int_times")
     model.slits.append(slit)
     slit = SlitModel(model.slits[0].instance)

--- a/tests/jwst/datamodels/test_open.py
+++ b/tests/jwst/datamodels/test_open.py
@@ -341,6 +341,7 @@ def test_open_kwargs_fits(tmp_path):
 def test_open_does_not_clear_wht(InitClass):
     """Cover a bug where the open function cleared the wht attribute in SlitModel."""
     m0 = InitClass((27, 1299))
+    m0.set_default("wht")
     m0.wht[:] = 1
 
     m1 = datamodels.open(m0)

--- a/tests/jwst/datamodels/test_schema_against_crds.py
+++ b/tests/jwst/datamodels/test_schema_against_crds.py
@@ -251,7 +251,7 @@ def test_crds_selectors_vs_datamodel(jail_environ, instrument):
                                     ref_exptype = model.meta.exposure.type
                                 except AttributeError:
                                     ref_exptype = None
-                                ref_instrument = model.meta.instrument.name
+                                ref_instrument = getattr(model.meta.instrument, "name", None)
                         if ref_exptype in model_map.keys():
                             ref_model = model_map[ref_exptype]
                         elif ref_instrument in model_map.keys():

--- a/tests/jwst/datamodels/test_specwcs_mirilrs_datamodel.py
+++ b/tests/jwst/datamodels/test_specwcs_mirilrs_datamodel.py
@@ -53,13 +53,15 @@ def test_miri_lrs_specwcs():
     assert model.meta.y_ref == 400
 
     # for slitless case assert the v2/v3 vertices are None if not in the file
-    assert model.meta.v2_vert1 is None
-    assert model.meta.v2_vert2 is None
-    assert model.meta.v2_vert3 is None
-    assert model.meta.v2_vert4 is None
-
-    assert model.meta.v3_vert1 is None
-    assert model.meta.v3_vert2 is None
-    assert model.meta.v3_vert3 is None
-    assert model.meta.v3_vert4 is None
+    for attr in [
+        "v2_vert1",
+        "v2_vert2",
+        "v2_vert3",
+        "v2_vert4",
+        "v3_vert1",
+        "v3_vert2",
+        "v3_vert3",
+        "v3_vert4",
+    ]:
+        assert getattr(model.meta, attr, None) is None
     model.validate()

--- a/tests/jwst/datamodels/test_validation.py
+++ b/tests/jwst/datamodels/test_validation.py
@@ -9,7 +9,7 @@ from stdatamodels.jwst.datamodels import JwstDataModel
 
 def test_strict_validation_enum():
     with JwstDataModel(strict_validation=True) as dm:
-        assert dm.meta.instrument.name is None
+        assert not hasattr(dm.meta.instrument, "name")
         with pytest.raises(ValidationError):
             # FOO is not in the allowed enumerated values
             dm.meta.instrument.name = "FOO"

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -43,8 +43,8 @@ def test_from_new_hdulist2():
     science = fits.ImageHDU(data=data, name="SCI")
     hdulist.append(science)
     with FitsModel(hdulist) as dm:
-        dq = dm.set_default("dq")
-        assert dq is not None
+        dm.set_default("dq")
+        assert dm.dq is not None
 
 
 def test_setting_arrays_on_fits():
@@ -347,7 +347,7 @@ def test_table_with_unsigned_int(tmp_path):
         "$schema": "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0",
         "type": "object",
         "properties": {
-            "meta": {"type": "object", "properties": {}},
+            "meta": {"type": "object", "properties": {"filename": {"type": "string"}}},
             "test_table": {
                 "title": "Test table",
                 "fits_hdu": "TESTTABL",
@@ -372,7 +372,8 @@ def test_table_with_unsigned_int(tmp_path):
         uint32_arr[-1] = uint32_info.max
 
         test_table = np.array(
-            list(zip(float64_arr, uint32_arr, strict=False)), dtype=dm.test_table.dtype
+            list(zip(float64_arr, uint32_arr, strict=False)),
+            dtype=[("FLOAT64_COL", np.float64), ("UINT32_COL", np.uint32)],
         )
 
         def assert_table_correct(model):
@@ -648,7 +649,7 @@ def test_table_linking(tmp_path):
         "$schema": "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0",
         "type": "object",
         "properties": {
-            "meta": {"type": "object", "properties": {}},
+            "meta": {"type": "object", "properties": {"filename": {"type": "string"}}},
             "test_table": {
                 "title": "Test table",
                 "fits_hdu": "TESTTABL",

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -43,7 +43,7 @@ def test_from_new_hdulist2():
     science = fits.ImageHDU(data=data, name="SCI")
     hdulist.append(science)
     with FitsModel(hdulist) as dm:
-        dq = dm.dq
+        dq = dm.set_default("dq")
         assert dq is not None
 
 
@@ -76,6 +76,7 @@ def test_from_scratch(tmp_path):
         with FitsModel(file_path) as dm2:
             assert dm2.shape == (50, 50)
             assert dm2.meta.telescope == "EYEGLASSES"
+            dm2.set_default("dq")
             assert dm2.dq.dtype.name == "uint32"
             assert np.all(dm2.data == data)
 
@@ -455,7 +456,7 @@ def test_from_hdulist(tmp_path):
 
     with fits.open(file_path, memmap=False) as hdulist:
         with FitsModel(hdulist) as dm:
-            dm.data  # noqa: B018
+            dm.set_default("data")
         assert not hdulist.fileinfo(0)["file"].closed
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ def test_delete():
         dm.meta.telescope = "JWST"
         assert dm.meta.telescope == "JWST"
         del dm.meta.telescope
-        assert dm.meta.telescope is None
+        assert not hasattr(dm.meta, "telescope")
 
 
 def test_copy():
@@ -69,7 +69,7 @@ def test_copy():
             dm2.meta.foo = "BAZ"
             assert dm.meta.foo == "BAR"
             dm2.meta.origin = "STScI"
-            assert dm.meta.origin is None
+            assert not hasattr(dm.meta, "origin")
 
 
 def test_stringify(tmp_path):
@@ -146,6 +146,7 @@ def test_base_model_has_no_arrays():
 
 def test_array_type():
     with BasicModel() as dm:
+        dm.set_default("dq")
         assert dm.dq.dtype == np.uint32
 
 
@@ -163,6 +164,7 @@ def test_dtype_match():
 def test_default_value_anyof_schema():
     """Make sure default values are set properly when anyOf in schema"""
     with AnyOfModel() as dm:
+        dm.set_default("meta.foo")
         assert dm.meta.foo is None
 
 
@@ -194,6 +196,7 @@ def test_secondary_shapes():
     specified in the initializer.
     """
     with BasicModel((256, 256)) as dm:
+        dm.set_default("area")
         assert dm.area.shape == (256, 256)
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -142,13 +142,14 @@ def test_table_array_shape_ndim(filename, tmp_path):
 
 def test_implicit_creation_lower_dimensionality():
     with BasicModel(np.zeros((10, 20))) as m:
+        m.set_default("dq")
         assert m.dq.shape == (20,)
 
 
 def test_add_schema_entry():
     with DataModel(strict_validation=True) as dm:
         dm.add_schema_entry("meta.foo.bar", {"enum": ["foo", "bar", "baz"]})
-        dm.meta.foo.bar  # noqa: B018
+        dm.set_default("meta.foo.bar")
         dm.meta.foo.bar = "bar"
         try:
             dm.meta.foo.bar = "what?"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,7 +34,7 @@ does_not_raise = _DoesNotRaiseContext()
 def test_scalar_attribute_assignment():
     model = ValidationModel()
 
-    assert model.meta.string_attribute is None
+    assert not hasattr(model.meta, "string_attribute")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         model.meta.string_attribute = "foo"
@@ -53,7 +53,7 @@ def test_scalar_attribute_assignment():
 def test_object_attribute_assignment():
     model = ValidationModel()
 
-    assert model.meta.object_attribute.string_attribute is None
+    assert not hasattr(model.meta.object_attribute, "string_attribute")
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         model.meta.object_attribute = {"string_attribute": "foo"}
@@ -70,7 +70,7 @@ def test_object_attribute_assignment():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         model.meta.object_attribute = None
-    assert model.meta.object_attribute.string_attribute is None
+    assert not hasattr(model.meta.object_attribute, "string_attribute")
 
 
 def test_list_attribute_ssignment():
@@ -130,7 +130,7 @@ def test_pass_invalid_values_attribute_assignment(monkeypatch, init_value, env_v
     if passed:
         assert model.meta.string_attribute == 42
     else:
-        assert model.meta.string_attribute is None
+        assert not hasattr(model.meta, "string_attribute")
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_strict_validation_attribute_assignment(
 
     with expected_context_manager:
         model.meta.string_attribute = 42
-    assert model.meta.string_attribute is None
+    assert not hasattr(model.meta, "string_attribute")
 
 
 def test_validate():
@@ -233,7 +233,7 @@ def test_validate_on_assignment(
 
     with expected_context_manager:
         model.meta.string_attribute = 42  # Bad assignment
-    assert model.meta.string_attribute is string_attribute_value
+    assert getattr(model.meta, "string_attribute", None) is string_attribute_value
 
 
 @pytest.mark.parametrize(
@@ -266,7 +266,7 @@ def test_validate_on_assignment_setitem(init_value, warning_class, string_attrib
         with pytest.warns(warning_class):
             model.meta.list_attribute[0] = {"string_attribute": value3}
 
-    assert model.meta.list_attribute[0].string_attribute == string_attribute_value
+    assert getattr(model.meta.list_attribute[0], "string_attribute", None) == string_attribute_value
 
 
 @pytest.mark.parametrize(
@@ -291,7 +291,7 @@ def test_validate_on_assignment_insert(
     else:
         with pytest.warns(warning_class):
             model.meta.list_attribute.insert(0, {"string_attribute": 42})
-    assert model.meta.list_attribute[0].string_attribute == string_attribute_value
+    assert getattr(model.meta.list_attribute[0], "string_attribute", None) == string_attribute_value
 
 
 # --------------------------------------------------------------------
@@ -319,7 +319,7 @@ def test_validate_on_assignment_strict_validation(
 
     with expected_context_manager:
         model.meta.string_attribute = 42
-    assert model.meta.string_attribute is value
+    assert getattr(model.meta, "string_attribute", None) is value
 
 
 @pytest.mark.parametrize(
@@ -342,7 +342,7 @@ def test_validate_on_assignment_pass_invalid_values(
     # even with validate_on_assignment=True
     with expected_context_manager:
         model.meta.string_attribute = 42  # Bad assignment
-    assert model.meta.string_attribute == value
+    assert getattr(model.meta, "string_attribute", None) == value
 
 
 def test_ndarray_validation(tmp_path):
@@ -386,7 +386,7 @@ def test_validation_memory_leak():
     a reference to the assigned array.
     """
     # basic model validates `data` to be a float32 with 2 dimensions
-    model = BasicModel()
+    model = BasicModel((10, 10))
 
     # get the default array
     original_array = model.data


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR modifies the way default attribute creation happens...

Still to decide:
- Are there specific model types where we want attributes set to their defaults?
- Are there specific attributes we want to ensure are always set?
- What should getattr/hasattr do in the case that the schema has specifically defined a default? there are only 4 explicitly-defined defaults in the core schema.  What about when it's not specifically defined, and on current main it will return None?
- Should the primary array be set to default if not provided?
- 


Failing unit test `tests/test_models.py::test_multivalued_default_table_schema` is due to exposing a bug already present on main, see https://github.com/spacetelescope/stdatamodels/issues/656

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
