### PR TITLE
Fix failure to handle ndim and max_ndim inside table datatypes

### DIFF
--- a/changes/659.bugfix.rst
+++ b/changes/659.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where ndim and max_ndim within table-like datatypes were ignored during default array creation

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -188,6 +188,13 @@ def _get_schema_type(schema):
 def _make_default_array(attr, schema, ctx):
     dtype = schema.get("datatype")
     if dtype is not None:
+        # asdf_datatype_to_numpy_dtype does not handle "ndim" or "max_ndim",
+        # so we need to convert to shape
+        if isinstance(dtype, list):
+            for dt in dtype:
+                ndim = dt.get("ndim", dt.get("max_ndim"))
+                if ndim is not None and "shape" not in dt:
+                    dt["shape"] = tuple([0] * ndim)
         dtype = ndarray.asdf_datatype_to_numpy_dtype(dtype)
     ndim = schema.get("ndim", schema.get("max_ndim"))
     default = schema.get("default", None)

--- a/tests/schemas/table_model.yaml
+++ b/tests/schemas/table_model.yaml
@@ -8,7 +8,7 @@ allOf:
     properties:
       table:
         fits_hdu: TABLE
-        default: [0, 42, NaN, "foo", 42.0, 0.0]
+        default: [0, 42, NaN, "foo", 42.0, 0.0, 0.0, 0.0]
         datatype:
           - name: int16_column
             datatype: int16
@@ -24,4 +24,11 @@ allOf:
           - name: float32_column_with_ndim
             datatype: float32
             ndim: 2
+          - name: float32_column_with_ndim_and_shape
+            datatype: float32
+            ndim: 2
+            shape: [3, 2]
+          - name: float32_column_with_max_ndim
+            datatype: float32
+            max_ndim: 2
 ...

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -181,6 +181,16 @@ def test_multivalued_default_table_schema():
                 continue
             assert np.allclose(dm.table[name], default, equal_nan=True)
 
+        # test shapes
+        shape_col = dm.table["float32_column_with_shape"]
+        assert shape_col.shape == (10, 3, 2)
+        ndim_col = dm.table["float32_column_with_ndim"]
+        assert ndim_col.shape == (10, 0, 0)
+        ndim_shape_col = dm.table["float32_column_with_ndim_and_shape"]
+        assert ndim_shape_col.shape == (10, 3, 2)
+        max_ndim_col = dm.table["float32_column_with_max_ndim"]
+        assert max_ndim_col.shape == (10, 0, 0)
+
 
 def test_multivalued_default_table_schema_bad():
     """Test error raise if the default does not match the array type"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -98,6 +98,8 @@ def test_table_array_shape_ndim(filename, tmp_path):
                 "STRING",
                 [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
                 [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
+                [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
+                [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
             )
         ]
         assert x.table.dtype == [
@@ -107,6 +109,8 @@ def test_table_array_shape_ndim(filename, tmp_path):
             ("ascii_column", "S64"),
             ("float32_column_with_shape", "=f4", (3, 2)),
             ("float32_column_with_ndim", "=f4", (3, 2)),
+            ("float32_column_with_ndim_and_shape", "=f4", (3, 2)),
+            ("float32_column_with_max_ndim", "=f4", (3, 2)),
         ]
 
         x.save(file_path)
@@ -121,6 +125,8 @@ def test_table_array_shape_ndim(filename, tmp_path):
                 ("ascii_column", "S64"),
                 ("float32_column_with_shape", "=f4", (3, 2)),
                 ("float32_column_with_ndim", "=f4", (3, 2)),
+                ("float32_column_with_ndim_and_shape", "=f4", (3, 2)),
+                ("float32_column_with_max_ndim", "=f4", (3, 2)),
             ],
             "equiv",
         )
@@ -135,6 +141,8 @@ def test_table_array_shape_ndim(filename, tmp_path):
                     "STRING",
                     # This element should fail because it's shape is (2, 2) and not (3, 2):
                     [[37.5, 38.0], [39.0, 40.0]],
+                    [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
+                    [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
                     [[37.5, 38.0], [39.0, 40.0], [41.0, 42.0]],
                 )
             ]


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #656 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where schema-defined `ndim` is ignored within list-like datatypes, i.e., specifications of table columns.

jwst regression tests https://github.com/spacetelescope/RegressionTests/actions/runs/21526734155 
all passing

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
