### PR TITLE
Drop unused INT_NUM keyword from specmeta

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specmeta.schema.yaml
@@ -154,11 +154,6 @@ properties:
     type: string
     fits_keyword: DETECTOR
     fits_hdu: EXTRACT1D
-  int_num:
-    title: Integration number
-    type: integer
-    fits_keyword: INT_NUM
-    fits_hdu: EXTRACT1D
   time_sys:
     title: "principal time system for time-related keywords"
     type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Toward [JP-4101](https://jira.stsci.edu/browse/JP-4101)

<!-- describe the changes comprising this PR here -->
This PR removes a keyword that is now stored as part of the table, after the restructuring of EXTRACT1D products.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
