### PR TITLE
JP-4296: Fix model equality comparison for numpy copies

### DIFF
--- a/changes/692.bugfix.rst
+++ b/changes/692.bugfix.rst
@@ -1,1 +1,1 @@
-Catch array comparison errors in datamodel equality checks and return False in that case.
+Fix a bug where comparing the equality of two datamodels would cause a crash if their arrays were not the same, instead of returning False.

--- a/changes/692.bugfix.rst
+++ b/changes/692.bugfix.rst
@@ -1,0 +1,1 @@
+Catch array comparison errors in datamodel equality checks and return False in that case.

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -344,6 +344,21 @@ class Node:
         self._ctx = ctx
         self._parent = parent
 
+    def __eq__(self, other):
+        if isinstance(other, Node):
+            try:
+                # Try a simple equality check first.  This will pass if
+                # any internal numpy arrays reference the same object.
+                return self._instance == other._instance
+            except ValueError:
+                # If it fails (e.g. internal numpy arrays are copies), then
+                # return False.  Copies are not considered equal.
+                return False
+        else:
+            # For non-node comparisons, allow equality checks to fail
+            # in complex cases
+            return self._instance == other
+
     def _validate(self):
         return validate.value_change(self._name, self._instance, self._schema, self._ctx)
 
@@ -358,21 +373,6 @@ class ObjectNode(Node):
     def __dir__(self):
         added = set(self._schema.get("properties", {}).keys())
         return sorted(set(super().__dir__()) | added)
-
-    def __eq__(self, other):
-        if isinstance(other, ObjectNode):
-            try:
-                # Try a simple equality check first.  This will pass if
-                # the internal numpy arrays reference the same object.
-                return self._instance == other._instance
-            except ValueError:
-                # If it fails (e.g. internal numpy arrays are copies), then
-                # return False.  Copies are not considered equal.
-                return False
-        else:
-            # For non-node comparisons to arrays, allow equality checks to fail
-            # in complex cases
-            return self._instance == other
 
     def __getattr__(self, attr):
         if attr.startswith("_"):
@@ -523,21 +523,6 @@ class ListNode(Node):
 
     def __repr__(self):
         return repr(self._instance)
-
-    def __eq__(self, other):
-        if isinstance(other, ListNode):
-            try:
-                # Try a simple equality check first.  This will pass if
-                # the internal numpy arrays reference the same object.
-                return self._instance == other._instance
-            except ValueError:
-                # If it fails (e.g. internal numpy arrays are copies), then
-                # return False.  Copies are not considered equal.
-                return False
-        else:
-            # For non-node comparisons to arrays, allow equality checks to fail
-            # in complex cases
-            return self._instance == other
 
     def __contains__(self, item):
         return item in self._instance

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -521,19 +521,23 @@ class ObjectNode(Node):
 class ListNode(Node):
     """A list-like object that supports validation against a schema."""
 
-    def __cast(self, other):
-        if isinstance(other, ListNode):
-            return other._instance
-        return other
-
     def __repr__(self):
         return repr(self._instance)
 
     def __eq__(self, other):
-        return self._instance == self.__cast(other)
-
-    def __ne__(self, other):
-        return self._instance != self.__cast(other)
+        if isinstance(other, ListNode):
+            try:
+                # Try a simple equality check first.  This will pass if
+                # the internal numpy arrays reference the same object.
+                return self._instance == other._instance
+            except ValueError:
+                # If it fails (e.g. internal numpy arrays are copies), then
+                # return False.  Copies are not considered equal.
+                return False
+        else:
+            # For non-node comparisons to arrays, allow equality checks to fail
+            # in complex cases
+            return self._instance == other
 
     def __contains__(self, item):
         return item in self._instance

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -361,8 +361,17 @@ class ObjectNode(Node):
 
     def __eq__(self, other):
         if isinstance(other, ObjectNode):
-            return self._instance == other._instance
+            try:
+                # Try a simple equality check first.  This will pass if
+                # the internal numpy arrays reference the same object.
+                return self._instance == other._instance
+            except ValueError:
+                # If it fails (e.g. internal numpy arrays are copies), then
+                # return False.  Copies are not considered equal.
+                return False
         else:
+            # For non-node comparisons to arrays, allow equality checks to fail
+            # in complex cases
             return self._instance == other
 
     def __getattr__(self, attr):

--- a/tests/schemas/validation_model.yaml
+++ b/tests/schemas/validation_model.yaml
@@ -25,4 +25,14 @@ allOf:
               properties:
                 string_attribute:
                   type: string
+          list_of_data_attribute:
+            type: array
+            items:
+              ndim: 2
+              datatype: float32
+              default: 0.0
+          list_of_string_attribute:
+            type: array
+            items:
+              type: string
 ...

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -603,6 +603,14 @@ def test_model_equality_no_arrays():
 
 
 def test_model_compare_to_dict():
+    """
+    Compare a DataModel to a dictionary.
+
+    This test exercises a currently supported behavior: DataModel
+    equality is implemented in ObjectNode, which allows direct
+    comparison between dictionaries and nodes. Support for DataModel
+    equality to dictionaries may be removed in the future.
+    """
     with BasicModel() as dm1:
         # comparing a simple node to a dictionary works
         compare = {"meta": {"model_type": "BasicModel"}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ from .models import (
     TableModel,
     TableModelBad,
     TransformModel,
+    ValidationModel,
 )
 
 
@@ -623,3 +624,53 @@ def test_model_compare_to_dict():
         compare["data"] = data.copy()
         with pytest.raises(ValueError, match=msg):
             assert dm1 == compare
+
+
+def test_list_node_eq_with_arrays():
+    with ValidationModel() as dm1:
+        data1 = np.zeros((10, 10))
+        data2 = np.ones((10, 10))
+        data_list = [data1, data2]
+        dm1.meta.list_of_data_attribute = data_list
+
+        # nodes with copied arrays are not equal
+        dm2 = dm1.copy()
+        assert dm2.meta.list_of_data_attribute != dm1.meta.list_of_data_attribute
+
+        # models with the same underlying array are equal
+        dm2.meta.list_of_data_attribute = [data1, data2]
+        assert dm2.meta.list_of_data_attribute == dm1.meta.list_of_data_attribute
+
+        dm2.close()
+
+
+def test_list_node_eq_no_arrays():
+    with ValidationModel() as dm1:
+        dm1.meta.list_of_string_attribute = ["a", "b"]
+
+        # nodes with copies of simple lists are equal
+        dm2 = dm1.copy()
+        assert dm2.meta.list_of_string_attribute == dm1.meta.list_of_string_attribute
+
+        dm2.close()
+
+
+def test_list_node_compare_to_list():
+    with ValidationModel() as dm1:
+        dm1.meta.list_of_string_attribute = ["a", "b"]
+        data1 = np.zeros((10, 10))
+        data2 = np.ones((10, 10))
+        dm1.meta.list_of_data_attribute = [data1, data2]
+
+        # comparing a simple node to a list works
+        assert dm1.meta.list_of_string_attribute == ["a", "b"]
+        assert dm1.meta.list_of_string_attribute != ["a", "c"]
+
+        # comparing to a list of data that contains the same arrays will pass
+        assert dm1.meta.list_of_data_attribute == [data1, data2]
+        assert dm1.meta.list_of_data_attribute != [data1]
+
+        # comparing to a copy will fail
+        msg = "The truth value of an array with more than one element is ambiguous"
+        with pytest.raises(ValueError, match=msg):
+            assert dm1.meta.list_of_data_attribute == [data1.copy(), data2.copy()]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -565,3 +565,61 @@ def test_open_from_file_with_kwargs_deprecation(tmp_path):
 
     with pytest.warns(DeprecationWarning, match="Unrecognized keyword arguments"):
         DataModel(fn, data=np.ones((10, 10)))
+
+
+def test_model_equality_with_arrays():
+    with BasicModel((50, 50)) as dm1:
+        dm1.meta.telescope == "telescope1"
+
+        # models with copied arrays are not equal
+        dm2 = dm1.copy()
+        assert dm2 != dm1
+
+        # models with the same underlying array are equal
+        dm2.data = dm1.data
+        assert dm2 == dm1
+
+        # models with the same array but mismatched metadata are not equal
+        dm2.meta.telescope = "telescope2"
+        assert dm2 != dm1
+
+        dm2.close()
+
+
+def test_model_equality_no_arrays():
+    with BasicModel() as dm1:
+        dm1.meta.telescope == "telescope1"
+
+        # copied models with no arrays are equal
+        dm2 = dm1.copy()
+        assert dm2 == dm1
+
+        # models with mismatched metadata are not equal
+        dm2.meta.telescope = "telescope2"
+        assert dm2 != dm1
+
+        dm2.close()
+
+
+def test_model_compare_to_dict():
+    with BasicModel() as dm1:
+        # comparing a simple node to a dictionary works
+        compare = {"meta": {"model_type": "BasicModel"}}
+        assert dm1 == compare
+        compare = {"meta": {"model_type": "BasicModel", "telescope": "test"}}
+        assert dm1 != compare
+
+        # add a data array
+        data = np.zeros((10, 10))
+        dm1.data = data
+
+        # comparing a node to a dictionary with an array, whether copied or not,
+        # raises a value error
+        msg = "The truth value of an array with more than one element is ambiguous"
+        compare = {"meta": {"model_type": "BasicModel"}, "data": data}
+        with pytest.raises(ValueError, match=msg):
+            assert dm1 == compare
+
+        compare["data"] = data.copy()
+        with pytest.raises(ValueError, match=msg):
+            assert dm1 == compare

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -93,6 +93,31 @@ def test_list_attribute_assignment():
     assert model.meta.list_attribute is None
 
 
+def test_list_of_data_attribute_assignment():
+    model = ValidationModel()
+    data1 = np.zeros((10, 10))
+
+    assert len(model.meta.list_of_data_attribute) == 0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model.meta.list_of_data_attribute.append(data1)
+    assert np.all(model.meta.list_of_data_attribute[0] == data1)
+
+    # Attempt to append an array with the wrong number of dimensions.
+    # This should probably raise a ValidationWarning but currently raises a ValueError.
+    # with pytest.warns(ValidationWarning):
+    with pytest.raises(ValueError, match="Array has wrong number of dimensions"):
+        model.meta.list_of_data_attribute.append(np.ones(10))
+    assert len(model.meta.list_of_data_attribute) == 1
+    assert np.all(model.meta.list_of_data_attribute[0] == data1)
+
+    # Assigning to None is allowed.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model.meta.list_of_data_attribute = None
+    assert model.meta.list_of_data_attribute is None
+
+
 def test_object_assignment_with_nested_null():
     model = ValidationModel()
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4296](https://jira.stsci.edu/browse/JP-4296)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

Currently, the datamodel `__eq__` comparison is a bit naive: it crashes with a ValueError if the datamodel contains a numpy array that is not the exact same object on both sides of the comparison.  This makes it difficult to do checks like `datamodel in list_of_datamodels`.

Proposed fix here is to just catch this error case and return False: copied numpy arrays should not be considered equal.  Effectively, shallow copies of datamodels can be equal, but deep copies cannot. This is much simpler than attempting to do an array comparison on elements within the node instance, doesn't break any existing working use cases for equality checks, and returns a useful answer for whether a datamodel instance is "in" a list.

Companion PR in jwst to update a couple unit tests:
https://github.com/spacetelescope/jwst/pull/10385

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
