### PR TITLE
Fix Rotation3DToGWAConverter not accepting length-one rotations

### DIFF
--- a/changes/678.bugfix.rst
+++ b/changes/678.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Rotation3DToGWAConverter not accepting length-one rotation lists

--- a/src/stdatamodels/jwst/transforms/converters/jwst_models.py
+++ b/src/stdatamodels/jwst/transforms/converters/jwst_models.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import asdf
+import numpy as np
 from asdf_astropy.converters.transform.core import TransformConverterBase
 from astropy.modeling import Model
 
@@ -18,7 +19,6 @@ __all__ = [
     "NIRISSGrismDispersionConverter",
     "NirissSOSSConverter",
     "RefractionIndexConverter",
-    "Rotation3DToGWAConverter",
     "Rotation3DToGWAConverter",
     "Slit2GwaConverter",
     "Slit2MsaConverter",
@@ -382,7 +382,7 @@ class Rotation3DToGWAConverter(TransformConverterBase):
         return Rotation3DToGWA(angles, axes_order)
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        node = {"angles": list(model.angles.value)}
+        node = {"angles": list(np.atleast_1d(model.angles.value))}
         node["axes_order"] = model.axes_order
         return node
 

--- a/tests/jwst/transforms/test_models.py
+++ b/tests/jwst/transforms/test_models.py
@@ -28,6 +28,12 @@ test_models = [
     DirCos2Unitless(),
     Unitless2DirCos(),
     Rotation3DToGWA(angles=[12.1, 1.3, 0.5, 3.4], axes_order="xyzx"),
+    Rotation3DToGWA(
+        angles=[
+            45,
+        ],
+        axes_order="y",
+    ),
     AngleFromGratingEquation(20000, -1),
     WavelengthFromGratingEquation(25000, 2),
     Logical("GT", 5, 10),


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #604

<!-- describe the changes comprising this PR here -->
This PR addresses a bug where the converter for `Rotation3DToGWA` did not accept rotation lists with a single element.

jwst regression tests https://github.com/spacetelescope/RegressionTests/actions/runs/22527010363

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
