### PR TITLE
Deprecate init of new arrays during datamodels open

### DIFF
--- a/src/stdatamodels/jwst/datamodels/util.py
+++ b/src/stdatamodels/jwst/datamodels/util.py
@@ -1,5 +1,6 @@
 """Various utility functions and data types."""
 
+import inspect
 import io
 import logging
 import warnings
@@ -62,11 +63,8 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
         If not guess and the model type is not explicit, raise a TypeError.
     **kwargs
         Additional keyword arguments passed to the DataModel constructor.  Some arguments
-        are general, others are file format-specific.  Arguments of note are:
-
-        - validate_arrays : bool
-          If `True`, arrays will be validated against ndim, max_ndim, and datatype
-          validators in the schemas.
+        are general, others are file format-specific. See the docstring of
+        :func:`~stdatamodels.jwst.datamodels.JwstDataModel.__init__` for details.
 
     Returns
     -------
@@ -93,6 +91,20 @@ def open(init=None, guess=True, **kwargs):  # noqa: A001
             stacklevel=2,
         )
         kwargs.pop("memmap")
+
+    allowed_kwargs = inspect.getfullargspec(dm.JwstDataModel.__init__).args
+    allowed_kwargs.remove("self")
+    allowed_kwargs.remove("init")
+    for kwarg in kwargs:
+        if kwarg not in allowed_kwargs:
+            warnings.warn(
+                f"Keyword argument {kwarg} not supported by open function. "
+                "Passing arbitrary kwargs through open into JwstDataModel is deprecated; "
+                "only the following named arguments of the JwstDataModel constructor are allowed: "
+                f"{allowed_kwargs}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     # Initialize variables used to select model class
 

--- a/tests/jwst/datamodels/test_open.py
+++ b/tests/jwst/datamodels/test_open.py
@@ -374,3 +374,21 @@ def test_memmap_deprecation(tmp_path):
     with pytest.warns(DeprecationWarning, match="Memory mapping is no longer supported"):
         with datamodels.open(path, memmap=True):
             pass
+
+
+def test_open_unrecognized_kwarg(tmp_path):
+    """
+    Test that passing an unrecognized kwarg to datamodels.open raises a DeprecationWarning.
+    """
+    # save an empty datamodel
+    path = str(tmp_path / "test.fits")
+    model = ImageModel()
+    model.save(path)
+
+    # pass array-like data as a kwarg
+    err = np.ones((2, 2))
+    with pytest.warns(
+        DeprecationWarning, match="Keyword argument err not supported by open function."
+    ):
+        model = datamodels.open(path, err=err)
+    np.testing.assert_allclose(model.err, 1)


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Relates to #398 

Sort-of a follow-up to https://github.com/spacetelescope/stdatamodels/pull/533 

<!-- describe the changes comprising this PR here -->
This PR makes it so the following raises a DeprecationWarning at the second-to-last line:
```
import stdatamodels.jwst.datamodels as dm
import numpy as np
model = dm.ImageModel()
fname = "test.fits"
model.save(fname)
data = np.ones((3,3))*5
model = dm.open(fname, data=data)
model.data  # 3x3 array filled with 5s
```

I elected to go with a deprecation warning since this breaks an allowed usage of `open` but given this is highly unlikely to be in widespread use (and that it sounds like the next stdatamodels version will be major anyway) I could be convinced to call this a bugfix and skip the deprecation period.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
