### PR TITLE
Remove hard-coded array copies from MultiExposureModel init

### DIFF
--- a/changes/737.bugfix.rst
+++ b/changes/737.bugfix.rst
@@ -1,0 +1,1 @@
+Remove hard-coded array names from ``MultiExposureModel`` init that caused an error when initializing from ``ImageModel``.

--- a/src/stdatamodels/jwst/datamodels/multiexposure.py
+++ b/src/stdatamodels/jwst/datamodels/multiexposure.py
@@ -55,22 +55,7 @@ class MultiExposureModel(JwstDataModel):
         if isinstance(init, (SlitModel, SlitDataModel, ImageModel)):
             super(MultiExposureModel, self).__init__(init=None, schema=schema, **kwargs)
             self.update(init)
-            self.exposures.append(self.exposures.item())
-            self.exposures[0].data = init.data
-            self.exposures[0].dq = init.dq
-            self.exposures[0].err = init.err
-            self.exposures[0].var_poisson = init.var_poisson
-            self.exposures[0].var_rnoise = init.var_rnoise
-            self.exposures[0].var_flat = init.var_flat
-            self.exposures[0].wavelength = init.wavelength
-            self.exposures[0].barshadow = init.barshadow
-            self.exposures[0].flatfield_point = init.flatfield_point
-            self.exposures[0].flatfield_uniform = init.flatfield_uniform
-            self.exposures[0].pathloss_point = init.pathloss_point
-            self.exposures[0].pathloss_uniform = init.pathloss_uniform
-            self.exposures[0].photom_point = init.photom_point
-            self.exposures[0].photom_uniform = init.photom_uniform
-            self.exposures[0].area = init.area
+            self.exposures.append(init)
             return
 
         super(MultiExposureModel, self).__init__(init=init, schema=schema, **kwargs)

--- a/tests/jwst/datamodels/test_multiexposure.py
+++ b/tests/jwst/datamodels/test_multiexposure.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from stdatamodels.jwst import datamodels as dm
+
+
+@pytest.mark.parametrize("model_type", [dm.ImageModel, dm.SlitModel, dm.SlitDataModel])
+def test_multiexposure_model_from_datamodel(model_type):
+    # Populate an input model with default arrays for everything in the schema
+    shape = (2, 2)
+    input_model = model_type(shape)
+    input_model.meta.bunit_data = "MJy"
+    populated_arrays = []
+    for prop, val in input_model.schema["properties"].items():
+        if "datatype" in val and not prop.startswith("int_times"):
+            setattr(input_model, prop, input_model.get_default(prop))
+            populated_arrays.append(prop)
+
+    # Make a multi-exposure model from the input
+    multi_model = dm.MultiExposureModel(input_model)
+
+    # Make sure input arrays are populated in the first exposure
+    for prop in populated_arrays:
+        copied_array = getattr(multi_model.exposures[0], prop)
+        np.testing.assert_allclose(copied_array, getattr(input_model, prop))
+
+    # Top level meta should be copied to the new model
+    assert multi_model.meta.bunit_data == "MJy"
+
+    input_model.close()
+    multi_model.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Fix a bug in MultiExposureModel.  It supports ImageModel as init, but then hard-codes array names that are not present in the ImageModel schema.

Minimal example:
```
from stdatamodels.jwst import datamodels
img = datamodels.ImageModel()
datamodels.MultiExposureModel(img)
```
raises `AttributeError: No attribute 'barshadow'`

I think this can be fixed by just directly appending the input model, but let me know if there's a reason for explicitly copying specific arrays.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
