### PR TITLE
Remove interpret bit flags

### DIFF
--- a/changes/694.removal.rst
+++ b/changes/694.removal.rst
@@ -1,0 +1,1 @@
+Remove dqflags.interpret_bit_flags (deprecated since 3.1.0)

--- a/src/stdatamodels/dqflags.py
+++ b/src/stdatamodels/dqflags.py
@@ -6,64 +6,7 @@ The flags are binary-packed structures representing information about a given el
 If a given bit is set, the flag assigned to that bit is interpreted as being set or active.
 """
 
-import warnings
-
-from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
-
-from stdatamodels.basic_utils import multiple_replace
-
-__all__ = ["dqflags_to_mnemonics", "interpret_bit_flags"]
-
-
-def interpret_bit_flags(bit_flags, flip_bits=None, mnemonic_map=None):
-    """
-    Convert input bit flags to a single integer value (bit mask) or `None`.
-
-    .. deprecated:: 3.0
-       Use `astropy.nddata.bitmask.interpret_bit_flags` instead.
-       Note that the ``mnemonic_map`` parameter is named ``flag_name_map`` in the astropy version.
-       Note also that the astropy version does not support whitespace between flags,
-       e.g., "DO_NOT_USE+WARM" will work as expected, but "DO_NOT_USE + WARM" will not.
-
-    Wraps `astropy.nddata.bitmask.interpret_bit_flags`, allowing the
-    bit mnemonics to be used in place of integers.
-
-    Parameters
-    ----------
-    bit_flags : int, str, list, None
-        See `astropy.nddata.bitmask.interpret_bit_flags`.
-        Also allows strings using Roman mnemonics
-
-    flip_bits : bool, None
-        See `astropy.nddata.bitmask.interpret_bit_flags`.
-
-    mnemonic_map : dict
-        Dictionary associating the mnemonic string to an integer value
-        representing the set bit for that mnemonic.
-
-    Returns
-    -------
-    bitmask : int or None
-        Returns an integer bit mask formed from the input bit value or `None`
-        if input ``bit_flags`` parameter is `None` or an empty string.
-        If input string value was prepended with '~' (or ``flip_bits`` was set
-        to `True`), then returned value will have its bits flipped
-        (inverse mask).
-    """
-    warnings.warn(
-        "The interpret_bit_flags function is deprecated and will be removed in a future version. "
-        "Use astropy.nddata.bitmask.interpret_bit_flags instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if mnemonic_map is None:
-        raise TypeError("`mnemonic_map` is a required argument")
-    bit_flags_dm = bit_flags
-    if isinstance(bit_flags, str):
-        dm_flags = {key: str(val) for key, val in mnemonic_map.items()}
-        bit_flags_dm = multiple_replace(bit_flags, dm_flags)
-
-    return ap_interpret_bit_flags(bit_flags_dm, flip_bits=flip_bits)
+__all__ = ["dqflags_to_mnemonics"]
 
 
 def dqflags_to_mnemonics(dqflags, mnemonic_map):

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -16,7 +16,6 @@ the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 
 # These imports are here for backwards compatibility
 from astropy.nddata.bitmask import ap_interpret_bit_flags
-from astropy.nddata.bitmask import interpret_bit_flags as interpret_bit_flags
 
 from stdatamodels.basic_utils import multiple_replace
 from stdatamodels.dqflags import dqflags_to_mnemonics
@@ -75,7 +74,6 @@ __all__ = [
     "ap_interpret_bit_flags",
     "dqflags_to_mnemonics",
     "group",
-    "interpret_bit_flags",
     "multiple_replace",
     "pixel",
 ]

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -15,7 +15,7 @@ the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 """
 
 # These imports are here for backwards compatibility
-from astropy.nddata.bitmask import ap_interpret_bit_flags
+from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
 
 from stdatamodels.basic_utils import multiple_replace
 from stdatamodels.dqflags import dqflags_to_mnemonics

--- a/src/stdatamodels/jwst/datamodels/dqflags.py
+++ b/src/stdatamodels/jwst/datamodels/dqflags.py
@@ -15,10 +15,11 @@ the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 """
 
 # These imports are here for backwards compatibility
-from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
+from astropy.nddata.bitmask import ap_interpret_bit_flags
+from astropy.nddata.bitmask import interpret_bit_flags as interpret_bit_flags
 
 from stdatamodels.basic_utils import multiple_replace
-from stdatamodels.dqflags import dqflags_to_mnemonics, interpret_bit_flags
+from stdatamodels.dqflags import dqflags_to_mnemonics
 
 # Pixel-specific flags
 pixel = {

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -1,6 +1,3 @@
-import pytest
-from astropy.nddata.bitmask import interpret_bit_flags as ap_interpret_bit_flags
-
 from stdatamodels import dqflags
 from stdatamodels.jwst.datamodels.dqflags import pixel
 
@@ -8,6 +5,3 @@ from stdatamodels.jwst.datamodels.dqflags import pixel
 def test_dqflags():
     assert dqflags.dqflags_to_mnemonics(1, pixel) == {"DO_NOT_USE"}
     assert dqflags.dqflags_to_mnemonics(7, pixel) == {"JUMP_DET", "DO_NOT_USE", "SATURATED"}
-    with pytest.warns(DeprecationWarning):
-        assert dqflags.interpret_bit_flags("DO_NOT_USE + WARM", mnemonic_map=pixel) == 4097
-    assert ap_interpret_bit_flags("DO_NOT_USE+WARM", flag_name_map=pixel) == 4097


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #559 

<!-- describe the changes comprising this PR here -->
This PR removes a method that has been deprecated for a while.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
