### PR TITLE
Change fwpostol and pwpostol to be strings per SDP request

### DIFF
--- a/changes/699.bugfix.rst
+++ b/changes/699.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect datatype for FWPOSTOL and PWPOSTOL

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -466,7 +466,7 @@ properties:
             blend_rule: max
           filter_wheel_tolerance:
             title: Filter wheel position tolerance
-            type: number
+            type: string
             fits_keyword: FWPOSTOL
             blend_table: True
             blend_rule: max
@@ -492,7 +492,7 @@ properties:
             blend_rule: max
           pupil_wheel_tolerance:
             title: Pupil wheel position tolerance
-            type: number
+            type: string
             fits_keyword: PWPOSTOL
             blend_table: True
             blend_rule: max

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -469,7 +469,6 @@ properties:
             type: string
             fits_keyword: FWPOSTOL
             blend_table: True
-            blend_rule: max
           pupil:
             title: Name of the pupil element used
             type: string
@@ -495,7 +494,6 @@ properties:
             type: string
             fits_keyword: PWPOSTOL
             blend_table: True
-            blend_rule: max
           grating:
             title: Name of the grating element used
             type: string


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses a bug reported by SDP that they store the FWPOSTOL and PWPOSTOL keywords as strings while we do not, causing issues.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
