### PR TITLE
Fix failure to update model type

### DIFF
--- a/changes/706.bugfix.rst
+++ b/changes/706.bugfix.rst
@@ -1,1 +1,1 @@
-Fix a bug where initializing a model from a different (but compatible) model type did not update model.meta.model_type
+Fix a bug where initializing a model from a different (but compatible) model type did not update ``model.meta.model_type``

--- a/changes/706.bugfix.rst
+++ b/changes/706.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where initializing a model from a different (but compatible) model type did not update model.meta.model_type

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -322,8 +322,9 @@ It's also possible to convert between compatible model types this way, e.g.::
     old_model = ImageModel()
     new_model = IFUImageModel(old_model)
 
-and in this case, a deep copy of the metadata will be performed but the data
-arrays will be shallow-copied for memory efficiency.
+and in this case, ``new_model is old_model`` will be ``False``. Simple metadata will be copied and
+the ``meta.model_type`` attribute will be updated, but data arrays and other complex types (e.g.,
+the WCS object) will be shared between the two models.
 
 
 History information

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -306,6 +306,25 @@ model into a new one using the :meth:`~stdatamodels.DataModel.update` method::
 
     new_model.update(old_model)
 
+While it's typically not recommended for general use due to the possibility of
+unexpected behavior, copying a model can be achieved by passing it into
+a constructor of the same type::
+
+    old_model = ImageModel()
+    new_model = ImageModel(old_model)
+
+This simply creates a new reference to the model object, i.e. ``new_model is old_model`` will be ``True``.
+Changes to one model will affect the other.
+
+It's also possible to convert between compatible model types this way, e.g.::
+
+    old_model = ImageModel()
+    new_model = IFUImageModel(old_model)
+
+and in this case, a deep copy of the metadata will be performed but the data
+arrays will be shallow-copied for memory efficiency.
+
+
 History information
 -------------------
 

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -35,7 +35,8 @@ see everything that's currently in the model::
     └─date (str): 2026-02-26T14:56:12.278
 
 Notice that only the primary array ("data") is allocated, has the shape we put in,
-and has a data type of float32 as defined by the `ImageModel` schema.
+and has a data type of float32 as defined by the
+:class:`~stdatamodels.jwst.datamodels.ImageModel` schema.
 To set additional arrays to their default values, use the
 ``get_default`` method::
 

--- a/docs/source/jwst/datamodels/models.rst
+++ b/docs/source/jwst/datamodels/models.rst
@@ -314,17 +314,18 @@ a constructor of the same type::
     old_model = ImageModel()
     new_model = ImageModel(old_model)
 
-This simply creates a new reference to the model object, i.e. ``new_model is old_model`` will be ``True``.
-Changes to one model will affect the other.
+This will perform a shallow copy: in this case ``old_model.instance == new_model.instance``,
+and changes to one model will affect the other.
 
 It's also possible to convert between compatible model types this way, e.g.::
 
     old_model = ImageModel()
     new_model = IFUImageModel(old_model)
 
-and in this case, ``new_model is old_model`` will be ``False``. Simple metadata will be copied and
-the ``meta.model_type`` attribute will be updated, but data arrays and other complex types (e.g.,
-the WCS object) will be shared between the two models.
+This will also perform a shallow copy, except
+that some metadata elements (such as ``meta.model_type``) will be updated and therefore
+``old_model.instance != new_model.instance``. Almost all attributes will still be shared
+between models, so changes to one will affect the other.
 
 
 History information

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -221,7 +221,7 @@ class DataModel(properties.ObjectNode):
                 # but share the same data arrays.
                 self._instance = copy.copy(self._instance)
                 if "meta" in self._instance:
-                    self._instance["meta"] = copy.deepcopy(self._instance["meta"])
+                    self._instance["meta"] = copy.copy(self._instance["meta"])
 
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -220,6 +220,7 @@ class DataModel(properties.ObjectNode):
                 self._validate_arrays = True
                 self.validate()
                 self._validate_arrays = current_validate_arrays
+            self.meta.model_type = self._model_type
             return
 
         elif isinstance(init, AsdfFile):
@@ -551,8 +552,7 @@ class DataModel(properties.ObjectNode):
         # store the data model type, if not already set
         klass = self.__class__.__name__
         if klass != "DataModel":
-            if not self.meta.hasattr("model_type"):
-                self.meta.model_type = klass
+            self.meta.model_type = klass
 
     def on_save(self, path=None):
         """

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -216,11 +216,18 @@ class DataModel(properties.ObjectNode):
             asdffile = None
             self.clone(self, init)
             if not isinstance(init, self.__class__):
+                # In this case we want the models to be different instances,
+                # have different metadata (e.g. meta.model_type should be different),
+                # but share the same data arrays.
+                self._instance = copy.copy(self._instance)
+                if "meta" in self._instance:
+                    self._instance["meta"] = copy.deepcopy(self._instance["meta"])
+
                 current_validate_arrays = self._validate_arrays
                 self._validate_arrays = True
                 self.validate()
                 self._validate_arrays = current_validate_arrays
-            self.meta.model_type = self._model_type
+            self.on_init(init)
             return
 
         elif isinstance(init, AsdfFile):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -140,6 +140,10 @@ def test_init_from_another_model():
     with BasicModel(input_model) as dm:
         assert dm.data.shape == (50, 50)
         assert dm.meta.model_type == "BasicModel"
+        assert input_model._instance is not dm._instance
+        assert input_model.data is dm.data
+    assert input_model.meta.model_type == "FitsModel"
+    input_model.close()
 
 
 def test_init_from_another_model_on_file(tmp_path):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -135,7 +135,12 @@ def test_init_incompatible_datamodel():
 
 
 def test_init_from_another_model():
-    """Init model from a compatible model type should update model_type attribute."""
+    """
+    Init model from a compatible model type should update model_type attribute.
+
+    Expected behavior is a shallow copy where data arrays and other complex types (e.g. WCS)
+    are shared, but simple metadata are copied such that meta.model_type can be different.
+    """
     input_model = FitsModel((50, 50))
 
     class MockWcs:
@@ -151,6 +156,7 @@ def test_init_from_another_model():
         assert input_model != dm
         assert input_model._instance is not dm._instance
         assert input_model.data is dm.data
+        assert isinstance(input_model.meta.wcs, MockWcs)
         assert input_model.meta.wcs is dm.meta.wcs
     assert input_model.meta.model_type == "FitsModel"
     input_model.close()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -137,11 +137,21 @@ def test_init_incompatible_datamodel():
 def test_init_from_another_model():
     """Init model from a compatible model type should update model_type attribute."""
     input_model = FitsModel((50, 50))
+
+    class MockWcs:
+        """For these purposes this just needs to be a complex type."""
+
+        def __init__(self):
+            self.foo = "bar"
+
+    input_model.meta.wcs = MockWcs()
     with BasicModel(input_model) as dm:
         assert dm.data.shape == (50, 50)
         assert dm.meta.model_type == "BasicModel"
+        assert input_model != dm
         assert input_model._instance is not dm._instance
         assert input_model.data is dm.data
+        assert input_model.meta.wcs is dm.meta.wcs
     assert input_model.meta.model_type == "FitsModel"
     input_model.close()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,6 +134,26 @@ def test_init_incompatible_datamodel():
         BasicModel(input_model, schema=schema)
 
 
+def test_init_from_another_model():
+    """Init model from a compatible model type should update model_type attribute."""
+    input_model = FitsModel((50, 50))
+    with BasicModel(input_model) as dm:
+        assert dm.data.shape == (50, 50)
+        assert dm.meta.model_type == "BasicModel"
+
+
+def test_init_from_another_model_on_file(tmp_path):
+    """Init model from a file containing a different but compatible model type should update model_type attribute."""
+    input_model = FitsModel((50, 50))
+    file_path = tmp_path / "test.fits"
+    input_model.save(file_path)
+    input_model.close()
+
+    with BasicModel(file_path) as dm:
+        assert dm.data.shape == (50, 50)
+        assert dm.meta.model_type == "BasicModel"
+
+
 def test_set_array():
     with pytest.raises(ValueError):
         with BasicModel() as dm:


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #705 

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where initializing a model from a different (but compatible) model type did not update ``model.meta.model_type``

Note that this also relates to https://github.com/spacetelescope/stdatamodels/issues/698 as it should make it so e.g.
```
model = dm.ImageModel()
model2 = dm.IFUImageModel(model)
model == model2
```
will be False instead of True.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
