### PR TITLE
JP-4289: Custom ramp validation for superstripe

### DIFF
--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -1,4 +1,8 @@
+import warnings
+
 import numpy as np
+
+from stdatamodels.exceptions import ValidationWarning
 
 from .model_base import JwstDataModel
 
@@ -83,3 +87,37 @@ class RampModel(JwstDataModel):
                 return np.zeros((self.data.shape[0], *image_shape), dtype=np.float32)
 
         return super().get_default(attr)
+
+    def validate(self):
+        """
+        Validate the model instance against its schema.
+
+        Override the parent method to check the pixeldq dimensionality.
+        If ``meta.subarray.num_superstripe`` is greater than zero,
+        the pixeldq should be 3D, with the first dimension matching
+        the number of stripes.
+        """
+        super().validate()
+
+        if self.data is None or self.pixeldq is None:
+            return
+
+        try:
+            nstripe = getattr(self.meta.subarray, "num_superstripe", None)
+            image_shape = self.data.shape[-2:]
+            if nstripe is None or nstripe == 0:
+                message = f"Pixeldq array must have shape {image_shape}"
+                assert self.pixeldq.shape == image_shape, message
+            else:
+                pdims = (nstripe, *image_shape)
+                message = (
+                    f"Pixeldq array must have shape {pdims} for "
+                    f"num_superstripe={nstripe}, image shape {image_shape}"
+                )
+                assert self.pixeldq.shape == pdims, message
+
+        except AssertionError as error_message:
+            if self._strict_validation:
+                raise
+            else:
+                warnings.warn(str(error_message), ValidationWarning, stacklevel=2)

--- a/src/stdatamodels/jwst/datamodels/ramp.py
+++ b/src/stdatamodels/jwst/datamodels/ramp.py
@@ -44,8 +44,10 @@ class RampModel(JwstDataModel):
         """
         Retrieve the schema-defined default value of an attribute.
 
-        Overrides the parent method to set pixeldq to a 2D array if
-        data is defined.
+        Override the parent method to set pixeldq to a 2D array if
+        data is defined; 3D array if ``meta.subarray.num_superstripe``
+        is also defined.
+
         Override the parent method to give zeroframe the correct shape
         if data is defined.
 
@@ -65,16 +67,19 @@ class RampModel(JwstDataModel):
         AttributeError
             If the given attribute is not defined in the schema.
         """
-        # This is a band-aid solution to allow multistripe modes to
-        # have 3D pixeldq, but set the default appropriately for
-        # all other RampModels.
-        # If we can move multi-stripe RampModels to their own model
-        # type, we can resume using the schema to make a default pixeldq.
-        if attr == "pixeldq" and self.data is not None:
-            return np.zeros(self.data.shape[-2:], dtype=np.uint32)
+        if self.data is not None:
+            image_shape = self.data.shape[-2:]
+            nstripe = self.meta.subarray.num_superstripe
 
-        if attr == "zeroframe" and self.data is not None:
-            shp = (self.data.shape[0],) + self.data.shape[-2:]
-            return np.zeros(shp, dtype=np.float32)
+            if attr == "pixeldq":
+                # Make a 3D array for superstripe data
+                if nstripe is not None and nstripe > 0:
+                    return np.zeros((nstripe, *image_shape), dtype=np.uint32)
+
+                # Otherwise, make a 2D array
+                return np.zeros(image_shape, dtype=np.uint32)
+
+            if attr == "zeroframe":
+                return np.zeros((self.data.shape[0], *image_shape), dtype=np.float32)
 
         return super().get_default(attr)

--- a/src/stdatamodels/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/ramp.schema.yaml
@@ -20,10 +20,7 @@ allOf:
       fits_hdu: PIXELDQ
       default: 0
       datatype: uint32
-      # TODO: removing ndim is necessary for multi-stripe modes, but
-      # breaks default array setting from the schema for all other
-      # modes. This will need resolution in a future build.
-      # ndim: 2
+      max_ndim: 3
     groupdq:
       title: 4-D data quality array for each plane
       fits_hdu: GROUPDQ

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -492,14 +492,32 @@ def test_ramp_model_pixel_dq_default():
         np.testing.assert_equal(default, 0)
 
 
-def test_ramp_model_pixel_dq_3d():
-    """Ensure RampModel pixeldq can be assigned a 3D array."""
+def test_superstripe_ramp_model_pixel_dq_default():
+    """Ensure superstripe RampModel pixeldq has a 3D default."""
     nstripes, nints, ngroups, nrows, ncols = 3, 2, 10, 5, 5
     dims = (nstripes * nints, ngroups, nrows, ncols)
+    idims = (nrows, ncols)
     pdims = (nstripes, nrows, ncols)
 
     with datamodels.RampModel(dims, validate_arrays=True, strict_validation=True) as ramp:
-        ramp.pixeldq = np.zeros(pdims)
+        # without num_superstripe, default is 2D
+        assert ramp.get_default("pixeldq").shape == idims
+
+        # the 2D default was assigned on init
+        assert ramp.pixeldq.shape == idims
+
+        # with zero superstripe, default is the same
+        ramp.meta.subarray.num_superstripe = 0
+        assert ramp.get_default("pixeldq").shape == idims
+
+        # with non-zero superstripe, default is nstripe x nrows x ncols
+        ramp.meta.subarray.num_superstripe = nstripes
+        default = ramp.get_default("pixeldq")
+        assert default.shape == pdims
+        np.testing.assert_equal(default, 0)
+
+        # The 3D default can overwrite the previously assigned 2D one
+        ramp.pixeldq = default
         assert ramp.pixeldq.shape == pdims
 
 

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -492,6 +492,32 @@ def test_ramp_model_pixel_dq_default():
         np.testing.assert_equal(default, 0)
 
 
+def test_ramp_model_validate():
+    """Test custom RampModel validation."""
+    nstripes, nints, ngroups, nrows, ncols = 3, 2, 10, 5, 5
+    dims = (nstripes * nints, ngroups, nrows, ncols)
+    idims = (nrows, ncols)
+    pdims = (nstripes, nrows, ncols)
+
+    with datamodels.RampModel(dims) as ramp:
+        # without num_superstripe, a 3D pixeldq raises a validation warning
+        ramp.pixeldq = np.zeros(pdims)
+        msg = r"Pixeldq array must have shape \(5, 5\)"
+        with pytest.warns(ValidationWarning, match=msg):
+            ramp.validate()
+
+        # with num_superstripe, 3D pixeldq is okay
+        ramp.meta.subarray.num_superstripe = nstripes
+        ramp.pixeldq = np.zeros(pdims)
+        ramp.validate()
+
+        # with num_superstripe, 2D pixeldq is not okay
+        ramp.pixeldq = np.zeros(idims)
+        msg = r"Pixeldq array must have shape \(3, 5, 5\) for num_superstripe=3"
+        with pytest.warns(ValidationWarning, match=msg):
+            ramp.validate()
+
+
 def test_superstripe_ramp_model_pixel_dq_default():
     """Ensure superstripe RampModel pixeldq has a 3D default."""
     nstripes, nints, ngroups, nrows, ncols = 3, 2, 10, 5, 5


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Toward [JP-4289](https://jira.stsci.edu/browse/JP-4289)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Alternate solution to #713, keeping RampModel for superstripe support.  Custom validation added and get_default updated to return 3D pixeldq for num_superstripe > 0.

Needs coordination with https://github.com/spacetelescope/jwst/pull/10465

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
