### PR TITLE
Remove deprecated kwargs in asdf_in_fits.open

### DIFF
--- a/changes/693.removal.rst
+++ b/changes/693.removal.rst
@@ -1,0 +1,1 @@
+Disable passing keyword arguments through asdf_in_fits.open and fits_support.from_fits_asdf into asdf.open (deprecated since 4.1.0

--- a/changes/693.removal.rst
+++ b/changes/693.removal.rst
@@ -1,1 +1,1 @@
-Disable passing keyword arguments through asdf_in_fits.open and fits_support.from_fits_asdf into asdf.open (deprecated since 4.1.0
+Disable passing keyword arguments through asdf_in_fits.open and fits_support.from_fits_asdf into asdf.open (deprecated since 4.1.0).

--- a/src/stdatamodels/asdf_in_fits.py
+++ b/src/stdatamodels/asdf_in_fits.py
@@ -1,5 +1,3 @@
-import warnings
-
 import asdf
 from astropy.io import fits
 
@@ -56,7 +54,7 @@ def write(filename, tree, hdulist=None, **kwargs):
     to_hdulist(tree, hdulist=hdulist).writeto(filename, **kwargs)
 
 
-def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False, **kwargs):  # noqa: A001
+def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_tag=False):  # noqa: A001
     """
     Read ASDF data embedded in a fits file.
 
@@ -72,9 +70,6 @@ def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_t
     ignore_unrecognized_tag : bool, optional
         If `True`, ignore unrecognized tags in the ASDF data.
         Defaults to `False`.
-    **kwargs
-        Additional keyword arguments to pass to asdf.open.
-        Usage of kwargs is deprecated and will be removed in a future version.
 
     Returns
     -------
@@ -82,20 +77,12 @@ def open(filename_or_hdu, ignore_missing_extensions=False, ignore_unrecognized_t
         :obj:`asdf.AsdfFile` created from ASDF data embedded in the opened
         FITS file.
     """
-    if kwargs:
-        warnings.warn(
-            "Passing additional keyword arguments from asdf_in_fits.open into asdf.open "
-            "is deprecated and will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     is_hdu = isinstance(filename_or_hdu, fits.HDUList)
     hdulist = filename_or_hdu if is_hdu else fits.open(filename_or_hdu)
     af = fits_support.from_fits_asdf(
         hdulist,
         ignore_missing_extensions=ignore_missing_extensions,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
-        **kwargs,
     )
 
     if is_hdu:

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -821,7 +821,9 @@ def from_fits(
 
 
 def from_fits_asdf(
-    hdulist, ignore_unrecognized_tag=False, ignore_missing_extensions=False, **kwargs
+    hdulist,
+    ignore_unrecognized_tag=False,
+    ignore_missing_extensions=False,
 ):
     """
     Open the ASDF extension from a FITS HDUlist.
@@ -836,9 +838,6 @@ def from_fits_asdf(
     ignore_missing_extensions : bool
         When `True`, ignore missing extensions in the ASDF file.
         When `False`, raise an error when an extension is missing.
-    **kwargs : dict
-        Additional keyword arguments to pass to `asdf.open`.
-        Usage of kwargs is deprecated and will be removed in a future version.
 
     Returns
     -------
@@ -858,7 +857,6 @@ def from_fits_asdf(
         generic_file,
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         ignore_missing_extensions=ignore_missing_extensions,
-        **kwargs,
     )
     # map hdulist to blocks here
     _map_hdulist_to_arrays(hdulist, af)

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -193,17 +193,3 @@ def test_open_asdf_in_fits_hdu(saved_array_model, test_array):
             assert_array_almost_equal(af["data"], test_array)
         # make sure file was not closed with context
         assert not hdu.fileinfo(0)["file"].closed
-
-
-def test_deprecated_kwargs_warning(saved_array_model):
-    """
-    Test that a warning is raised when passing additional
-    keyword arguments to asdf_in_fits.open.
-    """
-    with pytest.warns(
-        DeprecationWarning,
-        match="Passing additional keyword arguments from asdf_in_fits.open into asdf.open "
-        "is deprecated and will be removed in a future version.",
-    ):
-        with asdf_in_fits.open(saved_array_model, lazy_load=True) as af:
-            assert af is not None


### PR DESCRIPTION
Closes #538 

<!-- describe the changes comprising this PR here -->
This PR removes a deprecation that has been in place for multiple builds.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
