### PR TITLE
Speed up validation on assignment for simple types

### DIFF
--- a/changes/714.misc.rst
+++ b/changes/714.misc.rst
@@ -1,0 +1,1 @@
+Reduce overhead in validation of scalar values on assignment, minorly improving runtime of ObjectNode.__setattr__

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -172,6 +172,8 @@ _VALIDATORS["datatype"] = _validate_datatype
 _VALIDATORS["ndim"] = ndarray.validate_ndim
 _VALIDATORS["max_ndim"] = ndarray.validate_max_ndim
 
+_PLAIN_SCALAR_TYPES = (str, int, float, bool, np.generic)
+
 
 def _check_value(value, schema, ctx):
     """
@@ -188,23 +190,28 @@ def _check_value(value, schema, ctx):
     """
     # Do not validate None values.  These are regarded as missing in DataModel,
     # and will eventually be stripped out when the model is saved to FITS or ASDF.
-    if value is not None:
+    if value is None:
+        return
+
+    if not isinstance(value, _PLAIN_SCALAR_TYPES):
+        # Plain scalar types cannot contain None subtrees, FITS records, or ASDF-tagged
+        # objects, so they can skip a bunch of steps.
         # There may also be Nones hiding within the value.  Do this before
-        # converting to tagged tree, so that we don't have to descend unnecessarily
-        # into nodes for custom types.
+        # converting to tagged tree, so that we don't have to descend
+        # unnecessarily into nodes for custom types.
         value = remove_none_from_tree(value)
         value = convert_fitsrec_to_array_in_tree(value)
-        # without this "write_context" asdf will queue up blocks for writing which
-        # will hold onto arrays after they have be overwritten
+        # without this "write_context" asdf will queue up blocks for writing
+        # which will hold onto arrays after they have been overwritten
         with ctx._asdf._blocks.write_context(None):
             value = yamlutil.custom_tree_to_tagged_tree(value, ctx._asdf)
 
-        if ctx._validate_arrays:
-            validators = _VALIDATORS
-        else:
-            validators = YAML_VALIDATORS
+    if ctx._validate_arrays:
+        validators = _VALIDATORS
+    else:
+        validators = YAML_VALIDATORS
 
-        asdf_schema.validate(value, ctx=ctx._asdf, schema=schema, validators=validators)
+    asdf_schema.validate(value, ctx=ctx._asdf, schema=schema, validators=validators)
 
 
 def _error_message(path, error):

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -193,9 +193,9 @@ def _check_value(value, schema, ctx):
     if value is None:
         return
 
+    # Plain scalar types cannot contain None subtrees, FITS records, or ASDF-tagged
+    # objects, so they can skip a bunch of steps.
     if not isinstance(value, _PLAIN_SCALAR_TYPES):
-        # Plain scalar types cannot contain None subtrees, FITS records, or ASDF-tagged
-        # objects, so they can skip a bunch of steps.
         # There may also be Nones hiding within the value.  Do this before
         # converting to tagged tree, so that we don't have to descend
         # unnecessarily into nodes for custom types.


### PR DESCRIPTION
Relates to #690 

<!-- describe the changes comprising this PR here -->
This PR makes validation on assignment a bit faster.

- Does not change `DataModel.validate()` runtime at all, because that passes a whole instance dict into `validate.value_change`.
- Improves runtime of all `ObjectNode.__setattr__` instances for simple types, if `validate_on_assignment` is True, which it usually is.  For my test case of just setting the instrument name 1e5 times, it was a bit better than a factor of 2 faster.

This is especially helpful if we move forward with https://github.com/spacetelescope/stdatamodels/pull/710 because that would make it so all attributes are set using `ObjectNode.__setattr__` during an `update` call.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
