### PR TITLE
Deprecate basic_utils.multiple_replace

### DIFF
--- a/changes/728.removal.rst
+++ b/changes/728.removal.rst
@@ -1,0 +1,1 @@
+Deprecate basic_utils.multiple_replace

--- a/src/stdatamodels/basic_utils.py
+++ b/src/stdatamodels/basic_utils.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 __all__ = ["multiple_replace"]
 
@@ -34,6 +35,11 @@ def multiple_replace(string, rep_dict):
     >>> multiple_replace("button mutton", {"but": "mut", "mutton": "lamb"})
     'mutton lamb'
     """  # numpydoc ignore=SS05
+    warnings.warn(
+        "The multiple_replace function is deprecated and will be removed in a future release. ",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     pattern = re.compile(
         "|".join([re.escape(k) for k in sorted(rep_dict, key=len, reverse=True)]), flags=re.DOTALL
     )

--- a/src/stdatamodels/basic_utils.py
+++ b/src/stdatamodels/basic_utils.py
@@ -32,6 +32,8 @@ def multiple_replace(string, rep_dict):
     If the replacements where chained, the result would have been
     'lamb lamb'
 
+    >>> import warnings
+    >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
     >>> multiple_replace("button mutton", {"but": "mut", "mutton": "lamb"})
     'mutton lamb'
     """  # numpydoc ignore=SS05

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -1,7 +1,18 @@
+import pytest
+
 from stdatamodels import dqflags
+from stdatamodels.basic_utils import multiple_replace
+from stdatamodels.jwst.datamodels.dqflags import multiple_replace as dqflags_multiple_replace
 from stdatamodels.jwst.datamodels.dqflags import pixel
 
 
 def test_dqflags():
     assert dqflags.dqflags_to_mnemonics(1, pixel) == {"DO_NOT_USE"}
     assert dqflags.dqflags_to_mnemonics(7, pixel) == {"JUMP_DET", "DO_NOT_USE", "SATURATED"}
+
+
+def test_multiple_replace_deprecated():
+    with pytest.warns(DeprecationWarning, match="The multiple_replace function is deprecated"):
+        multiple_replace("button mutton", {"but": "mut", "mutton": "lamb"})
+    with pytest.warns(DeprecationWarning, match="The multiple_replace function is deprecated"):
+        dqflags_multiple_replace("button mutton", {"but": "mut", "mutton": "lamb"})


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #711 

<!-- describe the changes comprising this PR here -->
This PR deprecates `basic_utils.multiple_replace`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
