### PR TITLE
JP-4273: Allow multiple apertures in PSF file

### DIFF
--- a/changes/734.feature.rst
+++ b/changes/734.feature.rst
@@ -1,0 +1,1 @@
+Update schema for SpecPsfModel to allow multiple apertures in the same file.

--- a/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
@@ -12,6 +12,8 @@ allOf:
 - $ref: keyword_pexptype.schema
 - $ref: keyword_filter.schema
 - $ref: keyword_pfilter.schema
+- $ref: keyword_grating.schema
+- $ref: keyword_pgrating.schema
 - type: object
   properties:
     apertures:

--- a/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/specpsf.schema.yaml
@@ -5,46 +5,49 @@ id: "http://stsci.edu/schemas/jwst_datamodel/specpsf.schema"
 allOf:
 - $ref: referencefile.schema
 - $ref: keyword_band.schema
+- $ref: keyword_pband.schema
 - $ref: keyword_channel.schema
+- $ref: keyword_pchannel.schema
 - $ref: keyword_exptype.schema
-- $ref: keyword_readpatt.schema
-- $ref: keyword_psubarray.schema
+- $ref: keyword_pexptype.schema
 - $ref: keyword_filter.schema
-- $ref: subarray.schema
-
+- $ref: keyword_pfilter.schema
 - type: object
   properties:
-    meta:
-      type: object
-      properties:
-        psf:
-          title: PSF parameters
-          type: object
-          properties:
-            subpix:
-              title: oversampling factor
-              type: number
-              fits_keyword: SUBPIX
-            center_col:
-              title: column ePSF shifted to
-              type: number
-              fits_keyword: CENTCOL
-            center_row:
-              title: row ePSF shifted to
-              type: number
-              fits_keyword: CENTROW
-- type: object
-  properties:
-    data:
-      title: The PSF image
-      fits_hdu: PSF
-      default: 0.0
-      ndim: 2
-      datatype: float64
-    wave:
-      title: Wavelength image
-      fits_hdu: WAVE
-      default: 0
-      ndim: 1
-      datatype: float64
-
+    apertures:
+      type: array
+      title: Array of PSF models
+      items:
+        type: object
+        properties:
+          name:
+            title: Aperture name
+            fits_keyword: APERTURE
+            fits_hdu: PSF
+          subpix:
+            title: Oversampling factor
+            type: number
+            fits_keyword: SUBPIX
+            fits_hdu: PSF
+          center_col:
+            title: Center column (vertical dispersion)
+            type: number
+            fits_keyword: CENTCOL
+            fits_hdu: PSF
+          center_row:
+            title: Center row (horizontal dispersion)
+            type: number
+            fits_keyword: CENTROW
+            fits_hdu: PSF
+          data:
+            title: PSF image
+            fits_hdu: PSF
+            default: 0.0
+            ndim: 2
+            datatype: float64
+          wave:
+            title: Wavelength image
+            fits_hdu: WAVE
+            default: 0
+            ndim: 1
+            datatype: float64

--- a/src/stdatamodels/jwst/datamodels/specpsf.py
+++ b/src/stdatamodels/jwst/datamodels/specpsf.py
@@ -24,19 +24,20 @@ def _migrate_psf_keywords(hdulist):
     hdulist : HDUList
         The updated HDUList.
     """
+    if len(hdulist) < 2:
+        return hdulist
+
+    primary_header = hdulist[0].header
     keys_to_copy = ["APERTURE", "CENTCOL", "CENTROW", "SUBPIX"]
-    if len(hdulist) == 3:
-        primary_header = hdulist[0].header
-        psf_ext = hdulist[1]
-        if psf_ext.name != "PSF":
-            return hdulist
-        for key in keys_to_copy:
-            if key == "APERTURE":
-                value = primary_header.get(key, "ANY")
-            else:
-                value = primary_header.get(key, None)
-            if value is not None:
-                psf_ext.header[key] = value
+    values_to_copy = [primary_header.get(key, None) for key in keys_to_copy]
+    for ext in hdulist[1:]:
+        if ext.name == "PSF":
+            for key, value in zip(keys_to_copy, values_to_copy, strict=True):
+                if ext.header.get(key, None) is None:
+                    if value is not None:
+                        ext.header[key] = value
+                    elif key == "APERTURE":
+                        ext.header[key] = "ANY"
 
     return hdulist
 

--- a/src/stdatamodels/jwst/datamodels/specpsf.py
+++ b/src/stdatamodels/jwst/datamodels/specpsf.py
@@ -3,19 +3,63 @@ from .reference import ReferenceFileModel
 __all__ = ["SpecPsfModel"]
 
 
+def _migrate_psf_keywords(hdulist):
+    """
+    Migrate PSF keywords from primary HDU to first PSF extension.
+
+    Files produced with SpecPsfModel prior to
+    https://github.com/spacetelescope/stdatamodels/pull/734
+    expected a single PSF/WAVE extension, with descriptive keywords
+    in the primary header. This function copies these keywords to
+    the correct place in the new schema that allows for multiple
+    PSFs in the same file.
+
+    Parameters
+    ----------
+    hdulist : HDUList
+        FITS HDUList to read.
+
+    Returns
+    -------
+    hdulist : HDUList
+        The updated HDUList.
+    """
+    keys_to_copy = ["APERTURE", "CENTCOL", "CENTROW", "SUBPIX"]
+    if len(hdulist) == 3:
+        primary_header = hdulist[0].header
+        psf_ext = hdulist[1]
+        if psf_ext.name != "PSF":
+            return hdulist
+        for key in keys_to_copy:
+            if key == "APERTURE":
+                value = primary_header.get(key, "ANY")
+            else:
+                value = primary_header.get(key, None)
+            if value is not None:
+                psf_ext.header[key] = value
+
+    return hdulist
+
+
 class SpecPsfModel(ReferenceFileModel):
     """
     A data model for spectral PSF reference data.
 
+    PSF models are contained in a list, under the ``apertures``
+    attribute.
+
     Attributes
     ----------
-    data : numpy float32 array
-         The PSF image
-    wave : numpy float32 array
-         Wavelength image
+    apertures.items.data : ndarray
+        2D PSF image.
+    apertures.items.wave : ndarray
+        1D wavelength image.
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/specpsf.schema"
 
     def __init__(self, init=None, **kwargs):
         super(SpecPsfModel, self).__init__(init=init, **kwargs)
+
+    def _migrate_hdulist(self, hdulist):
+        return _migrate_psf_keywords(hdulist)

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -942,7 +942,7 @@ def test_moving_target_table_migration(tmp_path):
         check_error_column(dm)
 
 
-@pytest.mark.parametrize("input_type", ["expected", "wrong_name", "extra_extension"])
+@pytest.mark.parametrize("input_type", ["old", "new", "wrong_name", "extra_extension", "too_small"])
 def test_specpsf_keyword_migration(tmp_path, input_type):
     """
     Test FITS HDUList migration for SpecPsfModel.
@@ -959,36 +959,52 @@ def test_specpsf_keyword_migration(tmp_path, input_type):
     if input_type == "wrong_name":
         name = "BAD"
 
-    hdul = fits.HDUList(
-        [
-            fits.PrimaryHDU(header=fits.Header({"SUBPIX": 4, "CENTCOL": 5})),
-            fits.ImageHDU(psf, name=name),
-            fits.ImageHDU(wave, name="WAVE"),
-        ]
-    )
+    header = fits.Header({"SUBPIX": 4, "CENTCOL": 5})
+    if input_type == "new":
+        header["APERTURE"] = "ANY"
+        hdul = fits.HDUList(
+            [
+                fits.PrimaryHDU(),
+                fits.ImageHDU(psf, name=name, header=header),
+                fits.ImageHDU(wave, name="WAVE"),
+            ]
+        )
+    elif input_type == "too_small":
+        hdul = fits.HDUList([fits.PrimaryHDU(header=header)])
+    else:
+        hdul = fits.HDUList(
+            [
+                fits.PrimaryHDU(header=header),
+                fits.ImageHDU(psf, name=name),
+                fits.ImageHDU(wave, name="WAVE"),
+            ]
+        )
     if input_type == "extra_extension":
-        hdul.append(fits.ImageHDU(psf, name="EXTRA"))
+        hdul.append(fits.ImageHDU(psf.copy(), name="EXTRA"))
     hdul.writeto(input_fn, overwrite=True)
     hdul.close()
 
     with datamodels.SpecPsfModel(input_fn) as spec_psf:
+        if input_type == "too_small":
+            assert len(spec_psf.apertures) == 0
+            return
+
         assert len(spec_psf.apertures) == 1
-        if input_type == "expected":
+        if input_type == "wrong_name":
+            # Keywords not copied, since PSF extension didn't exist
+            assert spec_psf.apertures[0].name is None
+            assert spec_psf.apertures[0].subpix is None
+            assert spec_psf.apertures[0].center_col is None
+            assert spec_psf.apertures[0].data is None
+            # Only the wave array is read in
+            assert spec_psf.apertures[0].wave.shape == wave.shape
+        else:
+            # Keywords appropriately read in
             assert spec_psf.apertures[0].name == "ANY"
             assert spec_psf.apertures[0].subpix == 4
             assert spec_psf.apertures[0].center_col == 5
             assert spec_psf.apertures[0].data.shape == psf.shape
             assert spec_psf.apertures[0].wave.shape == wave.shape
-        else:
-            assert spec_psf.apertures[0].name is None
-            assert spec_psf.apertures[0].subpix is None
-            assert spec_psf.apertures[0].center_col is None
-            assert spec_psf.apertures[0].wave.shape == wave.shape
-            if input_type == "wrong_name":
-                # Only the wave array is read in
-                assert spec_psf.apertures[0].data is None
-            else:
-                assert spec_psf.apertures[0].data.shape == psf.shape
 
 
 @pytest.mark.parametrize("ModelClass", [WfssBkgModel, FlatModel, MaskModel])

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -942,6 +942,55 @@ def test_moving_target_table_migration(tmp_path):
         check_error_column(dm)
 
 
+@pytest.mark.parametrize("input_type", ["expected", "wrong_name", "extra_extension"])
+def test_specpsf_keyword_migration(tmp_path, input_type):
+    """
+    Test FITS HDUList migration for SpecPsfModel.
+
+    Primary header keywords for single-extension PSF files are migrated to the first aperture.
+    If the input model has an unexpected format, the update is not performed.
+    """
+    input_fn = str(tmp_path / "test_psf.fits")
+    psf = np.ones((10, 10), dtype=np.float32)
+    wave = np.arange(1, 11, dtype=np.float32)
+
+    # Expected input hdul has extension named "PSF"
+    name = "PSF"
+    if input_type == "wrong_name":
+        name = "BAD"
+
+    hdul = fits.HDUList(
+        [
+            fits.PrimaryHDU(header=fits.Header({"SUBPIX": 4, "CENTCOL": 5})),
+            fits.ImageHDU(psf, name=name),
+            fits.ImageHDU(wave, name="WAVE"),
+        ]
+    )
+    if input_type == "extra_extension":
+        hdul.append(fits.ImageHDU(psf, name="EXTRA"))
+    hdul.writeto(input_fn, overwrite=True)
+    hdul.close()
+
+    with datamodels.SpecPsfModel(input_fn) as spec_psf:
+        assert len(spec_psf.apertures) == 1
+        if input_type == "expected":
+            assert spec_psf.apertures[0].name == "ANY"
+            assert spec_psf.apertures[0].subpix == 4
+            assert spec_psf.apertures[0].center_col == 5
+            assert spec_psf.apertures[0].data.shape == psf.shape
+            assert spec_psf.apertures[0].wave.shape == wave.shape
+        else:
+            assert spec_psf.apertures[0].name is None
+            assert spec_psf.apertures[0].subpix is None
+            assert spec_psf.apertures[0].center_col is None
+            assert spec_psf.apertures[0].wave.shape == wave.shape
+            if input_type == "wrong_name":
+                # Only the wave array is read in
+                assert spec_psf.apertures[0].data is None
+            else:
+                assert spec_psf.apertures[0].data.shape == psf.shape
+
+
 @pytest.mark.parametrize("ModelClass", [WfssBkgModel, FlatModel, MaskModel])
 def test_mixins_from_shape(ModelClass):
     """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4273](https://jira.stsci.edu/browse/JP-4273)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
To support optimal extraction for NIRSpec FS, we need to allow the SpecPsfModel to contain multiple apertures, to match all possible fixed slits.

Existing SpecPsfModels for MIRI LRS have some keywords in the primary header that will need to be moved to the extension header, so I've added some migration code for that.  Otherwise, existing PSF files should read in as is just fine.

JWST spectral extraction code will need to be updated to match the new schema. PR is: https://github.com/spacetelescope/jwst/pull/10516

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
