### PR TITLE
remove crds upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ test = [
   "pytest>=9.0",
   "pytest-asdf-plugin",
   "pytest-doctestplus",
-  "crds>=11.17.1,<13.1.15",
+  "crds>=11.17.1,!=13.1.15",
   "requests",
-  "scipy>=1.9.2",           # same as astropy
+  "scipy>=1.9.2",            # same as astropy
 ]
 docs = [
   "sphinx",


### PR DESCRIPTION
Remove the crds upper pin added in https://github.com/spacetelescope/stdatamodels/pull/721
replace with `!=13.1.15` since we haven't previously upper pinned crds.

I did not run regtests for just this PR as jwst has an upper pin.

Regtests for this combined with https://github.com/spacetelescope/jwst/pull/10514 (which removes the jwst upper pin):
https://github.com/spacetelescope/RegressionTests/actions/runs/25454074998

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
