### PR TITLE
avoid dtype setting deprecated in numpy 2.5

### DIFF
--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -68,10 +68,9 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
 
     # When a FITS file includes a pseudo-unsigned-int column, astropy will return
     # a FITS_rec with an incorrect table dtype.
+    # It's also unsafe to directly cast any FITS_rec with a
+    # pseudo-unsigned column.
     # https://github.com/astropy/astropy/issues/8862
-    # Due to an issue in astropy, it's not safe to directly cast
-    # a FITS_rec with a pseudo-unsigned column.
-    # See https://github.com/astropy/astropy/issues/8862
     if isinstance(a, fits.fitsrec.FITS_rec):
         if any(c.bzero is not None for c in a.columns):
             return _safe_asanyarray(a, out_dtype)

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -67,14 +67,14 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
                 raise ValueError(msg)
 
     # When a FITS file includes a pseudo-unsigned-int column, astropy will return
-    # a FITS_rec with an incorrect table dtype.  The following code rebuilds
-    # in_dtype from the individual fields, which are correctly labeled with an
-    # unsigned int dtype.
-    # We can remove this once the issue is resolved in astropy:
+    # a FITS_rec with an incorrect table dtype.
     # https://github.com/astropy/astropy/issues/8862
+    # Due to an issue in astropy, it's not safe to directly cast
+    # a FITS_rec with a pseudo-unsigned column.
+    # See https://github.com/astropy/astropy/issues/12112
     if isinstance(a, fits.fitsrec.FITS_rec):
-        a.dtype = _rebuild_fits_rec_dtype(a)
-        in_dtype = a.dtype
+        if any(c.bzero is not None for c in a.columns):
+            return _safe_asanyarray(a, out_dtype)
 
     if in_dtype == out_dtype:
         return a

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -71,7 +71,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
     # https://github.com/astropy/astropy/issues/8862
     # Due to an issue in astropy, it's not safe to directly cast
     # a FITS_rec with a pseudo-unsigned column.
-    # See https://github.com/astropy/astropy/issues/12112
+    # See https://github.com/astropy/astropy/issues/8862
     if isinstance(a, fits.fitsrec.FITS_rec):
         if any(c.bzero is not None for c in a.columns):
             return _safe_asanyarray(a, out_dtype)
@@ -161,7 +161,7 @@ def _safe_asanyarray(a, dtype):
         if any(c.bzero is not None for c in a.columns):
             # Due to an issue in astropy, it's not safe to directly cast
             # a FITS_rec with a pseudo-unsigned column.
-            # See https://github.com/astropy/astropy/issues/12112
+            # See https://github.com/astropy/astropy/issues/8862
             result = np.zeros(a.shape, dtype=dtype)
             for old_col, new_col in zip(a.dtype.names, result.dtype.names, strict=False):
                 result[new_col] = a[old_col]


### PR DESCRIPTION
Numpy 2.5 will deprecate setting dtype. This update our handling of a fitsrec issue where the dtype is incorrectly reported to avoid setting the dtype.

Regression tests with this PR and `requirements-dev-thirdparty.txt` show unrelated (photutils 3.0?) failures:
https://github.com/spacetelescope/RegressionTests/actions/runs/25018852701

This is an alternative to and closes https://github.com/spacetelescope/stdatamodels/pull/716

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
