### PR TITLE
JP-4197: Add units to wfss photom ref file schemas

### DIFF
--- a/changes/665.feature.rst
+++ b/changes/665.feature.rst
@@ -1,0 +1,1 @@
+Add PHOTUNIT and WAVEUNIT attributes to WFSS photom ref file schemas

--- a/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
@@ -11,12 +11,12 @@ allOf:
 - type: object
   properties:
     phot_unit:
-      title: Photometric flux conversion unit
+      title: Unit of phot table photmjsr column
       fits_keyword: PHOTUNIT
       fits_hdu: PHOTOM
       type: string
     wave_unit:
-      title: Wavelength unit for photometric table
+      title: Unit of phot table wavelength column
       fits_keyword: WAVEUNIT
       fits_hdu: PHOTOM
       type: string

--- a/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
@@ -10,6 +10,18 @@ allOf:
 - $ref: keyword_pixelarea.schema
 - type: object
   properties:
+    phot_unit:
+      title: Photometric flux conversion unit
+      fits_keyword: PHOTUNIT
+      fits_hdu: PHOTOM
+      type: string
+    wave_unit:
+      title: Wavelength unit for photometric table
+      fits_keyword: WAVEUNIT
+      fits_hdu: PHOTOM
+      type: string
+- type: object
+  properties:
     phot_table:
       title: Photometric flux conversion factors table
       fits_hdu: PHOTOM

--- a/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/niswfss_photom.schema.yaml
@@ -20,8 +20,6 @@ allOf:
       fits_keyword: WAVEUNIT
       fits_hdu: PHOTOM
       type: string
-- type: object
-  properties:
     phot_table:
       title: Photometric flux conversion factors table
       fits_hdu: PHOTOM

--- a/src/stdatamodels/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
@@ -11,12 +11,12 @@ allOf:
 - type: object
   properties:
     phot_unit:
-      title: Photometric flux conversion unit
+      title: Unit of phot table photmjsr column
       fits_keyword: PHOTUNIT
       fits_hdu: PHOTOM
       type: string
     wave_unit:
-      title: Wavelength unit for photometric table
+      title: Unit of phot table wavelength column
       fits_keyword: WAVEUNIT
       fits_hdu: PHOTOM
       type: string

--- a/src/stdatamodels/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/nrcwfss_photom.schema.yaml
@@ -10,6 +10,18 @@ allOf:
 - $ref: keyword_pixelarea.schema
 - type: object
   properties:
+    phot_unit:
+      title: Photometric flux conversion unit
+      fits_keyword: PHOTUNIT
+      fits_hdu: PHOTOM
+      type: string
+    wave_unit:
+      title: Wavelength unit for photometric table
+      fits_keyword: WAVEUNIT
+      fits_hdu: PHOTOM
+      type: string
+- type: object
+  properties:
     phot_table:
       title: Photometric flux conversion factors table
       fits_hdu: PHOTOM


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Relates to [JP-4197](https://jira.stsci.edu/browse/JP-4197)

<!-- describe the changes comprising this PR here -->
This PR adds units attributes to the WFSS photom reference file schemas.  The new keyword will live in the PHOTOM fits header, and will be accessible via `model.wave_unit` and `model.phot_unit`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
