### PR TITLE
JP-4228: Disable default metadata setting on access

### DIFF
--- a/changes/688.bugfix.rst
+++ b/changes/688.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where accessing metadata attributes that did not exist would set them to default values

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -394,8 +394,8 @@ class ObjectNode(Node):
             # If so it's assumed to be a node, and must be created to allow nested attribute access.
             # Otherwise, return None and don't set anything
             val = _make_default(attr, schema, self._ctx)
-            # if not isinstance(val, (dict, list)):
-            #     return None
+            if not isinstance(val, (dict, list)):
+                return None
             if val is not None:
                 self._instance[attr] = val
 

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -651,7 +651,6 @@ def test_amioi_model_oifits_compliance(tmp_path, oifits_ami_model):
     oifits_ami_model.save(fn)
 
 
-@pytest.mark.xfail(reason="fails when reverting default meta behavior")
 @pytest.mark.parametrize(
     "attr",
     [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -238,7 +238,6 @@ def test_get_default_attribute_error():
             im.get_default("non_existent_attribute")
 
 
-@pytest.mark.xfail(reason="fails when reverting default meta behavior")
 def test_implicit_meta_none():
     """
     Test access to undefined metadata attributes.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Relates to [JP-4228](https://jira.stsci.edu/browse/JP-4228)

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where accessing a metadata attribute that was not yet defined in a model would cause it to be set to its default; see example.

Old behavior:

```
import stdatamodels.jwst.datamodels as dm
model = dm.SlitModel()
"source_id" in model  # False
model.source_id  # 0
"source_id" in model  # True
```

New behavior:

```
model = dm.SlitModel()
"source_id" in model  # False
model.source_id  # None
"source_id" in model  # False
```


Must be coordinated with https://github.com/spacetelescope/jwst/pull/10344

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
