### PR TITLE
Bugfix for opening datamodels when a model as a string frame.

### DIFF
--- a/changes/667.bugfix.rst
+++ b/changes/667.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for possible string as a frame used in NIRCAM IFU WCS.

--- a/src/stdatamodels/jwst/datamodels/ifuimage.py
+++ b/src/stdatamodels/jwst/datamodels/ifuimage.py
@@ -1,3 +1,7 @@
+import warnings
+
+from gwcs import WCS, EmptyFrame, EmptyFrameDeprecationWarning, Frame2D, Step
+
 from .model_base import JwstDataModel
 
 __all__ = ["IFUImageModel"]
@@ -38,8 +42,30 @@ class IFUImageModel(JwstDataModel):
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/ifuimage.schema"
 
     def __init__(self, init=None, **kwargs):
-        super(IFUImageModel, self).__init__(init=init, **kwargs)
+        # Catch the possible usage of a string as the name of a frame for IFUImageModel.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", EmptyFrameDeprecationWarning)
+            super(IFUImageModel, self).__init__(init=init, **kwargs)
+
+        if any(issubclass(warn.category, EmptyFrameDeprecationWarning) for warn in w):
+            self._fix_wcs_empty_frame_name()
 
         # Implicitly create arrays
         self.dq = self.dq
         self.err = self.err
+
+    def _fix_wcs_empty_frame_name(self):
+        """Fix the name of the default frame if it was set to a string."""
+        input_step = self.meta.wcs.pipeline[0]
+        if not isinstance(input_step.frame, EmptyFrame):
+            raise TypeError("Cannot recover from unexpected string frame in WCS pipeline.")
+        else:
+            pipeline = [
+                Step(
+                    frame=Frame2D(name=input_step.frame.name, axes_order=(0, 1)),
+                    transform=input_step.transform,
+                )
+            ]
+            pipeline.extend(self.meta.wcs.pipeline[1:])
+
+            self.meta.wcs = WCS(forward_transform=pipeline)

--- a/tests/jwst/datamodels/test_wcs.py
+++ b/tests/jwst/datamodels/test_wcs.py
@@ -1,9 +1,11 @@
 import warnings
 
+import gwcs
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
+from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import FilteroffsetModel, ImageModel
 
 
@@ -111,3 +113,12 @@ def test_wcs_ref_models():
         fo.meta.instrument.channel = "SHORT"
         fo.meta.instrument.module = "A"
         fo.validate()
+
+
+def test_wcs_ifu_bad_frame(test_data_path):
+    path = test_data_path / "ifu_split_wcs.fits"
+
+    dm = datamodels.open(path)
+
+    assert isinstance(dm.meta.wcs.pipeline[0].frame, gwcs.Frame2D)
+    assert dm.meta.wcs.pipeline[0].frame.name == "coordinates"


### PR DESCRIPTION
PR spacetelescope/jwst#9452, introduced a GWCS with a malformed coordinate frame. GWCS technically allows for strings as coordinate frames but this is specifically frowned upon and was intended for testing only. GWCS is planning on removing support for such coordinate frames because it adds significant complications for GWCS to use a coordinate frame internally.

In spacetelescope/gwcs#714 and spacetelescope/gwcs#717 deprecation warnings for strings as coordinate frames are being introduced.

This PR resolves this issue regardless of how GWCS decides to change itself by detecting the case introduced into the `IFUImageModel` during its construction (which occurs during things like datamodel opening) and then updates the offending string-as-frame to a proper coordinate frame according to the fix in spacetelescope/jwst#10117. This results in a proper GWCS with a functional frame.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
