### PR TITLE
Move custom zeroframe handling from properties.py into get_default overrides

### DIFF
--- a/src/stdatamodels/jwst/datamodels/level1b.py
+++ b/src/stdatamodels/jwst/datamodels/level1b.py
@@ -62,3 +62,31 @@ class Level1bModel(JwstDataModel):
 
     def _migrate_hdulist(self, hdulist):
         return _migrate_moving_target_table(hdulist)
+
+    def get_default(self, attr):
+        """
+        Retrieve the schema-defined default value of an attribute.
+
+        Override the parent method to give zeroframe the correct shape.
+
+        Parameters
+        ----------
+        attr : str
+            Attribute to set to its default value.
+
+        Returns
+        -------
+        object or None
+            The default value for the given attribute. If the attribute is schema-defined
+            but has no default value in the schema, this will return None.
+
+        Raises
+        ------
+        AttributeError
+            If the given attribute is not defined in the schema.
+        """
+        if attr == "zeroframe" and self.data is not None:
+            shp = (self.data.shape[0],) + self.data.shape[-2:]
+            return np.zeros(shp, dtype=np.float32)
+
+        return super().get_default(attr)

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -71,4 +71,8 @@ class RampModel(JwstDataModel):
         if attr == "pixeldq" and self.data is not None:
             return np.zeros(self.data.shape[-2:], dtype=np.uint32)
 
+        if attr == "zeroframe" and self.data is not None:
+            shp = (self.data.shape[0],) + self.data.shape[-2:]
+            return np.zeros(shp, dtype=np.float32)
+
         return super().get_default(attr)

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -46,6 +46,8 @@ class RampModel(JwstDataModel):
 
         Overrides the parent method to set pixeldq to a 2D array if
         data is defined.
+        Override the parent method to give zeroframe the correct shape
+        if data is defined.
 
         Parameters
         ----------

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -225,15 +225,7 @@ def _make_default_array(attr, schema, ctx):
                 if ndim is None:
                     shape = primary_array.shape
                 else:
-                    if attr == "zeroframe":
-                        dims = primary_array.shape
-                        if len(dims) != 4:
-                            error_msg = "To allocate ZEROFRAME, the primary array must "
-                            error_msg += f"have 4 dimensions, but has {len(dims)}."
-                            raise IndexError(error_msg)
-                        shape = (dims[0], dims[2], dims[3])
-                    else:
-                        shape = primary_array.shape[-ndim:]
+                    shape = primary_array.shape[-ndim:]
             elif ndim is None:
                 shape = (0,)
             else:

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -460,7 +460,8 @@ def test_ramp_model_zero_frame_open_file(tmp_path):
         np.testing.assert_allclose(zframe0, zframe1, 1.0e-5)
 
 
-def test_ramp_model_zero_frame_by_dimensions():
+@pytest.mark.parametrize("ModelType", [datamodels.Level1bModel, datamodels.RampModel])
+def test_ramp_model_zero_frame_by_dimensions(ModelType):
     """
     Ensures creating a RampModel by dimensions results in the correct
     dimensions for ZEROFRAME.
@@ -469,7 +470,7 @@ def test_ramp_model_zero_frame_by_dimensions():
     dims = (nints, ngroups, nrows, ncols)
     zdims = (nints, nrows, ncols)
 
-    with datamodels.RampModel(dims) as ramp:
+    with ModelType(dims) as ramp:
         ramp.zeroframe = ramp.get_default("zeroframe")
         assert ramp.zeroframe.shape == zdims
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR cleans up a custom override that's only relevant for `RampModel` and `Level1bModel` by taking it out of the base code and putting it into the `get_default` methods of those classes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
