### PR TITLE
JP-4242: Add trace_model to slit model

### DIFF
--- a/changes/697.feature.rst
+++ b/changes/697.feature.rst
@@ -1,0 +1,1 @@
+Add a trace model image to slit datamodels.

--- a/src/stdatamodels/jwst/datamodels/schemas/ifuimage.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ifuimage.schema.yaml
@@ -41,6 +41,7 @@ allOf:
       title: Trace model
       fits_hdu: TRACEMODEL
       datatype: float32
+      ndim: 2
 - $ref: variance.schema
 - type: object
   properties:

--- a/src/stdatamodels/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -47,6 +47,11 @@ allOf:
       fits_hdu: CON
       default: 0
       datatype: int32
+    trace_model:
+      title: Trace model
+      fits_hdu: TRACEMODEL
+      datatype: float32
+      ndim: 2
 - $ref: variance.schema
 - $ref: flatcorr.schema
 - $ref: pathlosscorr.schema

--- a/src/stdatamodels/jwst/datamodels/slit.py
+++ b/src/stdatamodels/jwst/datamodels/slit.py
@@ -39,6 +39,8 @@ class SlitDataModel(JwstDataModel):
         photom array for uniform source
     area : numpy float32 array
         Pixel area map array
+    trace_model : numpy float32 array
+        Trace model array
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/slitdata.schema"
@@ -91,6 +93,8 @@ class SlitModel(JwstDataModel):
         Photom array for uniform source
     area : numpy float32 array
         Pixel area map array
+    trace_model : numpy float32 array
+        Trace model array
     int_times : numpy table
         Table of times for each integration
     """

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -65,12 +65,19 @@ def test_multislit():
         slit.data = rng.random((5, 5))
         slit.dm = rng.random((5, 5))
         slit.err = rng.random((5, 5))
-        for attr in ["wavelength", "pathloss_point", "pathloss_uniform", "barshadow"]:
+        for attr in [
+            "wavelength",
+            "pathloss_point",
+            "pathloss_uniform",
+            "barshadow",
+            "trace_model",
+        ]:
             setattr(dm.slits[-1], attr, dm.slits[-1].get_default(attr))
         assert slit.wavelength.shape == (0, 0)
         assert slit.pathloss_point.shape == (0, 0)
         assert slit.pathloss_uniform.shape == (0, 0)
         assert slit.barshadow.shape == (0, 0)
+        assert slit.trace_model.shape == (0, 0)
 
 
 def test_multislit_from_image():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4242](https://jira.stsci.edu/browse/JP-4242)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Add trace_model to slit data.

JWST PR that uses these changes: https://github.com/spacetelescope/jwst/pull/10264

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
