### PR TITLE
JP-4289: Add superstripe ramp model

### DIFF
--- a/changes/713.feature.rst
+++ b/changes/713.feature.rst
@@ -1,0 +1,1 @@
+Add the ``SuperstripeRampModel`` datamodel to allow superstripe mode ramps to have 3D ``pixeldq`` arrays and require all other ramps to have 2D ``pixeldq`` arrays.

--- a/src/stdatamodels/jwst/datamodels/__init__.py
+++ b/src/stdatamodels/jwst/datamodels/__init__.py
@@ -77,7 +77,7 @@ from .pixelarea import (
 )
 from .psfmask import PsfMaskModel
 from .quad import QuadModel
-from .ramp import RampModel
+from .ramp import RampModel, SuperstripeRampModel
 from .rampfitoutput import RampFitOutputModel
 from .readnoise import ReadnoiseModel
 from .reference import (
@@ -259,6 +259,7 @@ __all__ = [
     "SpecwcsModel",
     "StrayLightModel",
     "SuperBiasModel",
+    "SuperstripeRampModel",
     "TSOMultiSpecModel",
     "TSOSpecModel",
     "ThroughputModel",

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .model_base import JwstDataModel
 
-__all__ = ["RampModel"]
+__all__ = ["RampModel", "SuperstripeRampModel"]
 
 
 class RampModel(JwstDataModel):
@@ -44,8 +44,6 @@ class RampModel(JwstDataModel):
         """
         Retrieve the schema-defined default value of an attribute.
 
-        Overrides the parent method to set pixeldq to a 2D array if
-        data is defined.
         Override the parent method to give zeroframe the correct shape
         if data is defined.
 
@@ -65,16 +63,85 @@ class RampModel(JwstDataModel):
         AttributeError
             If the given attribute is not defined in the schema.
         """
-        # This is a band-aid solution to allow multistripe modes to
-        # have 3D pixeldq, but set the default appropriately for
-        # all other RampModels.
-        # If we can move multi-stripe RampModels to their own model
-        # type, we can resume using the schema to make a default pixeldq.
-        if attr == "pixeldq" and self.data is not None:
-            return np.zeros(self.data.shape[-2:], dtype=np.uint32)
-
         if attr == "zeroframe" and self.data is not None:
             shp = (self.data.shape[0],) + self.data.shape[-2:]
             return np.zeros(shp, dtype=np.float32)
+
+        return super().get_default(attr)
+
+
+class SuperstripeRampModel(JwstDataModel):
+    """
+    A data model for 4D ramps taken in superstripe mode.
+
+    Attributes
+    ----------
+    data : numpy float32 array
+         The science data with dimensions ``(nint * nstripe, ngroup, ny, nx)``.
+    pixeldq : numpy uint32 array
+         3-D data quality array for all planes with dimensions ``(nstripe, ny, nx)``.
+    groupdq : numpy uint8 array
+         4-D data quality array for each plane, matching data dimensions.
+    zeroframe : numpy float32 array
+         3-D zeroframe array with dimensions ``(nint * nstripe, ny, nx)``.
+    group : numpy table
+         group parameters table
+    int_times : numpy table
+         table of times for each integration
+    """
+
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/superstripe_ramp.schema"
+
+    def __init__(self, init=None, **kwargs):
+        super(SuperstripeRampModel, self).__init__(init=init, **kwargs)
+
+        # Ensure that if data exists, pixeldq and groupdq arrays exist
+        if self.data is None:
+            return
+        if self.pixeldq is None:
+            self.pixeldq = self.get_default("pixeldq")
+        if self.groupdq is None:
+            self.groupdq = self.get_default("groupdq")
+
+    def get_default(self, attr):
+        """
+        Retrieve the schema-defined default value of an attribute.
+
+        Override the parent method to set pixeldq to a 3D array if
+        data and ``meta.subarray.num_superstripe`` are defined.
+
+        Also override the parent method to give zeroframe the correct
+        shape if data is defined.
+
+        Parameters
+        ----------
+        attr : str
+            Attribute to set to its default value.
+
+        Returns
+        -------
+        object or None
+            The default value for the given attribute. If the attribute is schema-defined
+            but has no default value in the schema, this will return None.
+
+        Raises
+        ------
+        AttributeError
+            If the given attribute is not defined in the schema.
+        """
+        if self.data is not None:
+            image_shape = self.data.shape[-2:]
+            nstripe = self.meta.subarray.num_superstripe
+
+            if attr == "pixeldq":
+                if nstripe is not None and nstripe > 0:
+                    return np.zeros((nstripe, *image_shape), dtype=np.uint32)
+
+                # If num_superstripe is not defined or is 0, pixeldq defaults do
+                # not make sense for this model.
+                return None
+
+            if attr == "zeroframe":
+                return np.zeros((self.data.shape[0], *image_shape), dtype=np.float32)
 
         return super().get_default(attr)

--- a/src/stdatamodels/jwst/datamodels/schemas/superstripe_ramp.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/superstripe_ramp.schema.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0"
-id: "http://stsci.edu/schemas/jwst_datamodel/ramp.schema"
+id: "http://stsci.edu/schemas/jwst_datamodel/superstripe_ramp.schema"
 allOf:
 - $ref: core.schema
 - $ref: bunit.schema
@@ -16,11 +16,11 @@ allOf:
       ndim: 4
       datatype: float32
     pixeldq:
-      title: 2-D data quality array for all planes
+      title: 3-D data quality array for all planes
       fits_hdu: PIXELDQ
       default: 0
       datatype: uint32
-      ndim: 2
+      ndim: 3
     groupdq:
       title: 4-D data quality array for each plane
       fits_hdu: GROUPDQ
@@ -38,12 +38,6 @@ allOf:
       fits_hdu: REFOUT
       default: 0.0
       ndim: 4
-      datatype: float32
-    average_dark_current:
-      title: Average dark current
-      fits_hdu: AVDRKCUR
-      default: 0.0
-      ndim: 2
       datatype: float32
 - $ref: group.schema
 - $ref: int_times.schema

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -487,7 +487,9 @@ def test_ramp_model_zero_frame_open_file(tmp_path):
         np.testing.assert_allclose(zframe0, zframe1, 1.0e-5)
 
 
-@pytest.mark.parametrize("ModelType", [datamodels.Level1bModel, datamodels.RampModel])
+@pytest.mark.parametrize(
+    "ModelType", [datamodels.Level1bModel, datamodels.RampModel, datamodels.SuperstripeRampModel]
+)
 def test_ramp_model_zero_frame_by_dimensions(ModelType):
     """
     Ensures creating a RampModel by dimensions results in the correct
@@ -519,15 +521,40 @@ def test_ramp_model_pixel_dq_default():
         np.testing.assert_equal(default, 0)
 
 
-def test_ramp_model_pixel_dq_3d():
-    """Ensure RampModel pixeldq can be assigned a 3D array."""
+def test_superstripe_ramp_model_pixel_dq_3d():
+    """Ensure SuperstripeRampModel pixeldq can be assigned a 3D array."""
     nstripes, nints, ngroups, nrows, ncols = 3, 2, 10, 5, 5
     dims = (nstripes * nints, ngroups, nrows, ncols)
     pdims = (nstripes, nrows, ncols)
 
-    with datamodels.RampModel(dims, validate_arrays=True, strict_validation=True) as ramp:
+    with datamodels.SuperstripeRampModel(
+        dims, validate_arrays=True, strict_validation=True
+    ) as ramp:
         ramp.pixeldq = np.zeros(pdims)
         assert ramp.pixeldq.shape == pdims
+
+
+def test_superstripe_ramp_model_pixel_dq_default():
+    """Ensure SuperstripeRampModel pixeldq has a 3D default."""
+    nstripes, nints, ngroups, nrows, ncols = 3, 2, 10, 5, 5
+    dims = (nstripes * nints, ngroups, nrows, ncols)
+    pdims = (nstripes, nrows, ncols)
+
+    with datamodels.SuperstripeRampModel(
+        dims, validate_arrays=True, strict_validation=True
+    ) as ramp:
+        # without num_superstripe, default is None
+        assert ramp.get_default("pixeldq") is None
+
+        # with zero superstripe, default is None
+        ramp.meta.subarray.num_superstripe = 0
+        assert ramp.get_default("pixeldq") is None
+
+        # with non-zero supserstripe, default is nstripe x nrows x ncols
+        ramp.meta.subarray.num_superstripe = nstripes
+        default = ramp.get_default("pixeldq")
+        assert default.shape == pdims
+        np.testing.assert_equal(default, 0)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4289](https://jira.stsci.edu/browse/JP-4289)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Add a new ramp model for superstripe mode to better reflect the data structure.

Allows pixeldq to be 3D for superstripe data, 2D for regular ramp models.

Requires coordination with jwst PR https://github.com/spacetelescope/jwst/pull/10446

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
