### PR TITLE
Compatibility with numpy 2.5

### DIFF
--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -8,7 +8,10 @@ import numpy as np
 from asdf import treeutil
 from asdf.treeutil import RemoveNode
 from astropy.io import fits
+from astropy.utils import minversion
 from numpy.lib.recfunctions import merge_arrays
+
+NUMPY_LT_2_5 = not minversion(np, "2.5.0.dev0")
 
 
 def gentle_asarray(a, dtype, allow_extra_columns=False):
@@ -73,7 +76,10 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
     # We can remove this once the issue is resolved in astropy:
     # https://github.com/astropy/astropy/issues/8862
     if isinstance(a, fits.fitsrec.FITS_rec):
-        a.dtype = _rebuild_fits_rec_dtype(a)
+        if NUMPY_LT_2_5:
+            a.dtype = _rebuild_fits_rec_dtype(a)
+        else:
+            np.ndarray._set_dtype(a, _rebuild_fits_rec_dtype(a))
         in_dtype = a.dtype
 
     if in_dtype == out_dtype:


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses deprecation warning seen in jwst devdeps, as reported by Melanie Clarke.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
- [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`stdatamodels@git+https://github.com/pllim/stdatamodels@numpydev-dtype`)
  - stable: https://github.com/spacetelescope/RegressionTests/actions/runs/25008333494 (passed)
  - devdeps: https://github.com/spacetelescope/RegressionTests/actions/runs/25009988560 (failures not related to deprecation warnings anymore)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
