### PR TITLE
JP-4268: Remove PastasossModel padding attribute from schema

### DIFF
--- a/changes/685.removal.rst
+++ b/changes/685.removal.rst
@@ -1,0 +1,1 @@
+Remove unused attribute 'padding' from PastasossModel schema

--- a/src/stdatamodels/jwst/datamodels/schemas/pastasossmodel.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/pastasossmodel.schema.yaml
@@ -70,10 +70,6 @@ allOf:
             title: Pixel oversampling
             type: integer
             default: 1
-          padding:
-            title: Native pixel-size padding around the image
-            type: integer
-            default: 0
           cutoff:
             title: Pixel cutoff for trace validity
             type: integer


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-4268](https://jira.stsci.edu/browse/JP-4268)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #684 

<!-- describe the changes comprising this PR here -->
This PR removes an unused attribute from the pastasoss ref file schema.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
