### PR TITLE
Fix handling of logical int8 columns

### DIFF
--- a/changes/738.bugfix.rst
+++ b/changes/738.bugfix.rst
@@ -1,0 +1,1 @@
+Fix handling of logical/int8 FITS_rec columns when provided boolean values.

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -138,8 +138,7 @@ def _as_fitsrec(val):
         coldefs = fits.ColDefs(val)
         uint = any(c._pseudo_unsigned_ints for c in coldefs)
         if any(c.format == "L" for c in coldefs):
-            # We need to copy this data as we need to modify the values to match what
-            # astropy expects.
+            # Copy so we can modify the values to match what astropy expects.
             fits_rec = fits.FITS_rec(val.copy())
             for c in coldefs:
                 if c.format == "L":

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -137,7 +137,18 @@ def _as_fitsrec(val):
     else:
         coldefs = fits.ColDefs(val)
         uint = any(c._pseudo_unsigned_ints for c in coldefs)
-        fits_rec = fits.FITS_rec(val)
+        if any(c.format == "L" for c in coldefs):
+            # We need to copy this data as we need to modify the values to match what
+            # astropy expects.
+            fits_rec = fits.FITS_rec(val.copy())
+            for c in coldefs:
+                if c.format == "L":
+                    d = fits_rec[c.name]
+                    m = d.astype(bool)
+                    d[m] = ord("T")
+                    d[~m] = ord("F")
+        else:
+            fits_rec = fits.FITS_rec(val)
         fits_rec._coldefs = coldefs
         # FITS_rec needs to know if it should be operating in pseudo-unsigned-ints mode,
         # otherwise it won't properly convert integer columns with TZEROn before saving.

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -807,6 +807,19 @@ def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
     oifits_ami_model.save(fn)
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_amioi_logical_flag(value):
+    """
+    Test that int8 stored "FLAG" columns accept bools.
+
+    This is a targeted test to reproduce a bug found in:
+    https://github.com/spacetelescope/stdatamodels/issues/735
+    """
+    model = datamodels.AmiOIModel()
+    model.t3 = [(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, [0, 0, 0], value)]
+    assert model.t3[0][-1] == value
+
+
 def test_dq_def_roundtrip(tmp_path, test_data_path):
     """
     Open a MaskModel with a defined DQ array and dq_def that modifies the

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -807,17 +807,22 @@ def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
     oifits_ami_model.save(fn)
 
 
-@pytest.mark.parametrize("value", [True, False])
-def test_amioi_logical_flag(value):
+@pytest.mark.parametrize("value", [True, False, 0, 1, ord("T"), ord("F")])
+def test_amioi_logical_flag(tmp_path, value, oifits_ami_model):
     """
     Test that int8 stored "FLAG" columns accept bools.
 
     This is a targeted test to reproduce a bug found in:
     https://github.com/spacetelescope/stdatamodels/issues/735
     """
-    model = datamodels.AmiOIModel()
-    model.t3 = [(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, [0, 0, 0], value)]
-    assert model.t3[0][-1] == value
+    oifits_ami_model.t3[0][-1] = value
+    assert oifits_ami_model.t3[0][-1] == bool(value)
+
+    # make sure it round-trips
+    fn = tmp_path / "test.fits"
+    oifits_ami_model.save(fn)
+    with datamodels.open(fn) as model:
+        assert model.t3[0][-1] == bool(value)
 
 
 def test_dq_def_roundtrip(tmp_path, test_data_path):

--- a/tests/schemas/table_model.yaml
+++ b/tests/schemas/table_model.yaml
@@ -8,8 +8,10 @@ allOf:
     properties:
       table:
         fits_hdu: TABLE
-        default: [0, 42, NaN, "foo", 42.0, 0.0, 0.0, 0.0]
+        default: [False, 0, 42, NaN, "foo", 42.0, 0.0, 0.0, 0.0]
         datatype:
+          - name: int8_column
+            datatype: int8
           - name: int16_column
             datatype: int16
           - name: uint16_column

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -305,6 +305,7 @@ def test_get_dtype_table():
         assert isinstance(dtype, np.dtype)
         expected_dtype = np.dtype(
             [
+                ("int8_column", "<i1"),
                 ("int16_column", "<i2"),
                 ("uint16_column", "<u2"),
                 ("float32_column", "<f4"),
@@ -374,6 +375,17 @@ def test_multivalued_default_table_schema():
         assert ndim_shape_col.shape == (10, 3, 2)
         max_ndim_col = dm.table["float32_column_with_max_ndim"]
         assert max_ndim_col.shape == (10, 0, 0)
+
+        # test logical type
+        assert np.all(dm.table["int8_column"] == False)
+
+
+def test_logical_column():
+    dm = TableModel((10,))
+    dm.table["int8_column"][:] = True
+    assert np.all(dm.table["int8_column"] == True)
+    dm.table["int8_column"][:] = False
+    assert np.all(dm.table["int8_column"] == False)
 
 
 def test_multivalued_default_table_schema_bad():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -92,6 +92,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
     with TableModel() as x:
         x.table = [
             (
+                False,
                 -42,
                 42000,
                 37.5,
@@ -103,6 +104,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
             )
         ]
         assert x.table.dtype == [
+            ("int8_column", "=i1"),
             ("int16_column", "=i2"),
             ("uint16_column", "=u2"),
             ("float32_column", "=f4"),
@@ -119,6 +121,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
         assert np.can_cast(
             x.table.dtype,
             [
+                ("int8_column", "=i1"),
                 ("int16_column", "=i2"),
                 ("uint16_column", "=u2"),
                 ("float32_column", "=f4"),
@@ -135,6 +138,7 @@ def test_table_array_shape_ndim(filename, tmp_path):
         with pytest.raises(ValueError):
             x.table = [
                 (
+                    False,
                     -42,
                     42000,
                     37.5,


### PR DESCRIPTION
Closes https://github.com/spacetelescope/stdatamodels/issues/735

Logical/int8 columns are causing warnings for astropy dev and do not work as expected (see above issue).

Update handling of structured arrays/fits_rec with logical/int8 columns copying data where needed to handle the mismatch between numpy bool storage and astropy/fits logical bool mapping.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/25576691180/job/75368198893

github is having issues so CI is unreliable. Will trying to restart some tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
