### PR TITLE
Support update from ObjectNode

### DIFF
--- a/changes/724.feature.rst
+++ b/changes/724.feature.rst
@@ -1,0 +1,1 @@
+Allow model.update to accept ObjectNode as input.

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -79,7 +79,8 @@ class JwstDataModel(_DataModel):
         ----------
         d : `~stdatamodels.jwst.datamodels.JwstDataModel` or dictionary-like object
             The model to copy the metadata elements from. Can also be a
-            dictionary or dictionary of dictionaries or lists.
+            dictionary or dictionary of dictionaries or lists, or an
+            `~stdatamodels.properties.ObjectNode`.
         only : str, list of str, or None
             Update only the named hdu, e.g. ``only='PRIMARY'``. Can either be
             a string or list of hdu names. If None, all hdus will be updated.

--- a/src/stdatamodels/jwst/datamodels/model_base.py
+++ b/src/stdatamodels/jwst/datamodels/model_base.py
@@ -3,6 +3,7 @@ import copy
 from astropy.time import Time
 
 from stdatamodels import DataModel as _DataModel
+from stdatamodels import properties
 from stdatamodels.dynamicdq import dynamic_mask
 
 from .dqflags import pixel
@@ -90,7 +91,7 @@ class JwstDataModel(_DataModel):
             Update from ``cal_logs`` as well as ``meta``.
         """
         # Get the cal logs first
-        if isinstance(d, _DataModel):
+        if isinstance(d, properties.Node):
             # Get cal logs if present
             if d.hasattr("cal_logs"):
                 logs = copy.deepcopy(d.cal_logs._instance)

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -19,6 +19,7 @@ from astropy.time import Time
 from . import filetype, fits_support, properties, validate
 from . import schema as mschema
 from .history import HistoryList
+from .properties import ObjectNode
 from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
 
 # This minimal schema creates metadata fields that
@@ -925,7 +926,7 @@ class DataModel(properties.ObjectNode):
         # calling ObjectNode.__setattr__
         # This triggers validation if validate_on_assignment is True.
         def assign_leaves(node, path=()):
-            if isinstance(node, dict):
+            if isinstance(node, (dict, ObjectNode)):
                 for key, val in node.items():
                     # skip extra_fits - handled separately below
                     if not path and key == "extra_fits":

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -881,7 +881,8 @@ class DataModel(properties.ObjectNode):
         ----------
         d : `~jwst.datamodels.DataModel` or dictionary-like object
             The model to copy the metadata elements from. Can also be a
-            dictionary or dictionary of dictionaries or lists.
+            dictionary or dictionary of dictionaries or lists, or an
+            `~stdatamodels.properties.ObjectNode`.
         only : str, None
             Update only the named hdu, e.g. ``only='PRIMARY'``. Can either be
             a string or list of hdu names. Default is to update all the hdus.

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -19,7 +19,6 @@ from astropy.time import Time
 from . import filetype, fits_support, properties, validate
 from . import schema as mschema
 from .history import HistoryList
-from .properties import ObjectNode
 from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
 
 # This minimal schema creates metadata fields that
@@ -909,7 +908,7 @@ class DataModel(properties.ObjectNode):
         # Resolve the source dict and, for DataModel input, the set of
         # schema-approved leaf paths (those with a fits_keyword in the
         # appropriate HDU).
-        if isinstance(d, DataModel):
+        if isinstance(d, properties.Node):
             hdu_keywords = set()
 
             def hdu_keywords_from_schema(subschema, path, combiner, ctx, recurse):
@@ -927,7 +926,7 @@ class DataModel(properties.ObjectNode):
         # calling ObjectNode.__setattr__
         # This triggers validation if validate_on_assignment is True.
         def assign_leaves(node, path=()):
-            if isinstance(node, (dict, ObjectNode)):
+            if isinstance(node, dict):
                 for key, val in node.items():
                     # skip extra_fits - handled separately below
                     if not path and key == "extra_fits":

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -440,6 +440,12 @@ class ObjectNode(Node):
     def __iter__(self):
         return NodeIterator(self)
 
+    def pop(self, a, b):  # noqa: D102
+        try:
+            return self._instance.pop(a)
+        except KeyError:
+            return b
+
     def hasattr(self, attr):
         """
         Check if the node has an attribute in its instance.

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -440,12 +440,6 @@ class ObjectNode(Node):
     def __iter__(self):
         return NodeIterator(self)
 
-    def pop(self, a, b):  # noqa: D102
-        try:
-            return self._instance.pop(a)
-        except KeyError:
-            return b
-
     def hasattr(self, attr):
         """
         Check if the node has an attribute in its instance.

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -6,6 +6,7 @@ from astropy.time import Time
 from numpy.testing import assert_array_equal
 
 from stdatamodels.jwst.datamodels import ImageModel, MultiSlitModel, SlitModel
+from stdatamodels.properties import ObjectNode
 
 
 def test_multislit_model():
@@ -168,3 +169,17 @@ def test_slit_from_multislit():
     slit.int_times = slit.get_default("int_times")
     model.slits.append(slit)
     slit = SlitModel(model.slits[0].instance)
+
+
+def test_slit_update_from_multislit():
+    """Cover a bug where JwstDataModel.update() would raise for ObjectNode input."""
+    multislit = MultiSlitModel()
+    slit = SlitModel()
+    slit.meta.telescope = "foo"
+    multislit.slits.append(slit)
+    slit_objnode = multislit.slits[0]
+    assert isinstance(slit_objnode, ObjectNode)
+
+    slit2 = SlitModel()
+    slit2.update(slit_objnode)
+    assert slit2.meta.telescope == "foo"

--- a/tests/jwst/datamodels/test_multislit.py
+++ b/tests/jwst/datamodels/test_multislit.py
@@ -175,11 +175,17 @@ def test_slit_update_from_multislit():
     """Cover a bug where JwstDataModel.update() would raise for ObjectNode input."""
     multislit = MultiSlitModel()
     slit = SlitModel()
-    slit.meta.telescope = "foo"
+    # name is in both SlitModel and MultiSlitModel slitdata schema
+    slit.name = "foo"
+    # telescope is not in MultiSlitModel slitdata schema
+    slit.meta.telescope = "bar"
     multislit.slits.append(slit)
     slit_objnode = multislit.slits[0]
     assert isinstance(slit_objnode, ObjectNode)
 
     slit2 = SlitModel()
     slit2.update(slit_objnode)
-    assert slit2.meta.telescope == "foo"
+    # schema-defined in both -> updated
+    assert slit2.name == "foo"
+    # schema-undefined in source -> not updated
+    assert slit2.meta.telescope is None


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #723 

<!-- describe the changes comprising this PR here -->
This PR allows `model.update(d)` to accept `ObjectNode` as `d`.  See the added unit test for a realistic example of when this is helpful.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
