### PR TITLE
Allow none arrays

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
         - linux: py314-cov-xdist
           coverage: codecov
         - macos: py314-xdist
+          posargs: -vv
         - windows: py314-xdist-nocrds
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c  # v2.4.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,6 @@ jobs:
         - linux: py314-cov-xdist
           coverage: codecov
         - macos: py314-xdist
-          posargs: -vv
         - windows: py314-xdist-nocrds
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c  # v2.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,8 @@ nitpick_ignore = [
     ("py:class", "jwst.datamodels.photom._PhotomModel"),
     ("py:class", "stdatamodels.properties.ObjectNode"),
     ("py:class", "stdatamodels.properties.Node"),
+    ("py:class", "stdatamodels.jwst.datamodels.model_base._DQMixin"),
+    ("py:class", "stdatamodels.jwst.datamodels.model_base._DefaultErrMixin"),
 ]
 for transform_base in [
     "_NIRCAMForwardGrismDispersion",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ nitpick_ignore = [
     ("py:class", "jwst.datamodels.photom._PhotomModel"),
     ("py:class", "stdatamodels.properties.ObjectNode"),
     ("py:class", "stdatamodels.properties.Node"),
-    ("py:class", "stdatamodels.jwst.datamodels.model_base._DQMixin"),
+    ("py:class", "stdatamodels.jwst.datamodels.model_base._DefaultDQMixin"),
     ("py:class", "stdatamodels.jwst.datamodels.model_base._DefaultErrMixin"),
 ]
 for transform_base in [

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -27,7 +27,7 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
         A Numpy array
     """
     if not hasattr(input_model, "dq"):
-        input_model.get_default("dq")
+        input_model.dq = input_model.get_default("dq")
     dq_table = getattr(input_model, "dq_def", None)
     # Get the DQ array and the flag definitions
     if (

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -26,7 +26,9 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     dqmask : ndarray
         A Numpy array
     """
-    dq_table = input_model.dq_def
+    if not hasattr(input_model, "dq"):
+        input_model.get_default("dq")
+    dq_table = getattr(input_model, "dq_def", None)
     # Get the DQ array and the flag definitions
     if (
         (dq_table is not None)

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -26,7 +26,7 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     dqmask : ndarray
         A Numpy array
     """
-    dq_table = getattr(input_model, "dq_def", None)
+    dq_table = input_model.dq_def
     # Get the DQ array and the flag definitions
     if (
         (dq_table is not None)

--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -26,8 +26,6 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     dqmask : ndarray
         A Numpy array
     """
-    if not hasattr(input_model, "dq"):
-        input_model.dq = input_model.get_default("dq")
     dq_table = getattr(input_model, "dq_def", None)
     # Get the DQ array and the flag definitions
     if (

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -32,7 +32,7 @@ class AsnModel(JwstDataModel):
         self.input_rootnames = []
         self.num_inputs = 0
 
-        if getattr(self, "asn_table", None) is None:
+        if self.asn_table is None:
             return
         if not len(self.asn_table):
             return

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -34,6 +34,8 @@ class AsnModel(JwstDataModel):
 
         if getattr(self, "asn_table", None) is None:
             return
+        if not len(self.asn_table):
+            return
 
         for i, etype in enumerate(self.asn_table.exptype):
             if "prod" in etype.lower():

--- a/src/stdatamodels/jwst/datamodels/asn.py
+++ b/src/stdatamodels/jwst/datamodels/asn.py
@@ -32,7 +32,7 @@ class AsnModel(JwstDataModel):
         self.input_rootnames = []
         self.num_inputs = 0
 
-        if not len(self.asn_table):
+        if getattr(self, "asn_table", None) is None:
             return
 
         for i, etype in enumerate(self.asn_table.exptype):
@@ -52,3 +52,6 @@ class AsnModel(JwstDataModel):
                         break
                 self.input_rootnames.append(rootname)
                 self.num_inputs += 1
+
+    def get_primary_array_name(self):  # noqa: D102
+        return "asn_table"

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["WfssBkgModel"]
 
 
-class SossBkgModel(ReferenceFileModel, DQMixin):
+class SossBkgModel(ReferenceFileModel, _DQMixin):
     """
     A data model of 2D background reference templates for NIRISS SOSS data.
 
@@ -22,7 +22,7 @@ class SossBkgModel(ReferenceFileModel, DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
 
 
-class WfssBkgModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class WfssBkgModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D WFSS master background reference files.
 

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
@@ -22,7 +22,7 @@ class SossBkgModel(ReferenceFileModel, DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
 
 
-class WfssBkgModel(ReferenceFileModel, DQMixin):
+class WfssBkgModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D WFSS master background reference files.
 

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -48,7 +48,3 @@ class WfssBkgModel(ReferenceFileModel):
         super(WfssBkgModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["WfssBkgModel"]
 
 
-class SossBkgModel(ReferenceFileModel):
+class SossBkgModel(ReferenceFileModel, DQMixin):
     """
     A data model of 2D background reference templates for NIRISS SOSS data.
 
@@ -22,11 +21,8 @@ class SossBkgModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(SossBkgModel, self).__init__(init=init, **kwargs)
 
-
-class WfssBkgModel(ReferenceFileModel):
+class WfssBkgModel(ReferenceFileModel, DQMixin):
     """
     A data model for 2D WFSS master background reference files.
 
@@ -43,8 +39,3 @@ class WfssBkgModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/wfssbkg.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(WfssBkgModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["WfssBkgModel"]

--- a/src/stdatamodels/jwst/datamodels/background.py
+++ b/src/stdatamodels/jwst/datamodels/background.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["WfssBkgModel"]
 
 
-class SossBkgModel(ReferenceFileModel, _DQMixin):
+class SossBkgModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model of 2D background reference templates for NIRISS SOSS data.
 
@@ -21,7 +21,7 @@ class SossBkgModel(ReferenceFileModel, _DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/sossbkg.schema"
 
 
-class WfssBkgModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class WfssBkgModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D WFSS master background reference files.
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,9 +1,11 @@
+from stdatamodels.jwst.datamodels.model_base import DQMixin
+
 from .model_base import JwstDataModel
 
 __all__ = ["CubeModel"]
 
 
-class CubeModel(JwstDataModel):
+class CubeModel(JwstDataModel, DQMixin):
     """
     A data model for 3D image cubes.
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["CubeModel"]
 
 
-class CubeModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class CubeModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 3D image cubes.
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -30,10 +30,3 @@ class CubeModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/cube.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(CubeModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["CubeModel"]
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["CubeModel"]
 
 
-class CubeModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class CubeModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 3D image cubes.
 

--- a/src/stdatamodels/jwst/datamodels/cube.py
+++ b/src/stdatamodels/jwst/datamodels/cube.py
@@ -1,11 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
-
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 __all__ = ["CubeModel"]
 
 
-class CubeModel(JwstDataModel, DQMixin):
+class CubeModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for 3D image cubes.
 

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["DarkMIRIModel", "DarkModel", "DarkNirspecModel"]
 
 
-class DarkModel(ReferenceFileModel):
+class DarkModel(ReferenceFileModel, DQMixin):
     """
     A data model for dark reference files.
 
@@ -22,13 +21,8 @@ class DarkModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/dark.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(DarkModel, self).__init__(init=init, **kwargs)
 
-        self.dq = dynamic_mask(self, pixel)
-
-
-class DarkMIRIModel(ReferenceFileModel):
+class DarkMIRIModel(ReferenceFileModel, DQMixin):
     """
     A data model for dark MIRI reference files.
 
@@ -44,13 +38,8 @@ class DarkMIRIModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/darkMIRI.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(DarkMIRIModel, self).__init__(init=init, **kwargs)
 
-        self.dq = dynamic_mask(self, pixel)
-
-
-class DarkNirspecModel(ReferenceFileModel):
+class DarkNirspecModel(ReferenceFileModel, DQMixin):
     """
     A data model for NIRSpec dark reference files.
 
@@ -71,8 +60,3 @@ class DarkNirspecModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/dark_nirspec.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(DarkNirspecModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["DarkMIRIModel", "DarkModel", "DarkNirspecModel"]
 
 
-class DarkModel(ReferenceFileModel, DQMixin):
+class DarkModel(ReferenceFileModel, _DQMixin):
     """
     A data model for dark reference files.
 
@@ -22,7 +22,7 @@ class DarkModel(ReferenceFileModel, DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/dark.schema"
 
 
-class DarkMIRIModel(ReferenceFileModel, DQMixin):
+class DarkMIRIModel(ReferenceFileModel, _DQMixin):
     """
     A data model for dark MIRI reference files.
 
@@ -39,7 +39,7 @@ class DarkMIRIModel(ReferenceFileModel, DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/darkMIRI.schema"
 
 
-class DarkNirspecModel(ReferenceFileModel, DQMixin):
+class DarkNirspecModel(ReferenceFileModel, _DQMixin):
     """
     A data model for NIRSpec dark reference files.
 

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["DarkMIRIModel", "DarkModel", "DarkNirspecModel"]
 
 
-class DarkModel(ReferenceFileModel, _DQMixin):
+class DarkModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for dark reference files.
 
@@ -21,7 +21,7 @@ class DarkModel(ReferenceFileModel, _DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/dark.schema"
 
 
-class DarkMIRIModel(ReferenceFileModel, _DQMixin):
+class DarkMIRIModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for dark MIRI reference files.
 
@@ -38,7 +38,7 @@ class DarkMIRIModel(ReferenceFileModel, _DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/darkMIRI.schema"
 
 
-class DarkNirspecModel(ReferenceFileModel, _DQMixin):
+class DarkNirspecModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for NIRSpec dark reference files.
 

--- a/src/stdatamodels/jwst/datamodels/dark.py
+++ b/src/stdatamodels/jwst/datamodels/dark.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["DarkMIRIModel", "DarkModel", "DarkNirspecModel"]

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -28,6 +28,3 @@ class FlatModel(ReferenceFileModel):
         super(FlatModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["FlatModel"]
 
 
-class FlatModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class FlatModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D flat-field images.
 

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["FlatModel"]
 
 
-class FlatModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class FlatModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D flat-field images.
 

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["FlatModel"]
 
 
-class FlatModel(ReferenceFileModel, DQMixin):
+class FlatModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D flat-field images.
 

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["FlatModel"]
 
 
-class FlatModel(ReferenceFileModel):
+class FlatModel(ReferenceFileModel, DQMixin):
     """
     A data model for 2D flat-field images.
 
@@ -23,8 +22,3 @@ class FlatModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/flat.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(FlatModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/flat.py
+++ b/src/stdatamodels/jwst/datamodels/flat.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["FlatModel"]

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -28,7 +28,3 @@ class FringeModel(ReferenceFileModel):
         super(FringeModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["FringeModel"]
 
 
-class FringeModel(ReferenceFileModel):
+class FringeModel(ReferenceFileModel, DQMixin):
     """
     A data model for 2D fringe correction images.
 
@@ -23,8 +22,3 @@ class FringeModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/fringe.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(FringeModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["FringeModel"]
 
 
-class FringeModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class FringeModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D fringe correction images.
 

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["FringeModel"]

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["FringeModel"]
 
 
-class FringeModel(ReferenceFileModel, DQMixin):
+class FringeModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D fringe correction images.
 

--- a/src/stdatamodels/jwst/datamodels/fringe.py
+++ b/src/stdatamodels/jwst/datamodels/fringe.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["FringeModel"]
 
 
-class FringeModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class FringeModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D fringe correction images.
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["GuiderCalModel", "GuiderRawModel"]
 
 
-class GuiderRawModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class GuiderRawModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for Guide Star pipeline raw data files.
 
@@ -30,7 +30,7 @@ class GuiderRawModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
 
-class GuiderCalModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class GuiderCalModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for Guide Star pipeline calibrated files.
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["GuiderCalModel", "GuiderRawModel"]
 
 
-class GuiderRawModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class GuiderRawModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for Guide Star pipeline raw data files.
 
@@ -30,7 +30,7 @@ class GuiderRawModel(JwstDataModel, DQMixin, DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
 
-class GuiderCalModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class GuiderCalModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for Guide Star pipeline calibrated files.
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -29,13 +29,6 @@ class GuiderRawModel(JwstDataModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(GuiderRawModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
-
 
 class GuiderCalModel(JwstDataModel):
     """
@@ -62,10 +55,3 @@ class GuiderCalModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_cal.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(GuiderCalModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["GuiderCalModel", "GuiderRawModel"]
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
 
 __all__ = ["GuiderCalModel", "GuiderRawModel"]
 
 
-class GuiderRawModel(JwstDataModel):
+class GuiderRawModel(JwstDataModel, DQMixin):
     """
     A data model for Guide Star pipeline raw data files.
 
@@ -30,7 +30,7 @@ class GuiderRawModel(JwstDataModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
 
-class GuiderCalModel(JwstDataModel):
+class GuiderCalModel(JwstDataModel, DQMixin):
     """
     A data model for Guide Star pipeline calibrated files.
 

--- a/src/stdatamodels/jwst/datamodels/guider.py
+++ b/src/stdatamodels/jwst/datamodels/guider.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 __all__ = ["GuiderCalModel", "GuiderRawModel"]
 
 
-class GuiderRawModel(JwstDataModel, DQMixin):
+class GuiderRawModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for Guide Star pipeline raw data files.
 
@@ -30,7 +30,7 @@ class GuiderRawModel(JwstDataModel, DQMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/guider_raw.schema"
 
 
-class GuiderCalModel(JwstDataModel, DQMixin):
+class GuiderCalModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for Guide Star pipeline calibrated files.
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 __all__ = ["IFUCubeModel"]
 
 
-class IFUCubeModel(JwstDataModel, DQMixin):
+class IFUCubeModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for 3D IFU  cubes.
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["IFUCubeModel"]
 
 
-class IFUCubeModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class IFUCubeModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 3D IFU  cubes.
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
 
 __all__ = ["IFUCubeModel"]
 
 
-class IFUCubeModel(JwstDataModel):
+class IFUCubeModel(JwstDataModel, DQMixin):
     """
     A data model for 3D IFU  cubes.
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -22,10 +22,3 @@ class IFUCubeModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifucube.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(IFUCubeModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["IFUCubeModel"]
 
 
-class IFUCubeModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class IFUCubeModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 3D IFU  cubes.
 

--- a/src/stdatamodels/jwst/datamodels/ifucube.py
+++ b/src/stdatamodels/jwst/datamodels/ifucube.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["IFUCubeModel"]
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["IFUImageModel"]
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["IFUImageModel"]
 
 
-class IFUImageModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class IFUImageModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D IFU images.
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 __all__ = ["IFUImageModel"]
 
 
-class IFUImageModel(JwstDataModel, DQMixin):
+class IFUImageModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D IFU images.
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["IFUImageModel"]
 
 
-class IFUImageModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class IFUImageModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D IFU images.
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
 
 __all__ = ["IFUImageModel"]
 
 
-class IFUImageModel(JwstDataModel):
+class IFUImageModel(JwstDataModel, DQMixin):
     """
     A data model for 2D IFU images.
 

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -36,10 +36,3 @@ class IFUImageModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuimage.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(IFUImageModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,6 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
-from .model_base import JwstDataModel
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["ImageModel"]
 

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["ImageModel"]
 
 
-class ImageModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class ImageModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,9 +1,11 @@
+from stdatamodels.jwst.datamodels.model_base import DQMixin
+
 from .model_base import JwstDataModel
 
 __all__ = ["ImageModel"]
 
 
-class ImageModel(JwstDataModel):
+class ImageModel(JwstDataModel, DQMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .model_base import JwstDataModel
 
 __all__ = ["ImageModel"]
 
 
-class ImageModel(JwstDataModel, DQMixin):
+class ImageModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/image.py
+++ b/src/stdatamodels/jwst/datamodels/image.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .model_base import JwstDataModel
 
 __all__ = ["ImageModel"]
 
 
-class ImageModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class ImageModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["LastFrameModel"]
 
 
-class LastFrameModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class LastFrameModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for Last frame correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["LastFrameModel"]
 
 
-class LastFrameModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class LastFrameModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for Last frame correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["LastFrameModel"]
 
 
-class LastFrameModel(ReferenceFileModel):
+class LastFrameModel(ReferenceFileModel, DQMixin):
     """
     A data model for Last frame correction reference files.
 
@@ -23,8 +22,3 @@ class LastFrameModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/lastframe.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(LastFrameModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["LastFrameModel"]
 
 
-class LastFrameModel(ReferenceFileModel, DQMixin):
+class LastFrameModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for Last frame correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -28,7 +28,3 @@ class LastFrameModel(ReferenceFileModel):
         super(LastFrameModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/lastframe.py
+++ b/src/stdatamodels/jwst/datamodels/lastframe.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["LastFrameModel"]

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["LinearityModel"]
 
 
-class LinearityModel(ReferenceFileModel, DQMixin):
+class LinearityModel(ReferenceFileModel, _DQMixin):
     """
     A data model for linearity correction information.
 

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -27,8 +27,5 @@ class LinearityModel(ReferenceFileModel):
 
         self.dq = dynamic_mask(self, pixel)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-
     def get_primary_array_name(self):  # noqa: D102
         return "coeffs"

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["LinearityModel"]
 
 
-class LinearityModel(ReferenceFileModel):
+class LinearityModel(ReferenceFileModel, DQMixin):
     """
     A data model for linearity correction information.
 
@@ -21,11 +20,6 @@ class LinearityModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/linearity.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(LinearityModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)
 
     def get_primary_array_name(self):  # noqa: D102
         return "coeffs"

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["LinearityModel"]

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["LinearityModel"]
 
 
-class LinearityModel(ReferenceFileModel, _DQMixin):
+class LinearityModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for linearity correction information.
 

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -23,11 +23,8 @@ class MaskModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(MaskModel, self).__init__(init=init, **kwargs)
 
-        if self.dq is not None or self.dq_def is not None:
+        if getattr(self, "dq", None) is not None or getattr(self, "dq_def", None) is not None:
             self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
 
     def get_primary_array_name(self):  # noqa: D102
         return "dq"

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["MaskModel"]

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["MaskModel"]
 
 
-class MaskModel(ReferenceFileModel):
+class MaskModel(ReferenceFileModel, DQMixin):
     """
     A data model for 2D masks.
 
@@ -19,12 +18,6 @@ class MaskModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mask.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(MaskModel, self).__init__(init=init, **kwargs)
-
-        if getattr(self, "dq", None) is not None or getattr(self, "dq_def", None) is not None:
-            self.dq = dynamic_mask(self, pixel)
 
     def get_primary_array_name(self):  # noqa: D102
         return "dq"

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["MaskModel"]
 
 
-class MaskModel(ReferenceFileModel, DQMixin):
+class MaskModel(ReferenceFileModel, _DQMixin):
     """
     A data model for 2D masks.
 

--- a/src/stdatamodels/jwst/datamodels/mask.py
+++ b/src/stdatamodels/jwst/datamodels/mask.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["MaskModel"]
 
 
-class MaskModel(ReferenceFileModel, _DQMixin):
+class MaskModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for 2D masks.
 

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -138,5 +138,5 @@ class DQMixin(_DataModel):
         # do the same handling for err array
         # this is only here to minimize number of downstream failures and
         # should be removed in the future once we can fix downstream patterns
-        if not hasattr(self, "err") and self.hasattr("err"):
+        if not hasattr(self, "err") and "err" in self.schema["properties"]:
             self.err = self.get_default("err")

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -122,15 +122,15 @@ class _DQMixin(_DataModel):
         super().__init__(*args, **kwargs)
 
         # If data array hasn't been initialized, do not initialize DQ
-        if not hasattr(self, self.get_primary_array_name()):
+        if getattr(self, self.get_primary_array_name(), None) is None:
             return
 
         # Otherwise, ensure DQ array exists
-        if not hasattr(self, "dq"):
+        if getattr(self, "dq", None) is None:
             self.dq = self.get_default("dq")
 
         # if dq_def is in the schema, attempt to apply dq flag mapping
-        if self.hasattr("dq_def"):
+        if getattr(self, "dq_def", None) is not None:
             self.dq = dynamic_mask(self, pixel)
 
     def __setattr__(self, attr, value):
@@ -140,7 +140,7 @@ class _DQMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
-            if not hasattr(self, "dq"):
+            if getattr(self, "dq", None) is None:
                 self.dq = self.get_default("dq")
 
 
@@ -151,13 +151,13 @@ class _DefaultErrMixin(_DataModel):
         super().__init__(*args, **kwargs)
 
         # If data array hasn't been initialized, do not initialize err
-        if not hasattr(self, self.get_primary_array_name()):
+        if getattr(self, self.get_primary_array_name(), None) is None:
             return
 
         # do the same handling for err array
         # this is only here to minimize number of downstream failures and
         # should be removed in the future once we can fix downstream patterns
-        if not hasattr(self, "err"):
+        if getattr(self, "err", None) is None:
             self.err = self.get_default("err")
 
     def __setattr__(self, attr, value):
@@ -167,5 +167,5 @@ class _DefaultErrMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
-            if not hasattr(self, "err"):
+            if getattr(self, "err", None) is None:
                 self.err = self.get_default("err")

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -134,3 +134,9 @@ class DQMixin(_DataModel):
         # if dq_def is in the schema, attempt to apply dq flag mapping
         if self.hasattr("dq_def"):
             self.dq = dynamic_mask(self, pixel)
+
+        # do the same handling for err array
+        # this is only here to minimize number of downstream failures and
+        # should be removed in the future once we can fix downstream patterns
+        if not hasattr(self, "err") and self.hasattr("err"):
+            self.err = self.get_default("err")

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -115,7 +115,7 @@ class JwstDataModel(_DataModel):
         super().update(d, only=only, extra_fits=extra_fits)
 
 
-class _DQMixin(_DataModel):
+class _DefaultDQMixin(_DataModel):
     """Mixin for models that should have dq array initialized on init."""
 
     def __init__(self, *args, **kwargs):

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -7,8 +7,6 @@ from stdatamodels.dynamicdq import dynamic_mask
 
 from .dqflags import pixel
 
-__all__ = ["DQMixin", "JwstDataModel"]
-
 
 class JwstDataModel(_DataModel):
     """Base class for JWST data models."""
@@ -117,7 +115,7 @@ class JwstDataModel(_DataModel):
         super().update(d, only=only, extra_fits=extra_fits)
 
 
-class DQMixin(_DataModel):
+class _DQMixin(_DataModel):
     """Mixin for models that should have dq array initialized on init."""
 
     def __init__(self, *args, **kwargs):
@@ -146,7 +144,7 @@ class DQMixin(_DataModel):
                 self.dq = self.get_default("dq")
 
 
-class DefaultErrMixin(_DataModel):
+class _DefaultErrMixin(_DataModel):
     """Mixin for models that should have err array initialized on init."""
 
     def __init__(self, *args, **kwargs):

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -135,6 +135,13 @@ class DQMixin(_DataModel):
         if self.hasattr("dq_def"):
             self.dq = dynamic_mask(self, pixel)
 
+
+class DefaultErrMixin(_DataModel):
+    """Mixin for models that should have err array initialized on init."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         # do the same handling for err array
         # this is only here to minimize number of downstream failures and
         # should be removed in the future once we can fix downstream patterns

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -7,6 +7,8 @@ from stdatamodels.dynamicdq import dynamic_mask
 
 from .dqflags import pixel
 
+__all__ = ["JwstDataModel"]
+
 
 class JwstDataModel(_DataModel):
     """Base class for JWST data models."""

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -140,7 +140,7 @@ class _DQMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
-            if getattr(self, attr, None) is None:
+            if value is None:
                 # do not set if primary is being set to None
                 return
             if getattr(self, "dq", None) is None:
@@ -170,7 +170,7 @@ class _DefaultErrMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
-            if getattr(self, attr, None) is None:
+            if value is None:
                 # do not set if primary is being set to None
                 return
             if getattr(self, "err", None) is None:

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -140,6 +140,9 @@ class _DQMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
+            if getattr(self, attr, None) is None:
+                # do not set if primary is being set to None
+                return
             if getattr(self, "dq", None) is None:
                 self.dq = self.get_default("dq")
 
@@ -167,5 +170,8 @@ class _DefaultErrMixin(_DataModel):
             return
 
         if attr == self.get_primary_array_name():
+            if getattr(self, attr, None) is None:
+                # do not set if primary is being set to None
+                return
             if getattr(self, "err", None) is None:
                 self.err = self.get_default("err")

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -133,19 +133,6 @@ class _DefaultDQMixin(_DataModel):
         if getattr(self, "dq_def", None) is not None:
             self.dq = dynamic_mask(self, pixel)
 
-    def __setattr__(self, attr, value):
-        """Override setattr of primary array to ensure dq is created."""
-        super().__setattr__(attr, value)  # set it first, so get_default("dq") sees correct shape
-        if not hasattr(self, "_schema"):  # get_primary_array_name() relies on schema being present
-            return
-
-        if attr == self.get_primary_array_name():
-            if value is None:
-                # do not set if primary is being set to None
-                return
-            if getattr(self, "dq", None) is None:
-                self.dq = self.get_default("dq")
-
 
 class _DefaultErrMixin(_DataModel):
     """Mixin for models that should have err array initialized on init."""
@@ -162,16 +149,3 @@ class _DefaultErrMixin(_DataModel):
         # should be removed in the future once we can fix downstream patterns
         if getattr(self, "err", None) is None:
             self.err = self.get_default("err")
-
-    def __setattr__(self, attr, value):
-        """Override setattr of primary array to ensure err is created."""
-        super().__setattr__(attr, value)  # set it first, so get_default("err") sees correct shape
-        if not hasattr(self, "_schema"):  # get_primary_array_name() relies on schema being present
-            return
-
-        if attr == self.get_primary_array_name():
-            if value is None:
-                # do not set if primary is being set to None
-                return
-            if getattr(self, "err", None) is None:
-                self.err = self.get_default("err")

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -16,7 +16,7 @@ class MultiSlitModel(JwstDataModel):
         >>> multislit_model = MultiSlitModel()
         >>> multislit_model.slits.append(SlitModel())
         >>> multislit_model[0]
-        <SlitModel(0, 0, 0)>
+        <SlitModel>
 
     If ``init`` is a file name or an ``ImageModel`` or a ``SlitModel``instance,
     an empty ``SlitModel`` will be created and assigned to attribute ``slits[0]``,

--- a/src/stdatamodels/jwst/datamodels/multislit.py
+++ b/src/stdatamodels/jwst/datamodels/multislit.py
@@ -16,7 +16,7 @@ class MultiSlitModel(JwstDataModel):
         >>> multislit_model = MultiSlitModel()
         >>> multislit_model.slits.append(SlitModel())
         >>> multislit_model[0]
-        <SlitModel>
+        <SlitModel(0, 0, 0)>
 
     If ``init`` is a file name or an ``ImageModel`` or a ``SlitModel``instance,
     an empty ``SlitModel`` will be created and assigned to attribute ``slits[0]``,

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -3,7 +3,7 @@ from astropy.io import fits
 from numpy.lib.recfunctions import merge_arrays
 
 from stdatamodels.dynamicdq import dynamic_mask
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin
 
 from .dqflags import pixel
 from .reference import ReferenceFileModel
@@ -36,7 +36,7 @@ def _migrate_fast_variation_table(hdulist):
     return hdulist
 
 
-class NirspecFlatModel(ReferenceFileModel, DefaultErrMixin):
+class NirspecFlatModel(ReferenceFileModel, _DefaultErrMixin):
     """
     A data model for NIRSpec flat-field reference files.
 

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -3,6 +3,7 @@ from astropy.io import fits
 from numpy.lib.recfunctions import merge_arrays
 
 from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin
 
 from .dqflags import pixel
 from .reference import ReferenceFileModel
@@ -35,7 +36,7 @@ def _migrate_fast_variation_table(hdulist):
     return hdulist
 
 
-class NirspecFlatModel(ReferenceFileModel):
+class NirspecFlatModel(ReferenceFileModel, DefaultErrMixin):
     """
     A data model for NIRSpec flat-field reference files.
 

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -3,9 +3,9 @@ from astropy.io import fits
 from numpy.lib.recfunctions import merge_arrays
 
 from stdatamodels.dynamicdq import dynamic_mask
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin
 
 from .dqflags import pixel
+from .model_base import _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["NirspecFlatModel", "NirspecQuadFlatModel"]

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -63,12 +63,8 @@ class NirspecFlatModel(ReferenceFileModel):
 
         super(NirspecFlatModel, self).__init__(init=init, **kwargs)
 
-        if self.dq is not None or self.dq_def is not None:
+        if getattr(self, "dq", None) is not None or getattr(self, "dq_def", None) is not None:
             self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
 
     def _migrate_hdulist(self, hdulist):
         return _migrate_fast_variation_table(hdulist)
@@ -105,6 +101,16 @@ class NirspecQuadFlatModel(ReferenceFileModel):
         if isinstance(init, NirspecFlatModel):
             super(NirspecQuadFlatModel, self).__init__(init=None, **kwargs)
             self.update(init)
+            for attr in [
+                "data",
+                "dq",
+                "err",
+                "wavelength",
+                "flat_table",
+                "dq_def",
+            ]:
+                if not hasattr(init, attr):
+                    init.get_default(attr)
             self.quadrants.append(self.quadrants.item())
             self.quadrants[0].data = init.data
             self.quadrants[0].dq = init.dq

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -64,7 +64,7 @@ class NirspecFlatModel(ReferenceFileModel, _DefaultErrMixin):
 
         super(NirspecFlatModel, self).__init__(init=init, **kwargs)
 
-        if getattr(self, "dq", None) is not None or getattr(self, "dq_def", None) is not None:
+        if self.dq is not None or self.dq_def is not None:
             self.dq = dynamic_mask(self, pixel)
 
     def _migrate_hdulist(self, hdulist):

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -102,16 +102,6 @@ class NirspecQuadFlatModel(ReferenceFileModel):
         if isinstance(init, NirspecFlatModel):
             super(NirspecQuadFlatModel, self).__init__(init=None, **kwargs)
             self.update(init)
-            for attr in [
-                "data",
-                "dq",
-                "err",
-                "wavelength",
-                "flat_table",
-                "dq_def",
-            ]:
-                if not hasattr(init, attr):
-                    setattr(init, attr, init.get_default(attr))
             self.quadrants.append(self.quadrants.item())
             self.quadrants[0].data = init.data
             self.quadrants[0].dq = init.dq

--- a/src/stdatamodels/jwst/datamodels/nirspec_flat.py
+++ b/src/stdatamodels/jwst/datamodels/nirspec_flat.py
@@ -110,7 +110,7 @@ class NirspecQuadFlatModel(ReferenceFileModel):
                 "dq_def",
             ]:
                 if not hasattr(init, attr):
-                    init.get_default(attr)
+                    setattr(init, attr, init.get_default(attr))
             self.quadrants.append(self.quadrants.item())
             self.quadrants[0].data = init.data
             self.quadrants[0].dq = init.dq

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["PersistenceSatModel"]
 
 
-class PersistenceSatModel(ReferenceFileModel):
+class PersistenceSatModel(ReferenceFileModel, DQMixin):
     """
     A data model for the persistence saturation value (full well).
 
@@ -21,8 +20,3 @@ class PersistenceSatModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/persat.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(PersistenceSatModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["PersistenceSatModel"]
 
 
-class PersistenceSatModel(ReferenceFileModel, _DQMixin):
+class PersistenceSatModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for the persistence saturation value (full well).
 

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["PersistenceSatModel"]

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["PersistenceSatModel"]
 
 
-class PersistenceSatModel(ReferenceFileModel, DQMixin):
+class PersistenceSatModel(ReferenceFileModel, _DQMixin):
     """
     A data model for the persistence saturation value (full well).
 

--- a/src/stdatamodels/jwst/datamodels/persat.py
+++ b/src/stdatamodels/jwst/datamodels/persat.py
@@ -26,6 +26,3 @@ class PersistenceSatModel(ReferenceFileModel):
         super(PersistenceSatModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = [
@@ -139,7 +138,7 @@ class MirLrsPhotomModel(_PhotomModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"
 
 
-class MirMrsPhotomModel(ReferenceFileModel):
+class MirMrsPhotomModel(ReferenceFileModel, DQMixin):
     """
     A data model for MIRI MRS photom reference files.
 
@@ -180,11 +179,6 @@ class MirMrsPhotomModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirmrs_photom.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(MirMrsPhotomModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)
 
 
 class NrcImgPhotomModel(_PhotomModel):

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
@@ -138,7 +138,7 @@ class MirLrsPhotomModel(_PhotomModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"
 
 
-class MirMrsPhotomModel(ReferenceFileModel, DQMixin):
+class MirMrsPhotomModel(ReferenceFileModel, _DQMixin):
     """
     A data model for MIRI MRS photom reference files.
 

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = [
@@ -137,7 +137,7 @@ class MirLrsPhotomModel(_PhotomModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/mirlrs_photom.schema"
 
 
-class MirMrsPhotomModel(ReferenceFileModel, _DQMixin):
+class MirMrsPhotomModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for MIRI MRS photom reference files.
 

--- a/src/stdatamodels/jwst/datamodels/photom.py
+++ b/src/stdatamodels/jwst/datamodels/photom.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = [

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["QuadModel"]
 
 
-class QuadModel(JwstDataModel, DQMixin, DefaultErrMixin):
+class QuadModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 4D image arrays.
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
 
 __all__ = ["QuadModel"]
 
 
-class QuadModel(JwstDataModel):
+class QuadModel(JwstDataModel, DQMixin):
     """
     A data model for 4D image arrays.
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["QuadModel"]
 
 
-class QuadModel(JwstDataModel, _DQMixin, _DefaultErrMixin):
+class QuadModel(JwstDataModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 4D image arrays.
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 __all__ = ["QuadModel"]
 
 
-class QuadModel(JwstDataModel, DQMixin):
+class QuadModel(JwstDataModel, DQMixin, DefaultErrMixin):
     """
     A data model for 4D image arrays.
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["QuadModel"]
 

--- a/src/stdatamodels/jwst/datamodels/quad.py
+++ b/src/stdatamodels/jwst/datamodels/quad.py
@@ -18,10 +18,3 @@ class QuadModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/quad.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(QuadModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -24,10 +24,3 @@ class RampModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(RampModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.pixeldq = self.pixeldq
-        self.groupdq = self.groupdq

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -29,9 +29,9 @@ class RampModel(JwstDataModel):
         super(RampModel, self).__init__(init=init, **kwargs)
 
         # Ensure that if data exists, pixeldq and groupdq arrays exist
-        if not hasattr(self, "data"):
+        if self.data is None:
             return
-        if not hasattr(self, "pixeldq") and "pixeldq" in self.schema["properties"]:
+        if self.pixeldq is None and "pixeldq" in self.schema["properties"]:
             self.pixeldq = self.get_default("pixeldq")
-        if not hasattr(self, "groupdq") and "groupdq" in self.schema["properties"]:
+        if self.groupdq is None and "groupdq" in self.schema["properties"]:
             self.groupdq = self.get_default("groupdq")

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -24,3 +24,14 @@ class RampModel(JwstDataModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(RampModel, self).__init__(init=init, **kwargs)
+
+        # Ensure that if data exists, pixeldq and groupdq arrays exist
+        if not hasattr(self, "data"):
+            return
+        if not hasattr(self, "pixeldq") and "pixeldq" in self.schema["properties"]:
+            self.pixeldq = self.get_default("pixeldq")
+        if not hasattr(self, "groupdq") and "groupdq" in self.schema["properties"]:
+            self.groupdq = self.get_default("groupdq")

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -31,7 +31,7 @@ class RampModel(JwstDataModel):
         # Ensure that if data exists, pixeldq and groupdq arrays exist
         if self.data is None:
             return
-        if self.pixeldq is None and "pixeldq" in self.schema["properties"]:
+        if self.pixeldq is None:
             self.pixeldq = self.get_default("pixeldq")
-        if self.groupdq is None and "groupdq" in self.schema["properties"]:
+        if self.groupdq is None:
             self.groupdq = self.get_default("groupdq")

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -15,6 +15,8 @@ class RampModel(JwstDataModel):
          2-D data quality array for all planes
     groupdq : numpy uint8 array
          4-D data quality array for each plane
+    average_dark_current: numpy float32 array
+         Average dark current for each pixel
     zeroframe : numpy float32 array
          Zeroframe array
     group : numpy table
@@ -35,3 +37,5 @@ class RampModel(JwstDataModel):
             self.pixeldq = self.get_default("pixeldq")
         if self.groupdq is None:
             self.groupdq = self.get_default("groupdq")
+        if self.average_dark_current is None:
+            self.average_dark_current = self.get_default("average_dark_current")

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -37,5 +37,3 @@ class RampModel(JwstDataModel):
             self.pixeldq = self.get_default("pixeldq")
         if self.groupdq is None:
             self.groupdq = self.get_default("groupdq")
-        if self.average_dark_current is None:
-            self.average_dark_current = self.get_default("average_dark_current")

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -4,7 +4,7 @@ from stdatamodels.dynamicdq import dynamic_mask
 from stdatamodels.exceptions import ValidationWarning
 
 from .dqflags import pixel
-from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin, _DefaultErrMixin
 
 __all__ = ["ReferenceCubeModel", "ReferenceFileModel", "ReferenceImageModel", "ReferenceQuadModel"]
 
@@ -84,7 +84,7 @@ class ReferenceFileModel(JwstDataModel):
             warnings.warn(message, ValidationWarning, stacklevel=2)
 
 
-class ReferenceImageModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class ReferenceImageModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D reference images.
 
@@ -101,7 +101,7 @@ class ReferenceImageModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referenceimage.schema"
 
 
-class ReferenceCubeModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class ReferenceCubeModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 3D reference images.
 
@@ -118,7 +118,7 @@ class ReferenceCubeModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 
 
-class ReferenceQuadModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class ReferenceQuadModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 4D reference images.
 

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -2,7 +2,7 @@ import warnings
 
 from stdatamodels.dynamicdq import dynamic_mask
 from stdatamodels.exceptions import ValidationWarning
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 from .dqflags import pixel
 
@@ -84,7 +84,7 @@ class ReferenceFileModel(JwstDataModel):
             warnings.warn(message, ValidationWarning, stacklevel=2)
 
 
-class ReferenceImageModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class ReferenceImageModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D reference images.
 
@@ -101,7 +101,7 @@ class ReferenceImageModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referenceimage.schema"
 
 
-class ReferenceCubeModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class ReferenceCubeModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 3D reference images.
 
@@ -118,7 +118,7 @@ class ReferenceCubeModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 
 
-class ReferenceQuadModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class ReferenceQuadModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 4D reference images.
 

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -2,9 +2,9 @@ import warnings
 
 from stdatamodels.dynamicdq import dynamic_mask
 from stdatamodels.exceptions import ValidationWarning
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 from .dqflags import pixel
+from .model_base import JwstDataModel, _DefaultErrMixin, _DQMixin
 
 __all__ = ["ReferenceCubeModel", "ReferenceFileModel", "ReferenceImageModel", "ReferenceQuadModel"]
 

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -103,10 +103,6 @@ class ReferenceImageModel(ReferenceFileModel):
     def __init__(self, init=None, **kwargs):
         super(ReferenceImageModel, self).__init__(init=init, **kwargs)
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
-
         if self.hasattr("dq_def"):
             self.dq = dynamic_mask(self, pixel)
 
@@ -127,13 +123,6 @@ class ReferenceCubeModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(ReferenceCubeModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
-
 
 class ReferenceQuadModel(ReferenceFileModel):
     """
@@ -150,10 +139,3 @@ class ReferenceQuadModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencequad.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(ReferenceQuadModel, self).__init__(init=init, **kwargs)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/reference.py
+++ b/src/stdatamodels/jwst/datamodels/reference.py
@@ -2,9 +2,9 @@ import warnings
 
 from stdatamodels.dynamicdq import dynamic_mask
 from stdatamodels.exceptions import ValidationWarning
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin, JwstDataModel
 
 from .dqflags import pixel
-from .model_base import JwstDataModel
 
 __all__ = ["ReferenceCubeModel", "ReferenceFileModel", "ReferenceImageModel", "ReferenceQuadModel"]
 
@@ -84,7 +84,7 @@ class ReferenceFileModel(JwstDataModel):
             warnings.warn(message, ValidationWarning, stacklevel=2)
 
 
-class ReferenceImageModel(ReferenceFileModel):
+class ReferenceImageModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D reference images.
 
@@ -100,14 +100,8 @@ class ReferenceImageModel(ReferenceFileModel):
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referenceimage.schema"
 
-    def __init__(self, init=None, **kwargs):
-        super(ReferenceImageModel, self).__init__(init=init, **kwargs)
 
-        if self.hasattr("dq_def"):
-            self.dq = dynamic_mask(self, pixel)
-
-
-class ReferenceCubeModel(ReferenceFileModel):
+class ReferenceCubeModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 3D reference images.
 
@@ -124,7 +118,7 @@ class ReferenceCubeModel(ReferenceFileModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/referencecube.schema"
 
 
-class ReferenceQuadModel(ReferenceFileModel):
+class ReferenceQuadModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 4D reference images.
 

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["ResetModel"]
 
 
-class ResetModel(ReferenceFileModel):
+class ResetModel(ReferenceFileModel, DQMixin):
     """
     A data model for reset correction reference files.
 
@@ -23,8 +22,3 @@ class ResetModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/reset.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(ResetModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["ResetModel"]
 
 
-class ResetModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class ResetModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for reset correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["ResetModel"]
 
 
-class ResetModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class ResetModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for reset correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -28,7 +28,3 @@ class ResetModel(ReferenceFileModel):
         super(ResetModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["ResetModel"]
 
 
-class ResetModel(ReferenceFileModel, DQMixin):
+class ResetModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for reset correction reference files.
 

--- a/src/stdatamodels/jwst/datamodels/reset.py
+++ b/src/stdatamodels/jwst/datamodels/reset.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["ResetModel"]

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -26,6 +26,3 @@ class SaturationModel(ReferenceFileModel):
         super(SaturationModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["SaturationModel"]
 
 
-class SaturationModel(ReferenceFileModel):
+class SaturationModel(ReferenceFileModel, DQMixin):
     """
     A data model for saturation checking information.
 
@@ -21,8 +20,3 @@ class SaturationModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/saturation.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(SaturationModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["SaturationModel"]
 
 
-class SaturationModel(ReferenceFileModel, _DQMixin):
+class SaturationModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for saturation checking information.
 

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["SaturationModel"]
 
 
-class SaturationModel(ReferenceFileModel, DQMixin):
+class SaturationModel(ReferenceFileModel, _DQMixin):
     """
     A data model for saturation checking information.
 

--- a/src/stdatamodels/jwst/datamodels/saturation.py
+++ b/src/stdatamodels/jwst/datamodels/saturation.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["SaturationModel"]

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
 
 __all__ = ["SlitDataModel", "SlitModel"]
 
 
-class SlitDataModel(JwstDataModel):
+class SlitDataModel(JwstDataModel, DQMixin):
     """
     A data model for 2D slit images.
 
@@ -55,7 +55,7 @@ class SlitDataModel(JwstDataModel):
                 setattr(self, key, kwargs[key])
 
 
-class SlitModel(JwstDataModel):
+class SlitModel(JwstDataModel, DQMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,4 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DQMixin
+from .model_base import JwstDataModel, _DQMixin
 
 __all__ = ["SlitDataModel", "SlitModel"]
 

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,9 +1,9 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin, JwstDataModel
+from stdatamodels.jwst.datamodels.model_base import JwstDataModel, _DQMixin
 
 __all__ = ["SlitDataModel", "SlitModel"]
 
 
-class SlitDataModel(JwstDataModel, DQMixin):
+class SlitDataModel(JwstDataModel, _DQMixin):
     """
     A data model for 2D slit images.
 
@@ -55,7 +55,7 @@ class SlitDataModel(JwstDataModel, DQMixin):
                 setattr(self, key, kwargs[key])
 
 
-class SlitModel(JwstDataModel, DQMixin):
+class SlitModel(JwstDataModel, _DQMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -1,9 +1,9 @@
-from .model_base import JwstDataModel, _DQMixin
+from .model_base import JwstDataModel, _DefaultDQMixin
 
 __all__ = ["SlitDataModel", "SlitModel"]
 
 
-class SlitDataModel(JwstDataModel, _DQMixin):
+class SlitDataModel(JwstDataModel, _DefaultDQMixin):
     """
     A data model for 2D slit images.
 
@@ -55,7 +55,7 @@ class SlitDataModel(JwstDataModel, _DQMixin):
                 setattr(self, key, kwargs[key])
 
 
-class SlitModel(JwstDataModel, _DQMixin):
+class SlitModel(JwstDataModel, _DefaultDQMixin):
     """
     A data model for 2D images.
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,10 +1,10 @@
-from .model_base import _DefaultErrMixin, _DQMixin
+from .model_base import _DefaultDQMixin, _DefaultErrMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["SuperBiasModel"]
 
 
-class SuperBiasModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
+class SuperBiasModel(ReferenceFileModel, _DefaultDQMixin, _DefaultErrMixin):
     """
     A data model for 2D super-bias images.
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["SuperBiasModel"]
 
 
-class SuperBiasModel(ReferenceFileModel, DQMixin):
+class SuperBiasModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
     """
     A data model for 2D super-bias images.
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DefaultErrMixin, DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["SuperBiasModel"]
 
 
-class SuperBiasModel(ReferenceFileModel, DQMixin, DefaultErrMixin):
+class SuperBiasModel(ReferenceFileModel, _DQMixin, _DefaultErrMixin):
     """
     A data model for 2D super-bias images.
 

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DefaultErrMixin, _DQMixin
-
+from .model_base import _DefaultErrMixin, _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["SuperBiasModel"]

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -28,7 +28,3 @@ class SuperBiasModel(ReferenceFileModel):
         super(SuperBiasModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err

--- a/src/stdatamodels/jwst/datamodels/superbias.py
+++ b/src/stdatamodels/jwst/datamodels/superbias.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["SuperBiasModel"]
 
 
-class SuperBiasModel(ReferenceFileModel):
+class SuperBiasModel(ReferenceFileModel, DQMixin):
     """
     A data model for 2D super-bias images.
 
@@ -23,8 +22,3 @@ class SuperBiasModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/superbias.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(SuperBiasModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -1,5 +1,4 @@
-from stdatamodels.jwst.datamodels.model_base import _DQMixin
-
+from .model_base import _DQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["TrapDensityModel"]

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -1,11 +1,11 @@
-from stdatamodels.jwst.datamodels.model_base import DQMixin
+from stdatamodels.jwst.datamodels.model_base import _DQMixin
 
 from .reference import ReferenceFileModel
 
 __all__ = ["TrapDensityModel"]
 
 
-class TrapDensityModel(ReferenceFileModel, DQMixin):
+class TrapDensityModel(ReferenceFileModel, _DQMixin):
     """
     A data model for the trap density of a detector, for persistence.
 

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -26,6 +26,3 @@ class TrapDensityModel(ReferenceFileModel):
         super(TrapDensityModel, self).__init__(init=init, **kwargs)
 
         self.dq = dynamic_mask(self, pixel)
-
-        # Implicitly create arrays
-        self.dq = self.dq

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -1,12 +1,11 @@
-from stdatamodels.dynamicdq import dynamic_mask
+from stdatamodels.jwst.datamodels.model_base import DQMixin
 
-from .dqflags import pixel
 from .reference import ReferenceFileModel
 
 __all__ = ["TrapDensityModel"]
 
 
-class TrapDensityModel(ReferenceFileModel):
+class TrapDensityModel(ReferenceFileModel, DQMixin):
     """
     A data model for the trap density of a detector, for persistence.
 
@@ -21,8 +20,3 @@ class TrapDensityModel(ReferenceFileModel):
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/trapdensity.schema"
-
-    def __init__(self, init=None, **kwargs):
-        super(TrapDensityModel, self).__init__(init=init, **kwargs)
-
-        self.dq = dynamic_mask(self, pixel)

--- a/src/stdatamodels/jwst/datamodels/trapdensity.py
+++ b/src/stdatamodels/jwst/datamodels/trapdensity.py
@@ -1,10 +1,10 @@
-from .model_base import _DQMixin
+from .model_base import _DefaultDQMixin
 from .reference import ReferenceFileModel
 
 __all__ = ["TrapDensityModel"]
 
 
-class TrapDensityModel(ReferenceFileModel, _DQMixin):
+class TrapDensityModel(ReferenceFileModel, _DefaultDQMixin):
     """
     A data model for the trap density of a detector, for persistence.
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -385,7 +385,7 @@ class DataModel(properties.ObjectNode):
         buf = ["<"]
         buf.append(self._model_type)
 
-        if self.shape:
+        if getattr(self, "shape", None) is not None:
             buf.append(str(self.shape))
 
         try:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -73,7 +73,7 @@ class DataModel(properties.ObjectNode):
             - None : Create a default data model with no shape.
 
             - tuple : Shape of the data array.
-              Initialize with empty data array with shape specified by the.
+              Initialize with default data array with shape specified by the tuple.
 
             - file path: Initialize from the given file (FITS or ASDF)
 
@@ -301,9 +301,8 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
 
-            # Initialization occurs when the primary array is first
-            # referenced. Do so now.
-            getattr(self, primary_array_name)
+            # Initialize the primary array to the given shape with default value.
+            self.get_default(primary_array_name)
 
         # initialize arrays from keyword arguments when they are present
         for attr, value in kwargs.items():
@@ -1244,6 +1243,73 @@ class DataModel(properties.ObjectNode):
         if attribute in self.instance:
             return getattr(self, attribute)
         raise AttributeError(f'{self} has no attribute "{attribute}"')
+
+    def get_default(self, attr):
+        """
+        Set the value of an attribute to its schema-defined default value.
+
+        TODO: this implementation is ugly
+
+        Parameters
+        ----------
+        attr : str
+            Attribute to set to its default value. Can be a dotted path
+            to a sub-object, e.g. "meta.foo" or "quadrants.0.flat_table"
+            where numeric parts refer to list indices. If a list index
+            doesn't exist, empty items will be created up to that index.
+        """
+        # Handle dotted paths like "meta.foo" or "quadrants.0.flat_table"
+        parts = attr.split(".")
+
+        if len(parts) == 1:
+            # Simple case: single attribute name
+            subschema = properties._get_schema_for_property(self._schema, attr)
+            default_arr = properties._make_default(attr, subschema, self._ctx)
+            setattr(self, attr, default_arr)
+        else:
+            # Navigate to the parent object
+            parent = self
+            parent_schema = self._schema
+
+            for part in parts[:-1]:
+                # Try to convert part to an integer (for list indexing)
+                try:
+                    index = int(part)
+                except ValueError:
+                    # Not an integer, treat as attribute name
+                    try:
+                        parent = getattr(parent, part)
+                    except AttributeError as err:
+                        raise KeyError(repr(attr)) from err
+                    # Get the schema for the parent
+                    parent_schema = properties._get_schema_for_property(parent_schema, part)
+                else:
+                    # It's an integer, use list indexing
+                    # If the list doesn't have enough items, add empty items
+                    while len(parent) <= index:
+                        parent.append(parent.item())
+                    parent = parent[index]
+                    # Get the schema for the indexed item
+                    parent_schema = properties._get_schema_for_index(parent_schema, index)
+
+            # Get schema and create default for the final attribute
+            final_attr = parts[-1]
+            # Try to convert final part to an integer
+            try:
+                final_index = int(final_attr)
+            except ValueError:
+                # Not an integer, treat as attribute name
+                subschema = properties._get_schema_for_property(parent_schema, final_attr)
+                default_arr = properties._make_default(final_attr, subschema, self._ctx)
+                setattr(parent, final_attr, default_arr)
+            else:
+                # Final part is an integer index
+                # If the list doesn't have enough items, add empty items
+                while len(parent) <= final_index:
+                    parent.append(parent.item())
+                subschema = properties._get_schema_for_index(parent_schema, final_index)
+                default_arr = properties._make_default(final_index, subschema, self._ctx)
+                parent[final_index] = default_arr
 
 
 class _FileReference:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -1330,7 +1330,7 @@ class DataModel(properties.ObjectNode):
         if not schema:
             raise AttributeError(f'{self} has no attribute "{attribute}"')
         if "datatype" not in schema:
-            raise AttributeError(f'Attribute "{attribute}" has no datatype defined in the schema.')
+            raise ValueError(f'Attribute "{attribute}" has no datatype defined in the schema.')
         return ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
 
 

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -12,7 +12,7 @@ import asdf
 import numpy as np
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
-from asdf.tags.core import NDArrayType, ndarray
+from asdf.tags.core import NDArrayType
 from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
@@ -1243,95 +1243,6 @@ class DataModel(properties.ObjectNode):
         if attribute in self.instance:
             return getattr(self, attribute)
         raise AttributeError(f'{self} has no attribute "{attribute}"')
-
-    def _navigate_to_parent_schema(self, attr):
-        """
-        Navigate through a dotted attribute path to find the parent schema.
-
-        Parameters
-        ----------
-        attr : str
-            Attribute path, e.g., "data", "meta.foo" or "quadrants.0.flat_table").
-
-        Returns
-        -------
-        parent_schema : dict
-            The schema for the parent of the final attribute.
-        final_attr : str
-            The final attribute name.
-        """
-        parts = attr.split(".")
-        final_attr = parts[-1]
-        parent = self
-        parent_schema = self._schema
-
-        for part in parts[:-1]:
-            try:
-                # Treat part as an integer list index
-                index = int(part)
-            except ValueError:
-                # Not an integer, treat as attribute name
-                try:
-                    parent = getattr(parent, part)
-                except AttributeError as err:
-                    raise KeyError(repr(attr)) from err
-                parent_schema = properties._get_schema_for_property(parent_schema, part)
-            else:
-                # It's an integer, use list indexing
-                parent_schema = properties._get_schema_for_index(parent_schema, index)
-
-        return parent_schema, final_attr
-
-    def get_default(self, attr):
-        """
-        Retrieve the schema-defined default value of an attribute.
-
-        Parameters
-        ----------
-        attr : str
-            Attribute to set to its default value. Can be a dotted path
-            to a sub-object, e.g. "meta.foo" or "quadrants.0.flat_table"
-            where numeric parts refer to list indices. If a list index
-            doesn't exist, empty items will be created up to that index.
-
-        Returns
-        -------
-        default_value : object
-            The default value for the given attribute.
-        """
-        parent_schema, final_attr = self._navigate_to_parent_schema(attr)
-
-        # Get schema and create default for the final attribute
-        subschema = properties._get_schema_for_property(parent_schema, final_attr)
-        if not subschema:
-            raise AttributeError(f'{self} has no attribute "{attr}"')
-        return properties._make_default(final_attr, subschema, self._ctx)
-
-    def get_dtype(self, attribute):
-        """
-        Retrieve the numpy dtype for an attribute.
-
-        Parameters
-        ----------
-        attribute : str
-            The attribute to retrieve the dtype for. Can be a dotted path
-            to a sub-object, e.g. "meta.foo" or "quadrants.0.flat_table"
-            where numeric parts refer to list indices.
-
-        Returns
-        -------
-        dtype : `numpy.dtype`
-            The numpy dtype for the attribute.
-        """
-        parent_schema, final_attr = self._navigate_to_parent_schema(attribute)
-
-        # Get schema for the final attribute
-        schema = properties._get_schema_for_property(parent_schema, final_attr)
-        if not schema:
-            raise AttributeError(f'{self} has no attribute "{attribute}"')
-        if "datatype" not in schema:
-            raise ValueError(f'Attribute "{attribute}" has no datatype defined in the schema.')
-        return ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
 
 
 class _FileReference:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -12,7 +12,7 @@ import asdf
 import numpy as np
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
-from asdf.tags.core import NDArrayType
+from asdf.tags.core import NDArrayType, ndarray
 from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
@@ -1244,6 +1244,44 @@ class DataModel(properties.ObjectNode):
             return getattr(self, attribute)
         raise AttributeError(f'{self} has no attribute "{attribute}"')
 
+    def _navigate_to_parent_schema(self, attr):
+        """
+        Navigate through a dotted attribute path to find the parent schema.
+
+        Parameters
+        ----------
+        attr : str
+            Attribute path, e.g., "data", "meta.foo" or "quadrants.0.flat_table").
+
+        Returns
+        -------
+        parent_schema : dict
+            The schema for the parent of the final attribute.
+        final_attr : str
+            The final attribute name.
+        """
+        parts = attr.split(".")
+        final_attr = parts[-1]
+        parent = self
+        parent_schema = self._schema
+
+        for part in parts[:-1]:
+            try:
+                # Treat part as an integer list index
+                index = int(part)
+            except ValueError:
+                # Not an integer, treat as attribute name
+                try:
+                    parent = getattr(parent, part)
+                except AttributeError as err:
+                    raise KeyError(repr(attr)) from err
+                parent_schema = properties._get_schema_for_property(parent_schema, part)
+            else:
+                # It's an integer, use list indexing
+                parent_schema = properties._get_schema_for_index(parent_schema, index)
+
+        return parent_schema, final_attr
+
     def get_default(self, attr):
         """
         Retrieve the schema-defined default value of an attribute.
@@ -1261,30 +1299,39 @@ class DataModel(properties.ObjectNode):
         default_value : object
             The default value for the given attribute.
         """
-        parts = attr.split(".")
-        final_attr = parts[-1]
-
-        # Navigate to the parent object
-        parent = self
-        parent_schema = self._schema
-        for part in parts[:-1]:
-            try:
-                # Treat part as an integer list index
-                index = int(part)
-            except ValueError:
-                # Not an integer, treat as attribute name
-                try:
-                    parent = getattr(parent, part)
-                except AttributeError as err:
-                    raise KeyError(repr(attr)) from err
-                # Get the schema for the parent
-                parent_schema = properties._get_schema_for_property(parent_schema, part)
-            else:
-                parent_schema = properties._get_schema_for_index(parent_schema, index)
+        parent_schema, final_attr = self._navigate_to_parent_schema(attr)
 
         # Get schema and create default for the final attribute
         subschema = properties._get_schema_for_property(parent_schema, final_attr)
+        if not subschema:
+            raise AttributeError(f'{self} has no attribute "{attr}"')
         return properties._make_default(final_attr, subschema, self._ctx)
+
+    def get_dtype(self, attribute):
+        """
+        Retrieve the numpy dtype for an attribute.
+
+        Parameters
+        ----------
+        attribute : str
+            The attribute to retrieve the dtype for. Can be a dotted path
+            to a sub-object, e.g. "meta.foo" or "quadrants.0.flat_table"
+            where numeric parts refer to list indices.
+
+        Returns
+        -------
+        dtype : `numpy.dtype`
+            The numpy dtype for the attribute.
+        """
+        parent_schema, final_attr = self._navigate_to_parent_schema(attribute)
+
+        # Get schema for the final attribute
+        schema = properties._get_schema_for_property(parent_schema, final_attr)
+        if not schema:
+            raise AttributeError(f'{self} has no attribute "{attribute}"')
+        if "datatype" not in schema:
+            raise AttributeError(f'Attribute "{attribute}" has no datatype defined in the schema.')
+        return ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
 
 
 class _FileReference:

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -974,6 +974,8 @@ class DataModel(properties.ObjectNode):
 
         def included(cursor, part):
             # Test if part is in the cursor
+            if cursor is None:
+                return False
             if isinstance(part, int):
                 return part >= 0 and part < len(cursor)
             else:

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -384,11 +384,11 @@ class ObjectNode(Node):
             if schema == {}:
                 raise AttributeError(f"No attribute '{attr}'") from err
 
-            # Do not populate default for arrays or tables
-            if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
-                raise AttributeError(
-                    f"Array-like attribute '{attr}' defined in schema but not set."
-                ) from err
+            # # Do not populate default for arrays or tables
+            # if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
+            #     raise AttributeError(
+            #         f"Array-like attribute '{attr}' defined in schema but not set."
+            #     ) from err
 
             val = _make_default(attr, schema, self._ctx)
             if val is not None:

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -446,6 +446,46 @@ class ObjectNode(Node):
                 val = getattr(val, field)
             yield (key, val)
 
+    def get_default(self, attr):
+        """
+        Retrieve the schema-defined default value of an attribute.
+
+        Parameters
+        ----------
+        attr : str
+            Attribute to set to its default value.
+
+        Returns
+        -------
+        object
+            The default value for the given attribute.
+        """
+        subschema = _get_schema_for_property(self._schema, attr)
+        if not subschema:
+            raise AttributeError(f'{self} has no attribute "{attr}"')
+        return _make_default(attr, subschema, self._ctx)
+
+    def get_dtype(self, attr):
+        """
+        Retrieve the numpy dtype for an attribute, if defined.
+
+        Parameters
+        ----------
+        attr : str
+            The attribute to retrieve the dtype for.
+
+        Returns
+        -------
+        `numpy.dtype`
+            The numpy dtype for the attribute.
+        """
+        schema = _get_schema_for_property(self._schema, attr)
+        if not schema:
+            raise AttributeError(f'{self} has no attribute "{attr}"')
+        if "datatype" not in schema:
+            raise ValueError(f'Attribute "{attr}" has no datatype defined in the schema.')
+        return ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
+
 
 class ListNode(Node):
     """A list-like Node."""

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -407,8 +407,8 @@ class ObjectNode(Node):
             self.__dict__[attr] = val
         else:
             schema = _get_schema_for_property(self._schema, attr)
-            if val is None:
-                val = _make_default(attr, schema, self._ctx)
+            # if val is None:
+            #     val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
 
             node = ObjectNode(attr, val, schema, self._ctx, self)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -384,6 +384,12 @@ class ObjectNode(Node):
             if schema == {}:
                 raise AttributeError(f"No attribute '{attr}'") from err
 
+            # Do not populate default for arrays or tables
+            if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
+                raise AttributeError(
+                    f"Array-like attribute '{attr}' defined in schema but not set."
+                ) from err
+
             val = _make_default(attr, schema, self._ctx)
             if val is not None:
                 self._instance[attr] = val

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -385,7 +385,9 @@ class ObjectNode(Node):
                 raise AttributeError(f"No attribute '{attr}'") from err
 
             if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
-                val = None
+                # data-like attributes should return None if not set
+                # not AttributeError, because we want hasattr(model, 'data') to be True
+                # but also don't want to set the array in getattr
                 return None
 
             val = schema.get("default", None)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -384,12 +384,11 @@ class ObjectNode(Node):
             if schema == {}:
                 raise AttributeError(f"No attribute '{attr}'") from err
 
-            # # Do not populate default for arrays or tables
-            # if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
-            #     raise AttributeError(
-            #         f"Array-like attribute '{attr}' defined in schema but not set."
-            #     ) from err
+            if "max_ndim" in schema or "ndim" in schema or "datatype" in schema:
+                val = None
+                return None
 
+            val = schema.get("default", None)
             val = _make_default(attr, schema, self._ctx)
             if val is not None:
                 self._instance[attr] = val

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -390,10 +390,13 @@ class ObjectNode(Node):
                 # but also don't want to set the array in getattr
                 return None
 
-            val = schema.get("default", None)
+            # Use _make_default to see if requested attribute is dict or list.
+            # If so it's assumed to be a node, and must be created to allow nested attribute access.
+            # Otherwise, return None and don't set anything
             val = _make_default(attr, schema, self._ctx)
-            if val is not None:
-                self._instance[attr] = val
+            if not isinstance(val, (dict, list)):
+                return None
+            self._instance[attr] = val
 
         if isinstance(val, dict):
             node = ObjectNode(attr, val, schema, self._ctx, self)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -407,8 +407,6 @@ class ObjectNode(Node):
             self.__dict__[attr] = val
         else:
             schema = _get_schema_for_property(self._schema, attr)
-            # if val is None:
-            #     val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
 
             node = ObjectNode(attr, val, schema, self._ctx, self)

--- a/tests/jwst/datamodels/test_fits.py
+++ b/tests/jwst/datamodels/test_fits.py
@@ -92,7 +92,7 @@ def test_resave_duplication_bug(tmp_path):
 
 def test_units_roundtrip(tmp_path):
     m = SpecModel()
-    m.get_default("spec_table")
+    m.spec_table = m.get_default("spec_table")
     m.spec_table.columns["WAVELENGTH"].unit = "nm"
 
     fn = tmp_path / "test1.fits"

--- a/tests/jwst/datamodels/test_fits.py
+++ b/tests/jwst/datamodels/test_fits.py
@@ -92,10 +92,7 @@ def test_resave_duplication_bug(tmp_path):
 
 def test_units_roundtrip(tmp_path):
     m = SpecModel()
-    # this next line is required for stdatamodels to cast
-    # spec_table to a FITS_rec (similar to having data assigned
-    # to the attribute)
-    m.spec_table = m.spec_table
+    m.get_default("spec_table")
     m.spec_table.columns["WAVELENGTH"].unit = "nm"
 
     fn = tmp_path / "test1.fits"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -854,12 +854,22 @@ def test_dq_mixin_from_shape(ModelClass):
     with ModelClass(shape) as im:
         assert im.hasattr("dq")
         assert im.dq.shape == shape
+        if isinstance(im, MaskModel):
+            assert not hasattr(im, "err")
+        else:
+            assert im.hasattr("err")
+            assert im.err.shape == shape
 
     data = np.zeros(shape, dtype=np.float32)
     # basic case: ImageModel
     with ModelClass(data) as im2:
         assert im2.hasattr("dq")
         assert im2.dq.shape == shape
+        if isinstance(im2, MaskModel):
+            assert not hasattr(im2, "err")
+        else:
+            assert im2.hasattr("err")
+            assert im2.err.shape == shape
 
 
 def test_dq_mixin_from_empty():
@@ -871,3 +881,4 @@ def test_dq_mixin_from_empty():
         shape = (5, 5)
         im.data = np.zeros(shape, dtype=np.float32)
         assert im.get_default("dq").shape == shape
+        assert im.get_default("err").shape == shape

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -85,6 +85,7 @@ def test_skip_fits_update(make_models, which_file):
 def test_asnmodel_table_size_zero():
     with pytest.warns(DeprecationWarning, match="AsnModel is deprecated"):
         with AsnModel() as dm:
+            dm.get_default("asn_table")
             assert len(dm.asn_table) == 0
 
 
@@ -92,6 +93,8 @@ def test_imagemodel():
     shape = (10, 10)
     with ImageModel(shape) as dm:
         assert dm.data.shape == shape
+        for attr in ["err", "dq", "zeroframe", "area", "pathloss_point", "pathloss_uniform"]:
+            dm.get_default(attr)
         assert dm.err.shape == shape
         assert dm.dq.shape == shape
         assert dm.data.mean() == 0.0
@@ -294,6 +297,7 @@ def test_slit_from_image():
     im.meta.instrument.name = "MIRI"
     slit_dm = SlitDataModel(im)
     assert_allclose(im.data, slit_dm.data)
+    slit_dm.get_default("wavelength")
     assert hasattr(slit_dm, "wavelength")
     # this should be enabled after gwcs starts using non-coordinate inputs
     # assert not hasattr(slit_dm, 'meta')
@@ -302,6 +306,7 @@ def test_slit_from_image():
     assert type(slit) is SlitModel
     assert_allclose(im.data, slit.data)
     assert_allclose(im.err, slit.err)
+    slit.get_default("wavelength")
     assert hasattr(slit, "wavelength")
     assert slit.meta.instrument.name == "MIRI"
 
@@ -463,6 +468,7 @@ def test_ramp_model_zero_frame_by_dimensions():
     zdims = (nints, nrows, ncols)
 
     with datamodels.RampModel(dims) as ramp:
+        ramp.get_default("zeroframe")
         assert ramp.zeroframe.shape == zdims
 
 
@@ -767,8 +773,10 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
     m = model()
     if model == NirspecQuadFlatModel:
         m.quadrants.append(m.quadrants.item())
+        m.get_default("quadrants.0.flat_table")
         m.quadrants[0].flat_table = make_data(m.quadrants[0].flat_table.dtype)
     else:
+        m.get_default("flat_table")
         m.flat_table = make_data(m.flat_table.dtype)
     m.save(fn)
     fn2 = tmp_path / "test2.fits"
@@ -805,6 +813,7 @@ def test_moving_target_table_migration(tmp_path):
         return np.array(fake_data, dtype=dtype)
 
     m = Level1bModel()
+    m.get_default("moving_target")
     m.moving_target = make_data(m.moving_target.dtype)
     m.save(fn)
     fn2 = tmp_path / "test_mt2.fits"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -29,6 +29,7 @@ from stdatamodels.jwst.datamodels import (
     NirspecQuadFlatModel,
     SlitDataModel,
     SlitModel,
+    SpecModel,
 )
 from stdatamodels.jwst.datamodels import _defined_models as defined_models
 from stdatamodels.jwst.datamodels import _deprecated_models as deprecated_models
@@ -775,8 +776,7 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
     m = model()
     if model == NirspecQuadFlatModel:
         m.quadrants.append(m.quadrants.item())
-        m.quadrants[0].flat_table = m.get_default("quadrants.0.flat_table")
-        m.quadrants[0].flat_table = make_data(m.get_dtype("quadrants.0.flat_table"))
+        m.quadrants[0].flat_table = make_data(m.quadrants[0].get_dtype("flat_table"))
     else:
         m.flat_table = make_data(m.get_dtype("flat_table"))
     m.save(fn)
@@ -923,5 +923,6 @@ def test_mixins_set_to_none():
 
 def test_nested_get_dtype():
     with MultiSpecModel() as dm:
-        dtype = dm.get_dtype("spec.0.spec_table")
+        dm.spec.append(SpecModel())
+        dtype = dm.spec[0].get_dtype("spec_table")
         assert isinstance(dtype, np.dtype)

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -776,10 +776,9 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
     if model == NirspecQuadFlatModel:
         m.quadrants.append(m.quadrants.item())
         m.quadrants[0].flat_table = m.get_default("quadrants.0.flat_table")
-        m.quadrants[0].flat_table = make_data(m.quadrants[0].flat_table.dtype)
+        m.quadrants[0].flat_table = make_data(m.get_dtype("quadrants.0.flat_table"))
     else:
-        m.flat_table = m.get_default("flat_table")
-        m.flat_table = make_data(m.flat_table.dtype)
+        m.flat_table = make_data(m.get_dtype("flat_table"))
     m.save(fn)
     fn2 = tmp_path / "test2.fits"
     with fits.open(fn) as ff:
@@ -815,8 +814,7 @@ def test_moving_target_table_migration(tmp_path):
         return np.array(fake_data, dtype=dtype)
 
     m = Level1bModel()
-    m.moving_target = m.get_default("moving_target")
-    m.moving_target = make_data(m.moving_target.dtype)
+    m.moving_target = make_data(m.get_dtype("moving_target"))
     m.save(fn)
     fn2 = tmp_path / "test_mt2.fits"
     with fits.open(fn) as ff:

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -840,14 +840,14 @@ def test_moving_target_table_migration(tmp_path):
 
 
 @pytest.mark.parametrize("ModelClass", [ImageModel, FlatModel, MaskModel])
-def test_dq_mixin_from_shape(ModelClass):
+def test_mixins_from_shape(ModelClass):
     """
-    Classes inheriting from DQMixin should have dq array created when init from shape or array.
+    Classes inheriting from DQMixin and DefaultErrMixin should have dq and err arrays created when init from shape or array.
 
     Three test cases chosen as follows:
-    - ImageModel: basic case, directly inherits from DQMixin
-    - FlatModel: inherits from ReferenceModel and DQMixin
-    - MaskModel: no 'data' array at all, 'dq' is primary array
+    - ImageModel: basic case, directly inherits from DQMixin and DefaultErrMixin
+    - FlatModel: inherits from ReferenceModel, DQMixin, and DefaultErrMixin
+    - MaskModel: no 'data' array at all, 'dq' is primary array, does not inherit from DefaultErrMixin
     """
     shape = (10, 10)
     # basic case: ImageModel
@@ -872,8 +872,8 @@ def test_dq_mixin_from_shape(ModelClass):
             assert im2.err.shape == shape
 
 
-def test_dq_mixin_from_empty():
-    """Classes inheriting from DQMixin should NOT have dq array created when init empty."""
+def test_mixins_from_empty():
+    """Classes inheriting from DQMixin and DefaultErrMixin should NOT have arrays created when init empty."""
     with ImageModel() as im:
         assert not hasattr(im, "dq")
         assert im.get_default("dq").size == 0

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -909,12 +909,16 @@ def test_mixins_from_array_set():
 
 
 def test_mixins_set_to_none():
-    """Setting data array to None should not set dq and err arrays to default."""
+    """Setting data array to None should not set dq and err arrays."""
     with ImageModel() as im:
         im.data = None
         assert im.data is None
+        # getattr returns None for array-like attributes not found, instead of AttributeError
         assert im.dq is None
         assert im.err is None
+        # but in reality these have not been set at all
+        assert "dq" not in im._instance
+        assert "err" not in im._instance
 
 
 def test_nested_get_dtype():

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -842,12 +842,12 @@ def test_moving_target_table_migration(tmp_path):
 @pytest.mark.parametrize("ModelClass", [ImageModel, FlatModel, MaskModel])
 def test_mixins_from_shape(ModelClass):
     """
-    Classes inheriting from DQMixin and DefaultErrMixin should have dq and err arrays created when init from shape or array.
+    Classes inheriting from _DQMixin and _DefaultErrMixin should have dq and err arrays created when init from shape or array.
 
     Three test cases chosen as follows:
-    - ImageModel: basic case, directly inherits from DQMixin and DefaultErrMixin
-    - FlatModel: inherits from ReferenceModel, DQMixin, and DefaultErrMixin
-    - MaskModel: no 'data' array at all, 'dq' is primary array, does not inherit from DefaultErrMixin
+    - ImageModel: basic case, directly inherits from _DQMixin and _DefaultErrMixin
+    - FlatModel: inherits from ReferenceModel, _DQMixin, and _DefaultErrMixin
+    - MaskModel: no 'data' array at all, 'dq' is primary array, does not inherit from _DefaultErrMixin
     """
     shape = (10, 10)
     # basic case: ImageModel
@@ -873,7 +873,7 @@ def test_mixins_from_shape(ModelClass):
 
 
 def test_mixins_from_empty():
-    """Classes inheriting from DQMixin and DefaultErrMixin should NOT have arrays created when init empty."""
+    """Classes inheriting from _DQMixin and _DefaultErrMixin should NOT have arrays created when init empty."""
     with ImageModel() as im:
         assert not hasattr(im, "dq")
         assert im.get_default("dq").size == 0
@@ -885,7 +885,7 @@ def test_mixins_from_empty():
 
 
 def test_mixins_from_array_init():
-    """Classes inheriting from DQMixin and DefaultErrMixin should have dq and err arrays created when init from array."""
+    """Classes inheriting from _DQMixin and _DefaultErrMixin should have dq and err arrays created when init from array."""
     shape = (10, 10)
     data = np.zeros(shape, dtype=np.float32)
     with ImageModel(data) as im:

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -894,7 +894,7 @@ def test_mixins_from_array_init():
 
 
 def test_mixins_from_array_set():
-    """Setting data array on an existing model should update dq and err arrays."""
+    """Setting data array on an existing model should not update dq and err arrays."""
     shape = (10, 10)
     data = np.zeros(shape, dtype=np.float32)
     with ImageModel() as im:
@@ -902,8 +902,8 @@ def test_mixins_from_array_set():
         assert im.err is None
 
         im.data = data
-        assert im.dq.shape == shape
-        assert im.err.shape == shape
+        assert "dq" not in im
+        assert "err" not in im
 
 
 def test_mixins_set_to_none():
@@ -915,8 +915,8 @@ def test_mixins_set_to_none():
         assert im.dq is None
         assert im.err is None
         # but in reality these have not been set at all
-        assert "dq" not in im._instance
-        assert "err" not in im._instance
+        assert "dq" not in im
+        assert "err" not in im
 
 
 def test_nested_get_dtype():

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -874,7 +874,7 @@ def test_mixins_from_shape(ModelClass):
 def test_mixins_from_empty():
     """Classes inheriting from _DQMixin and _DefaultErrMixin should NOT have arrays created when init empty."""
     with ImageModel() as im:
-        assert not hasattr(im, "dq")
+        # assert not hasattr(im, "dq")
         assert im.get_default("dq").size == 0
 
         shape = (5, 5)
@@ -894,6 +894,7 @@ def test_mixins_from_array_init():
         assert im.err.shape == shape
 
 
+@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_mixins_from_array_set():
     """Setting data array on an existing model should update dq and err arrays."""
     shape = (10, 10)

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -874,7 +874,8 @@ def test_mixins_from_shape(ModelClass):
 def test_mixins_from_empty():
     """Classes inheriting from _DQMixin and _DefaultErrMixin should NOT have arrays created when init empty."""
     with ImageModel() as im:
-        # assert not hasattr(im, "dq")
+        assert hasattr(im, "dq")
+        assert im.dq is None
         assert im.get_default("dq").size == 0
 
         shape = (5, 5)

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -85,7 +85,7 @@ def test_skip_fits_update(make_models, which_file):
 def test_asnmodel_table_size_zero():
     with pytest.warns(DeprecationWarning, match="AsnModel is deprecated"):
         with AsnModel() as dm:
-            dm.get_default("asn_table")
+            dm.asn_table = dm.get_default("asn_table")
             assert len(dm.asn_table) == 0
 
 
@@ -94,7 +94,7 @@ def test_imagemodel():
     with ImageModel(shape) as dm:
         assert dm.data.shape == shape
         for attr in ["err", "dq", "zeroframe", "area", "pathloss_point", "pathloss_uniform"]:
-            dm.get_default(attr)
+            setattr(dm, attr, dm.get_default(attr))
         assert dm.err.shape == shape
         assert dm.dq.shape == shape
         assert dm.data.mean() == 0.0
@@ -297,7 +297,7 @@ def test_slit_from_image():
     im.meta.instrument.name = "MIRI"
     slit_dm = SlitDataModel(im)
     assert_allclose(im.data, slit_dm.data)
-    slit_dm.get_default("wavelength")
+    slit_dm.wavelength = slit_dm.get_default("wavelength")
     assert hasattr(slit_dm, "wavelength")
     # this should be enabled after gwcs starts using non-coordinate inputs
     # assert not hasattr(slit_dm, 'meta')
@@ -306,7 +306,7 @@ def test_slit_from_image():
     assert type(slit) is SlitModel
     assert_allclose(im.data, slit.data)
     assert_allclose(im.err, slit.err)
-    slit.get_default("wavelength")
+    slit.wavelength = slit.get_default("wavelength")
     assert hasattr(slit, "wavelength")
     assert slit.meta.instrument.name == "MIRI"
 
@@ -468,7 +468,7 @@ def test_ramp_model_zero_frame_by_dimensions():
     zdims = (nints, nrows, ncols)
 
     with datamodels.RampModel(dims) as ramp:
-        ramp.get_default("zeroframe")
+        ramp.zeroframe = ramp.get_default("zeroframe")
         assert ramp.zeroframe.shape == zdims
 
 
@@ -773,10 +773,10 @@ def test_nirspec_flat_table_migration(tmp_path, model, shape):
     m = model()
     if model == NirspecQuadFlatModel:
         m.quadrants.append(m.quadrants.item())
-        m.get_default("quadrants.0.flat_table")
+        m.quadrants[0].flat_table = m.get_default("quadrants.0.flat_table")
         m.quadrants[0].flat_table = make_data(m.quadrants[0].flat_table.dtype)
     else:
-        m.get_default("flat_table")
+        m.flat_table = m.get_default("flat_table")
         m.flat_table = make_data(m.flat_table.dtype)
     m.save(fn)
     fn2 = tmp_path / "test2.fits"
@@ -813,7 +813,7 @@ def test_moving_target_table_migration(tmp_path):
         return np.array(fake_data, dtype=dtype)
 
     m = Level1bModel()
-    m.get_default("moving_target")
+    m.moving_target = m.get_default("moving_target")
     m.moving_target = make_data(m.moving_target.dtype)
     m.save(fn)
     fn2 = tmp_path / "test_mt2.fits"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -882,3 +882,29 @@ def test_mixins_from_empty():
         im.data = np.zeros(shape, dtype=np.float32)
         assert im.get_default("dq").shape == shape
         assert im.get_default("err").shape == shape
+
+
+def test_mixins_from_array_init():
+    """Classes inheriting from DQMixin and DefaultErrMixin should have dq and err arrays created when init from array."""
+    shape = (10, 10)
+    data = np.zeros(shape, dtype=np.float32)
+    with ImageModel(data) as im:
+        assert im.hasattr("dq")
+        assert im.dq.shape == shape
+        assert im.hasattr("err")
+        assert im.err.shape == shape
+
+
+def test_mixins_from_array_set():
+    """Setting data array on an existing model should update dq and err arrays."""
+    shape = (10, 10)
+    data = np.zeros(shape, dtype=np.float32)
+    with ImageModel() as im:
+        assert not hasattr(im, "dq")
+        assert not hasattr(im, "err")
+
+        im.data = data
+        assert im.hasattr("dq")
+        assert im.dq.shape == shape
+        assert im.hasattr("err")
+        assert im.err.shape == shape

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -895,20 +895,26 @@ def test_mixins_from_array_init():
         assert im.err.shape == shape
 
 
-@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_mixins_from_array_set():
     """Setting data array on an existing model should update dq and err arrays."""
     shape = (10, 10)
     data = np.zeros(shape, dtype=np.float32)
     with ImageModel() as im:
-        assert not hasattr(im, "dq")
-        assert not hasattr(im, "err")
+        assert im.dq is None
+        assert im.err is None
 
         im.data = data
-        assert im.hasattr("dq")
         assert im.dq.shape == shape
-        assert im.hasattr("err")
         assert im.err.shape == shape
+
+
+def test_mixins_set_to_none():
+    """Setting data array to None should not set dq and err arrays to default."""
+    with ImageModel() as im:
+        im.data = None
+        assert im.data is None
+        assert im.dq is None
+        assert im.err is None
 
 
 def test_nested_get_dtype():

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -24,6 +24,7 @@ from stdatamodels.jwst.datamodels import (
     Level1bModel,
     MaskModel,
     MultiSlitModel,
+    MultiSpecModel,
     NirspecFlatModel,
     NirspecQuadFlatModel,
     SlitDataModel,
@@ -908,3 +909,9 @@ def test_mixins_from_array_set():
         assert im.dq.shape == shape
         assert im.hasattr("err")
         assert im.err.shape == shape
+
+
+def test_nested_get_dtype():
+    with MultiSpecModel() as dm:
+        dtype = dm.get_dtype("spec.0.spec_table")
+        assert isinstance(dtype, np.dtype)

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -300,7 +300,6 @@ def test_slit_from_image():
     im.meta.instrument.name = "MIRI"
     slit_dm = SlitDataModel(im)
     assert_allclose(im.data, slit_dm.data)
-    slit_dm.wavelength = slit_dm.get_default("wavelength")
     assert hasattr(slit_dm, "wavelength")
     # this should be enabled after gwcs starts using non-coordinate inputs
     # assert not hasattr(slit_dm, 'meta')
@@ -309,7 +308,6 @@ def test_slit_from_image():
     assert type(slit) is SlitModel
     assert_allclose(im.data, slit.data)
     assert_allclose(im.err, slit.err)
-    slit.wavelength = slit.get_default("wavelength")
     assert hasattr(slit, "wavelength")
     assert slit.meta.instrument.name == "MIRI"
 
@@ -841,11 +839,11 @@ def test_moving_target_table_migration(tmp_path):
 @pytest.mark.parametrize("ModelClass", [ImageModel, FlatModel, MaskModel])
 def test_mixins_from_shape(ModelClass):
     """
-    Classes inheriting from _DQMixin and _DefaultErrMixin should have dq and err arrays created when init from shape or array.
+    Classes inheriting from _DefaultDQMixin and _DefaultErrMixin should have dq and err arrays created when init from shape or array.
 
     Three test cases chosen as follows:
-    - ImageModel: basic case, directly inherits from _DQMixin and _DefaultErrMixin
-    - FlatModel: inherits from ReferenceModel, _DQMixin, and _DefaultErrMixin
+    - ImageModel: basic case, directly inherits from _DefaultDQMixin and _DefaultErrMixin
+    - FlatModel: inherits from ReferenceModel, _DefaultDQMixin, and _DefaultErrMixin
     - MaskModel: no 'data' array at all, 'dq' is primary array, does not inherit from _DefaultErrMixin
     """
     shape = (10, 10)
@@ -872,7 +870,7 @@ def test_mixins_from_shape(ModelClass):
 
 
 def test_mixins_from_empty():
-    """Classes inheriting from _DQMixin and _DefaultErrMixin should NOT have arrays created when init empty."""
+    """Classes inheriting from _DefaultDQMixin and _DefaultErrMixin should NOT have arrays created when init empty."""
     with ImageModel() as im:
         assert hasattr(im, "dq")
         assert im.dq is None
@@ -885,7 +883,7 @@ def test_mixins_from_empty():
 
 
 def test_mixins_from_array_init():
-    """Classes inheriting from _DQMixin and _DefaultErrMixin should have dq and err arrays created when init from array."""
+    """Classes inheriting from _DefaultDQMixin and _DefaultErrMixin should have dq and err arrays created when init from array."""
     shape = (10, 10)
     data = np.zeros(shape, dtype=np.float32)
     with ImageModel(data) as im:

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -64,6 +64,8 @@ def test_multislit():
         slit.data = rng.random((5, 5))
         slit.dm = rng.random((5, 5))
         slit.err = rng.random((5, 5))
+        for attr in ["wavelength", "pathloss_point", "pathloss_uniform", "barshadow"]:
+            dm.get_default(f"slits.-1.{attr}")
         assert slit.wavelength.shape == (0, 0)
         assert slit.pathloss_point.shape == (0, 0)
         assert slit.pathloss_uniform.shape == (0, 0)
@@ -163,6 +165,6 @@ def test_slit_from_multislit():
     model = MultiSlitModel()
     slit = SlitModel()
     # access int_times so it's created
-    slit.int_times = slit.int_times
+    slit.get_default("int_times")
     model.slits.append(slit)
     slit = SlitModel(model.slits[0].instance)

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -65,7 +65,7 @@ def test_multislit():
         slit.dm = rng.random((5, 5))
         slit.err = rng.random((5, 5))
         for attr in ["wavelength", "pathloss_point", "pathloss_uniform", "barshadow"]:
-            setattr(dm.slits[-1], attr, dm.get_default(f"slits.-1.{attr}"))
+            setattr(dm.slits[-1], attr, dm.slits[-1].get_default(attr))
         assert slit.wavelength.shape == (0, 0)
         assert slit.pathloss_point.shape == (0, 0)
         assert slit.pathloss_uniform.shape == (0, 0)

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -65,7 +65,7 @@ def test_multislit():
         slit.dm = rng.random((5, 5))
         slit.err = rng.random((5, 5))
         for attr in ["wavelength", "pathloss_point", "pathloss_uniform", "barshadow"]:
-            dm.get_default(f"slits.-1.{attr}")
+            setattr(dm.slits[-1], attr, dm.get_default(f"slits.-1.{attr}"))
         assert slit.wavelength.shape == (0, 0)
         assert slit.pathloss_point.shape == (0, 0)
         assert slit.pathloss_uniform.shape == (0, 0)
@@ -164,7 +164,7 @@ def test_copy_multislit():
 def test_slit_from_multislit():
     model = MultiSlitModel()
     slit = SlitModel()
-    # access int_times so it's created
-    slit.get_default("int_times")
+    # set int_times to its default
+    slit.int_times = slit.get_default("int_times")
     model.slits.append(slit)
     slit = SlitModel(model.slits[0].instance)

--- a/tests/jwst/datamodels/test_open.py
+++ b/tests/jwst/datamodels/test_open.py
@@ -341,7 +341,7 @@ def test_open_kwargs_fits(tmp_path):
 def test_open_does_not_clear_wht(InitClass):
     """Cover a bug where the open function cleared the wht attribute in SlitModel."""
     m0 = InitClass((27, 1299))
-    m0.get_default("wht")
+    m0.wht = m0.get_default("wht")
     m0.wht[:] = 1
 
     m1 = datamodels.open(m0)

--- a/tests/jwst/datamodels/test_open.py
+++ b/tests/jwst/datamodels/test_open.py
@@ -341,6 +341,7 @@ def test_open_kwargs_fits(tmp_path):
 def test_open_does_not_clear_wht(InitClass):
     """Cover a bug where the open function cleared the wht attribute in SlitModel."""
     m0 = InitClass((27, 1299))
+    m0.get_default("wht")
     m0.wht[:] = 1
 
     m1 = datamodels.open(m0)

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,6 +9,15 @@ class BasicModel(DataModel):
     schema_url = "http://example.com/schemas/basic_model"
 
 
+class DefaultsModel(DataModel):
+    """Model with attributes that have default values."""
+
+    schema_url = "http://example.com/schemas/defaults_model"
+
+    def get_primary_array_name(self):  # noqa: D102
+        return "primary"
+
+
 class ValidationModel(DataModel):
     """Model with various kinds of validated attributes."""
 

--- a/tests/schemas/defaults_model.yaml
+++ b/tests/schemas/defaults_model.yaml
@@ -1,0 +1,27 @@
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: http://example.com/schemas/basic_model
+title: Basic model with some data arrays and metadata.
+
+allOf:
+  - $ref: core_metadata
+  - type: object
+    properties:
+      meta:
+        type: object
+        properties:
+          origin:
+            type: string
+          default_meta:
+            type: string
+            default: default
+          no_default_meta:
+            type: string
+      data:
+        ndim: 2
+        datatype: float32
+        default: 3.0
+      primary:
+        ndim: 2
+        datatype: float32
+        default: 2.0
+...

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -372,10 +372,9 @@ def test_table_with_unsigned_int(tmp_path):
         uint32_arr[0] = uint32_info.min
         uint32_arr[-1] = uint32_info.max
 
-        table_dtype = dm.schema["properties"]["test_table"]["datatype"]
-        # Convert schema datatype format to NumPy dtype format
-        np_dtype = [(col["name"], col["datatype"]) for col in table_dtype]
-        test_table = np.array(list(zip(float64_arr, uint32_arr, strict=False)), dtype=np_dtype)
+        test_table = np.array(
+            list(zip(float64_arr, uint32_arr, strict=False)), dtype=dm.get_dtype("test_table")
+        )
 
         def assert_table_correct(model):
             for idx, (col_name, col_data) in enumerate(

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -43,6 +43,7 @@ def test_from_new_hdulist2():
     science = fits.ImageHDU(data=data, name="SCI")
     hdulist.append(science)
     with FitsModel(hdulist) as dm:
+        dm.get_default("dq")
         dq = dm.dq
         assert dq is not None
 
@@ -74,6 +75,7 @@ def test_from_scratch(tmp_path):
         dm.to_fits(file_path)
 
         with FitsModel(file_path) as dm2:
+            dm2.get_default("dq")
             assert dm2.shape == (50, 50)
             assert dm2.meta.telescope == "EYEGLASSES"
             assert dm2.dq.dtype.name == "uint32"
@@ -370,9 +372,10 @@ def test_table_with_unsigned_int(tmp_path):
         uint32_arr[0] = uint32_info.min
         uint32_arr[-1] = uint32_info.max
 
-        test_table = np.array(
-            list(zip(float64_arr, uint32_arr, strict=False)), dtype=dm.test_table.dtype
-        )
+        table_dtype = dm.schema["properties"]["test_table"]["datatype"]
+        # Convert schema datatype format to NumPy dtype format
+        np_dtype = [(col["name"], col["datatype"]) for col in table_dtype]
+        test_table = np.array(list(zip(float64_arr, uint32_arr, strict=False)), dtype=np_dtype)
 
         def assert_table_correct(model):
             for idx, (col_name, col_data) in enumerate(
@@ -450,7 +453,7 @@ def test_get_short_doc():
 def test_from_hdulist(tmp_path):
     file_path = tmp_path / "test.fits"
 
-    with FitsModel() as dm:
+    with FitsModel((10, 10)) as dm:
         dm.save(file_path)
 
     with fits.open(file_path, memmap=False) as hdulist:

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -43,7 +43,7 @@ def test_from_new_hdulist2():
     science = fits.ImageHDU(data=data, name="SCI")
     hdulist.append(science)
     with FitsModel(hdulist) as dm:
-        dm.get_default("dq")
+        dm.dq = dm.get_default("dq")
         dq = dm.dq
         assert dq is not None
 
@@ -75,7 +75,7 @@ def test_from_scratch(tmp_path):
         dm.to_fits(file_path)
 
         with FitsModel(file_path) as dm2:
-            dm2.get_default("dq")
+            dm2.dq = dm2.get_default("dq")
             assert dm2.shape == (50, 50)
             assert dm2.meta.telescope == "EYEGLASSES"
             assert dm2.dq.dtype.name == "uint32"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,11 +166,12 @@ def test_primary_not_created_when_blank():
         im.validate()
 
 
-def test_cannot_set_primary_to_none():
+def test_set_arr_to_none():
     """Primary array should not be settable to None."""
-    with DefaultsModel((10, 10)) as im:
+    with DefaultsModel((10, 10), strict_validation=True) as im:
         im.primary = None
-        np.testing.assert_allclose(im.primary, 2.0)
+        im.validate()
+        assert im.primary is None
 
 
 def test_primary_created_when_shape():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -179,7 +179,7 @@ def test_set_arr_to_none(tmp_path):
 
     with DefaultsModel(tmp_path / "test.asdf", strict_validation=True) as im2:
         assert im2.primary is None
-        assert not "primary" in im2._instance
+        assert not "primary" in im2
 
 
 def test_primary_created_when_shape():
@@ -194,7 +194,7 @@ def test_non_primary_not_created_when_shape():
     with DefaultsModel((10, 10)) as im:
         assert hasattr(im, "data")
         assert im.data is None
-        assert "data" not in im._instance
+        assert "data" not in im
 
 
 def test_get_default_arr():
@@ -232,15 +232,15 @@ def test_implicit_meta_none():
         assert hasattr(im.meta, "default_meta")
         assert im.meta.default_meta is None
         assert im.meta.no_default_meta is None
-        assert "default_meta" not in im.meta._instance
-        assert "no_default_meta" not in im.meta._instance
+        assert "default_meta" not in im.meta
+        assert "no_default_meta" not in im.meta
 
 
 def test_get_dtype_basic():
     with BasicModel() as dm:
         dtype = dm.get_dtype("data")
         assert dtype == np.dtype(np.float32)
-        assert "data" not in dm._instance
+        assert "data" not in dm
 
 
 def test_get_dtype_table():
@@ -260,7 +260,7 @@ def test_get_dtype_table():
             ]
         )
         assert dtype == expected_dtype
-        assert "table" not in dm._instance
+        assert "table" not in dm
 
 
 def test_get_dtype_attribute_error():
@@ -428,7 +428,7 @@ def test_skip_serializing_null(tmp_path, filename):
 
     with BasicModel(file_path) as model:
         # Make sure that 'telescope' is not in the tree
-        assert "telescope" not in model.meta._instance
+        assert "telescope" not in model.meta
 
 
 def test_delete_failed_model():
@@ -467,7 +467,7 @@ def test_on_save_hook(tmp_path):
             self.meta.foo = "bar"
 
     model = OnSaveModel()
-    assert "foo" not in model.meta._instance
+    assert "foo" not in model.meta
     model.save(tmp_path / "test.asdf")
     assert model.meta.foo == "bar"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,6 +146,7 @@ def test_base_model_has_no_arrays():
 
 def test_array_type():
     with BasicModel() as dm:
+        dm.get_default("dq")
         assert dm.dq.dtype == np.uint32
 
 
@@ -204,6 +205,7 @@ def test_secondary_shapes():
     specified in the initializer.
     """
     with BasicModel((256, 256)) as dm:
+        dm.get_default("area")
         assert dm.area.shape == (256, 256)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -231,6 +231,8 @@ def test_get_dtype_table():
                 ("ascii_column", "S64"),
                 ("float32_column_with_shape", "<f4", (3, 2)),
                 ("float32_column_with_ndim", "<f4"),
+                ("float32_column_with_ndim_and_shape", "<f4", (3, 2)),
+                ("float32_column_with_max_ndim", "<f4"),
             ]
         )
         assert dtype == expected_dtype
@@ -279,7 +281,7 @@ def test_multivalued_default_table_schema():
             elif isinstance(default, str):
                 # allclose has trouble with string comparisons
                 for elem in dm.table[name]:
-                    assert elem.decode("utf-8") == default
+                    assert elem == default
                 continue
             assert np.allclose(dm.table[name], default, equal_nan=True)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,7 +166,7 @@ def test_primary_not_created_when_blank():
         im.validate()
 
 
-def test_set_arr_to_none(tmp_cwd):
+def test_set_arr_to_none(tmp_path):
     """Primary array is settable to None, and this raises no ValidationError."""
     with DefaultsModel((10, 10), strict_validation=True) as im:
         im.primary = None
@@ -175,12 +175,11 @@ def test_set_arr_to_none(tmp_cwd):
         assert im._instance["primary"] is None
 
         # ensure save-load works properly here too
-        im.save("test.asdf")
+        im.save(tmp_path / "test.asdf")
 
-    with DefaultsModel("test.asdf", strict_validation=True) as im2:
+    with DefaultsModel(tmp_path / "test.asdf", strict_validation=True) as im2:
         assert im2.primary is None
-        assert im2._instance["primary"] is None
-        im2.validate()
+        assert not "primary" in im2._instance
 
 
 def test_primary_created_when_shape():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,6 +158,7 @@ def test_array_type():
         assert dm.dq.dtype == np.uint32
 
 
+@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_primary_not_created_when_blank():
     """Primary array should not be created if not initialized with shape nor data."""
     with DefaultsModel() as im:
@@ -171,6 +172,7 @@ def test_primary_created_when_shape():
         np.testing.assert_allclose(im.primary, 2.0)
 
 
+@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_non_primary_not_created_when_shape():
     """Non-primary arrays shouldn't be created on init from shape, and hasattr should be False."""
     with DefaultsModel((10, 10)) as im:
@@ -180,7 +182,6 @@ def test_non_primary_not_created_when_shape():
 def test_get_default_arr():
     """Test get_default for non-primary array attribute gives proper shape and value."""
     with DefaultsModel((10, 10)) as im:
-        assert not hasattr(im, "data")
         default_data = im.get_default("data")
         assert default_data.shape == (10, 10)
         np.testing.assert_allclose(default_data, 3.0)
@@ -215,7 +216,7 @@ def test_get_dtype_basic():
     with BasicModel() as dm:
         dtype = dm.get_dtype("data")
         assert dtype == np.dtype(np.float32)
-        assert not hasattr(dm, "data")
+        assert not dm.hasattr("data")
 
 
 def test_get_dtype_table():
@@ -233,7 +234,7 @@ def test_get_dtype_table():
             ]
         )
         assert dtype == expected_dtype
-        assert not hasattr(dm, "table")
+        assert not dm.hasattr("table")
 
 
 def test_get_dtype_attribute_error():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -195,6 +195,13 @@ def test_get_default_meta():
         assert non_default_meta is None
 
 
+def test_get_default_attribute_error():
+    """Test get_default raises AttributeError for non-existent attribute."""
+    with DefaultsModel() as im:
+        with pytest.raises(AttributeError, match='has no attribute "non_existent_attribute"'):
+            im.get_default("non_existent_attribute")
+
+
 def test_implicit_meta_creation():
     """Test that metadata attributes are created on access, and hasattr is True."""
     with DefaultsModel() as im:
@@ -202,6 +209,45 @@ def test_implicit_meta_creation():
         assert hasattr(im.meta, "default_meta")
         assert im.meta.default_meta == "default"
         assert im.meta.no_default_meta is None
+
+
+def test_get_dtype_basic():
+    with BasicModel() as dm:
+        dtype = dm.get_dtype("data")
+        assert dtype == np.dtype(np.float32)
+        assert not hasattr(dm, "data")
+
+
+def test_get_dtype_table():
+    with TableModel() as dm:
+        dtype = dm.get_dtype("table")
+        assert isinstance(dtype, np.dtype)
+        expected_dtype = np.dtype(
+            [
+                ("int16_column", "<i2"),
+                ("uint16_column", "<u2"),
+                ("float32_column", "<f4"),
+                ("ascii_column", "S64"),
+                ("float32_column_with_shape", "<f4", (3, 2)),
+                ("float32_column_with_ndim", "<f4"),
+            ]
+        )
+        assert dtype == expected_dtype
+        assert not hasattr(dm, "table")
+
+
+def test_get_dtype_attribute_error():
+    with BasicModel() as dm:
+        with pytest.raises(AttributeError, match='has no attribute "non_existent_attribute"'):
+            dm.get_dtype("non_existent_attribute")
+
+
+def test_get_dtype_no_datatype():
+    with BasicModel() as dm:
+        with pytest.raises(
+            AttributeError, match='Attribute "meta" has no datatype defined in the schema.'
+        ):
+            dm.get_dtype("meta")
 
 
 def test_copy_model():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,12 +166,21 @@ def test_primary_not_created_when_blank():
         im.validate()
 
 
-def test_set_arr_to_none():
-    """Primary array should not be settable to None."""
+def test_set_arr_to_none(tmp_cwd):
+    """Primary array is settable to None, and this raises no ValidationError."""
     with DefaultsModel((10, 10), strict_validation=True) as im:
         im.primary = None
         im.validate()
         assert im.primary is None
+        assert im._instance["primary"] is None
+
+        # ensure save-load works properly here too
+        im.save("test.asdf")
+
+    with DefaultsModel("test.asdf", strict_validation=True) as im2:
+        assert im2.primary is None
+        assert im2._instance["primary"] is None
+        im2.validate()
 
 
 def test_primary_created_when_shape():
@@ -182,11 +191,11 @@ def test_primary_created_when_shape():
 
 
 def test_non_primary_not_created_when_shape():
-    """Non-primary arrays shouldn't be created on init from shape, and hasattr should be False."""
-    with DefaultsModel((10, 10), strict_validation=True) as im:
+    """Non-primary arrays shouldn't be created on init from shape."""
+    with DefaultsModel((10, 10)) as im:
         assert hasattr(im, "data")
         assert im.data is None
-        im.validate()
+        assert "data" not in im._instance
 
 
 def test_get_default_arr():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -221,13 +221,19 @@ def test_get_default_attribute_error():
             im.get_default("non_existent_attribute")
 
 
-def test_implicit_meta_creation():
-    """Test that metadata attributes are created on access, and hasattr is True."""
+def test_implicit_meta_none():
+    """
+    Test access to undefined metadata attributes.
+
+    Ensure returns None, even if there is a schema-defined default.
+    Ensure the attribute is not set during getattr."""
     with DefaultsModel() as im:
         assert hasattr(im.meta, "no_default_meta")
         assert hasattr(im.meta, "default_meta")
-        assert im.meta.default_meta == "default"
+        assert im.meta.default_meta is None
         assert im.meta.no_default_meta is None
+        assert "default_meta" not in im.meta._instance
+        assert "no_default_meta" not in im.meta._instance
 
 
 def test_get_dtype_basic():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,11 +158,19 @@ def test_array_type():
         assert dm.dq.dtype == np.uint32
 
 
-@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_primary_not_created_when_blank():
     """Primary array should not be created if not initialized with shape nor data."""
-    with DefaultsModel() as im:
-        assert not hasattr(im, "primary")
+    with DefaultsModel(strict_validation=True) as im:
+        assert hasattr(im, "primary")
+        assert im.primary is None
+        im.validate()
+
+
+def test_cannot_set_primary_to_none():
+    """Primary array should not be settable to None."""
+    with DefaultsModel((10, 10)) as im:
+        im.primary = None
+        np.testing.assert_allclose(im.primary, 2.0)
 
 
 def test_primary_created_when_shape():
@@ -172,11 +180,12 @@ def test_primary_created_when_shape():
         np.testing.assert_allclose(im.primary, 2.0)
 
 
-@pytest.mark.xfail(reason="Test should pass when default array setting work is complete.")
 def test_non_primary_not_created_when_shape():
     """Non-primary arrays shouldn't be created on init from shape, and hasattr should be False."""
-    with DefaultsModel((10, 10)) as im:
-        assert not hasattr(im, "data")
+    with DefaultsModel((10, 10), strict_validation=True) as im:
+        assert hasattr(im, "data")
+        assert im.data is None
+        im.validate()
 
 
 def test_get_default_arr():
@@ -216,7 +225,7 @@ def test_get_dtype_basic():
     with BasicModel() as dm:
         dtype = dm.get_dtype("data")
         assert dtype == np.dtype(np.float32)
-        assert not dm.hasattr("data")
+        assert "data" not in dm._instance
 
 
 def test_get_dtype_table():
@@ -236,7 +245,7 @@ def test_get_dtype_table():
             ]
         )
         assert dtype == expected_dtype
-        assert not dm.hasattr("table")
+        assert "table" not in dm._instance
 
 
 def test_get_dtype_attribute_error():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -208,9 +208,9 @@ def test_get_default_arr():
 def test_get_default_meta():
     """Test get_default for metadata attributes both with and without schema-defined defaults."""
     with DefaultsModel() as im:
-        default_meta = im.get_default("meta.default_meta")
+        default_meta = im.meta.get_default("default_meta")
         assert default_meta == "default"
-        non_default_meta = im.get_default("meta.no_default_meta")
+        non_default_meta = im.meta.get_default("no_default_meta")
         assert non_default_meta is None
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -245,7 +245,7 @@ def test_get_dtype_attribute_error():
 def test_get_dtype_no_datatype():
     with BasicModel() as dm:
         with pytest.raises(
-            AttributeError, match='Attribute "meta" has no datatype defined in the schema.'
+            ValueError, match='Attribute "meta" has no datatype defined in the schema.'
         ):
             dm.get_dtype("meta")
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -150,6 +150,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
 
 def test_implicit_creation_lower_dimensionality():
     with BasicModel(np.zeros((10, 20))) as m:
+        m.get_default("dq")
         assert m.dq.shape == (20,)
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -150,7 +150,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
 
 def test_implicit_creation_lower_dimensionality():
     with BasicModel(np.zeros((10, 20))) as m:
-        m.get_default("dq")
+        m.dq = m.get_default("dq")
         assert m.dq.shape == (20,)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,10 +70,10 @@ def test_object_attribute_assignment():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         model.meta.object_attribute = None
-    assert model.meta.object_attribute.string_attribute is None
+    assert model.meta.object_attribute is None
 
 
-def test_list_attribute_ssignment():
+def test_list_attribute_assignment():
     model = ValidationModel()
 
     assert len(model.meta.list_attribute) == 0
@@ -90,7 +90,7 @@ def test_list_attribute_ssignment():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         model.meta.list_attribute = None
-    assert len(model.meta.list_attribute) == 0
+    assert model.meta.list_attribute is None
 
 
 def test_object_assignment_with_nested_null():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -386,7 +386,7 @@ def test_validation_memory_leak():
     a reference to the assigned array.
     """
     # basic model validates `data` to be a float32 with 2 dimensions
-    model = BasicModel()
+    model = BasicModel((10, 10))
 
     # get the default array
     original_array = model.data


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR

- Allows setting of array-like attributes of models to `None`.  Previously, attempting this for an array with `ndim` in its schema would set the attribute to an ndarray of size 0 and that many dimensions.
- Makes `getattr` return `None` for un-initialized array-like attributes
- Fixes the bug where `getattr` and `hasattr` modified attributes.  For both data and metadata attributes, attempting to access an undefined attribute no longer sets that attribute to its schema-defined default, except if that attribute is an ObjectNode or ListNode.
- Preserves existing behavior that `hasattr` returns `True` for anything schema-defined, including data or metadata
- Adds `_DefaultErrMixin` and `_DQMixin` to replace `model.dq = model.dq` and `model.err = model.err` calls in class inits
- Adds `get_default` method to `ObjectNode` return the schema-defined default of an attribute.  This provides a way to explicitly generate a default array and replace e.g. `model.var_rnoise*=0`, `model.var_rnoise = model.var_rnoise`, or any of the other myriad ways that previously accessed an array trivially in order to set it to its default.
- Adds `get_dtype` method to `ObjectNode` to provide a convenient replacement for e.g. `model.spec_table = np.array(whatever, dtype=model.spec_table.dtype)` which is a common usage of the old default array setting behavior. This would now look like `model.spec_table = np.array(whatever, dtype=model.get_dtype("spec_table"))`

Example of the new hasattr and getattr behavior:
```
import stdatamodels.jwst.datamodels as dm
model = dm.ImageModel()
hasattr(model, "data")  # True
model.data is None  # True
"data" in model._instance  # False
hasattr(model.err)  # True
model.err is None  # True
"err" in model._instance  # False
model.info()  # does not contain data or err arrays at all
```

Example of new behavior when explicitly setting to None:
```
import stdatamodels.jwst.datamodels as dm
model = dm.ImageModel(strict_validation=True)
model.data = None
model.data is None  # True
model._instance["data"] is None  # True
model.validate()  # no errors
model.save("test.fits")

model2 = dm.open("test.fits")
data in model2._instance  # False
model2.data is None  # True
```
So the `None` in the instance is not preserved on save/load, but I think this is fine since `getattr` still returns None.

The changes here still allow `model.err = model.err` to be a valid construction in `__init__`, but it will no longer initialize to default; `model.err = model.err` is now equivalent to `model.err = None`.

The only side-effect that caused a failing stdatamodels unit test is that setting a tree that has a subtree to None makes it no longer accessible, i.e.
```
model = ImageModel()
hasattr(model.meta.observation, "date") # True
model.meta.observation = None
hasattr(model.meta.observation, "date")  # False
```
If this is not desired and we prefer it the old way, we can discuss options for that.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
