### PR TITLE
remove unnecessary generic_io usage

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -9,8 +9,8 @@ from functools import partial
 
 import asdf
 import numpy as np
-from asdf import generic_io, tagged, treeutil
 from asdf import schema as asdf_schema
+from asdf import tagged, treeutil
 from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict
 from astropy import time
@@ -852,9 +852,9 @@ def from_fits_asdf(
             ignore_unrecognized_tag=ignore_unrecognized_tag,
         )
 
-    generic_file = generic_io.get_file(io.BytesIO(asdf_extension.data), mode="rw")
     af = asdf.open(
-        generic_file,
+        io.BytesIO(asdf_extension.data),
+        mode="rw",
         ignore_unrecognized_tag=ignore_unrecognized_tag,
         ignore_missing_extensions=ignore_missing_extensions,
     )


### PR DESCRIPTION
Remove an unnecessary usage of `asdf.generic_io` (there are developing plans to remove this submodule as it's largely unnecessary as seen in this PR).

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/25395302167
all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
