### PR TITLE
Ensure shape attribute stays in-sync with primary array

### DIFF
--- a/changes/740.bugfix.rst
+++ b/changes/740.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure model.shape attribute remains in sync with shape of primary array

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -674,12 +674,16 @@ class DataModel(properties.ObjectNode):
     @property
     def shape(self):
         """Return the shape of the primary array."""
-        if self._shape is None:
-            primary_array_name = self.get_primary_array_name()
-            if primary_array_name and self.hasattr(primary_array_name):
-                primary_array = getattr(self, primary_array_name)
-                self._shape = primary_array.shape
-        return self._shape
+        primary_array_name = self.get_primary_array_name()
+        if primary_array_name and self.hasattr(primary_array_name):
+            primary_array = getattr(self, primary_array_name)
+            self._shape = primary_array.shape
+            return self._shape
+        return None
+
+    @shape.setter
+    def shape(self, value):
+        raise AttributeError("Model shape is read-only.")
 
     def __setattr__(self, attr, value):
         if attr in frozenset(("shape", "history", "_extra_fits", "schema")):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -176,7 +176,7 @@ class DataModel(properties.ObjectNode):
         # Determine what kind of input we have (init) and execute the
         # proper code to initialize the model
         self._file_references = []
-        self._shape = None  # temporary seed used by _make_default_array via ctx.shape
+        self._shape = None
         is_array = False
         is_shape = False
         shape = None
@@ -266,8 +266,6 @@ class DataModel(properties.ObjectNode):
             raise TypeError(f"Can't initialize datamodel using {str(type(init))}")
 
         # Initialize object fields as determined from the code above
-        # _shape seeds ctx.shape for _make_default_array before the primary array exists.
-        # It is cleared to None once the primary array is stored in _instance.
         self._shape = shape
         self._instance = asdffile.tree
         self._asdf = asdffile
@@ -291,7 +289,6 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
             setattr(self, primary_array_name, init)
-            self._shape = None
 
         # If a shape has been given, initialize the primary array.
         if is_shape:
@@ -302,9 +299,8 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
 
-            # _shape seeds ctx.shape so _make_default_array knows the requested size.
+            # _shape seeds ctx.shape so _make_default_array knows the requested size
             setattr(self, primary_array_name, self.get_default(primary_array_name))
-            self._shape = None
 
         # initialize arrays from keyword arguments when they are present
         for attr, value in kwargs.items():

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -462,6 +462,7 @@ class DataModel(properties.ObjectNode):
                 file_reference.increment()
                 target._file_references.append(file_reference)
 
+        target._shape = source._shape
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -299,7 +299,7 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
 
-            # _shape seeds ctx.shape so _make_default_array knows the requested size
+            # Initialize the primary array to the given shape with default value.
             setattr(self, primary_array_name, self.get_default(primary_array_name))
 
         # initialize arrays from keyword arguments when they are present

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -676,7 +676,7 @@ class DataModel(properties.ObjectNode):
     def shape(self):
         """Return the shape of the primary array."""
         primary_array_name = self.get_primary_array_name()
-        if primary_array_name and self.hasattr(primary_array_name):
+        if primary_array_name and getattr(self, primary_array_name, None) is not None:
             primary_array = getattr(self, primary_array_name)
             return primary_array.shape
         return self._shape

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -176,6 +176,7 @@ class DataModel(properties.ObjectNode):
         # Determine what kind of input we have (init) and execute the
         # proper code to initialize the model
         self._file_references = []
+        self._shape = None  # temporary seed used by _make_default_array via ctx.shape
         is_array = False
         is_shape = False
         shape = None
@@ -265,6 +266,8 @@ class DataModel(properties.ObjectNode):
             raise TypeError(f"Can't initialize datamodel using {str(type(init))}")
 
         # Initialize object fields as determined from the code above
+        # _shape seeds ctx.shape for _make_default_array before the primary array exists.
+        # It is cleared to None once the primary array is stored in _instance.
         self._shape = shape
         self._instance = asdffile.tree
         self._asdf = asdffile
@@ -288,6 +291,7 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
             setattr(self, primary_array_name, init)
+            self._shape = None
 
         # If a shape has been given, initialize the primary array.
         if is_shape:
@@ -298,8 +302,9 @@ class DataModel(properties.ObjectNode):
                     "has no primary array in its schema"
                 )
 
-            # Initialize the primary array to the given shape with default value.
+            # _shape seeds ctx.shape so _make_default_array knows the requested size.
             setattr(self, primary_array_name, self.get_default(primary_array_name))
+            self._shape = None
 
         # initialize arrays from keyword arguments when they are present
         for attr, value in kwargs.items():
@@ -461,7 +466,6 @@ class DataModel(properties.ObjectNode):
                 file_reference.increment()
                 target._file_references.append(file_reference)
 
-        target._shape = source._shape
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):
@@ -677,9 +681,8 @@ class DataModel(properties.ObjectNode):
         primary_array_name = self.get_primary_array_name()
         if primary_array_name and self.hasattr(primary_array_name):
             primary_array = getattr(self, primary_array_name)
-            self._shape = primary_array.shape
-            return self._shape
-        return None
+            return primary_array.shape
+        return self._shape
 
     def __setattr__(self, attr, value):
         if attr in frozenset(("shape", "history", "_extra_fits", "schema")):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -679,7 +679,7 @@ class DataModel(properties.ObjectNode):
         if primary_array_name and getattr(self, primary_array_name, None) is not None:
             primary_array = getattr(self, primary_array_name)
             return primary_array.shape
-        return self._shape
+        return None
 
     def __setattr__(self, attr, value):
         if attr in frozenset(("shape", "history", "_extra_fits", "schema")):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -678,8 +678,7 @@ class DataModel(properties.ObjectNode):
         if primary_array_name and self.hasattr(primary_array_name):
             primary_array = getattr(self, primary_array_name)
             self._shape = primary_array.shape
-            return self._shape
-        return None
+        return self._shape if self._shape is not None else None
 
     @shape.setter
     def shape(self, value):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -678,11 +678,8 @@ class DataModel(properties.ObjectNode):
         if primary_array_name and self.hasattr(primary_array_name):
             primary_array = getattr(self, primary_array_name)
             self._shape = primary_array.shape
-        return self._shape if self._shape is not None else None
-
-    @shape.setter
-    def shape(self, value):
-        raise AttributeError("Model shape is read-only.")
+            return self._shape
+        return None
 
     def __setattr__(self, attr, value):
         if attr in frozenset(("shape", "history", "_extra_fits", "schema")):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -176,10 +176,8 @@ class DataModel(properties.ObjectNode):
         # Determine what kind of input we have (init) and execute the
         # proper code to initialize the model
         self._file_references = []
-        self._shape = None
         is_array = False
         is_shape = False
-        shape = None
 
         if init is None:
             asdffile = AsdfFile(ignore_unrecognized_tag=ignore_unrecognized_tag)
@@ -193,8 +191,6 @@ class DataModel(properties.ObjectNode):
 
         elif isinstance(init, np.ndarray):
             asdffile = AsdfFile(ignore_unrecognized_tag=ignore_unrecognized_tag)
-
-            shape = init.shape
             is_array = True
 
         elif isinstance(init, tuple):
@@ -202,7 +198,6 @@ class DataModel(properties.ObjectNode):
                 if not isinstance(item, int):
                     raise ValueError("shape must be a tuple of ints")  # noqa: TRY004
 
-            shape = init
             is_shape = True
             asdffile = AsdfFile(ignore_unrecognized_tag=ignore_unrecognized_tag)
 
@@ -266,7 +261,6 @@ class DataModel(properties.ObjectNode):
             raise TypeError(f"Can't initialize datamodel using {str(type(init))}")
 
         # Initialize object fields as determined from the code above
-        self._shape = shape
         self._instance = asdffile.tree
         self._asdf = asdffile
 
@@ -300,7 +294,12 @@ class DataModel(properties.ObjectNode):
                 )
 
             # Initialize the primary array to the given shape with default value.
+            # Hack: store the shape in a hidden attribute so it becomes part of the ctx
+            # sent to properties.get_default(). This allows get_default to know that it's
+            # being called during datamodel init, when the primary array doesn't yet exist
+            self._init_shape = init
             setattr(self, primary_array_name, self.get_default(primary_array_name))
+            del self._init_shape
 
         # initialize arrays from keyword arguments when they are present
         for attr, value in kwargs.items():
@@ -462,7 +461,6 @@ class DataModel(properties.ObjectNode):
                 file_reference.increment()
                 target._file_references.append(file_reference)
 
-        target._shape = source._shape
         target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -212,7 +212,13 @@ def _make_default_array(attr, schema, ctx):
 
     if attr == primary_array_name:
         if ctx.shape is not None:
+            # primary array already exists
             shape = ctx.shape
+            _validate_primary_shape(schema, shape)
+        elif ctx._shape is not None:
+            # hit when get_default is called during datamodel init to set primary array
+            # for the first time
+            shape = ctx._shape
             _validate_primary_shape(schema, shape)
         elif ndim is not None:
             shape = tuple([0] * ndim)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -211,8 +211,8 @@ def _make_default_array(attr, schema, ctx):
     primary_array_name = ctx.get_primary_array_name()
 
     if attr == primary_array_name:
-        if ctx.shape is not None:
-            shape = ctx.shape
+        if ctx._shape is not None:
+            shape = ctx._shape
             _validate_primary_shape(schema, shape)
         elif ndim is not None:
             shape = tuple([0] * ndim)

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -211,15 +211,16 @@ def _make_default_array(attr, schema, ctx):
     primary_array_name = ctx.get_primary_array_name()
 
     if attr == primary_array_name:
-        if ctx.shape is not None:
+        if getattr(ctx, "_init_shape", None) is not None:
+            # _init_shape only exists during datamodel init to set primary array
+            # for the first time
+            shape = ctx._init_shape
+            _validate_primary_shape(schema, shape)
+        elif ctx.shape is not None:
             # primary array already exists
             shape = ctx.shape
             _validate_primary_shape(schema, shape)
-        elif ctx._shape is not None:
-            # hit when get_default is called during datamodel init to set primary array
-            # for the first time
-            shape = ctx._shape
-            _validate_primary_shape(schema, shape)
+
         elif ndim is not None:
             shape = tuple([0] * ndim)
         else:

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -211,8 +211,8 @@ def _make_default_array(attr, schema, ctx):
     primary_array_name = ctx.get_primary_array_name()
 
     if attr == primary_array_name:
-        if ctx._shape is not None:
-            shape = ctx._shape
+        if ctx.shape is not None:
+            shape = ctx.shape
             _validate_primary_shape(schema, shape)
         elif ndim is not None:
             shape = tuple([0] * ndim)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -81,12 +81,6 @@ def test_shape_primary_removed(delete_how):
         assert default_non_primary.size == 0
 
 
-def test_shape_returns_none_when_primary_set_to_none():
-    with BasicModel((50, 50)) as dm:
-        dm.data = None
-        assert dm.shape is None
-
-
 def test_shape_custom_primary():
     with DefaultsModel((50, 50)) as dm:
         assert dm.shape == (50, 50)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,17 +60,16 @@ def test_shape_stays_in_sync():
         assert dm.shape is None
 
 
-def test_shape_reverts_to_original():
+def test_shape_returns_none_when_primary_deleted():
     with BasicModel((50, 50)) as dm:
-        # deleting primary should reset shape to init value
         del dm.data
-        assert dm.shape == (50, 50)
+        assert dm.shape is None
 
-        # making primary None should reset shape to init value
-        # this happens even if primary array is set in the meantime
-        dm.data = np.zeros((10, 10))
+
+def test_shape_returns_none_when_primary_set_to_none():
+    with BasicModel((50, 50)) as dm:
         dm.data = None
-        assert dm.shape == (50, 50)
+        assert dm.shape is None
 
 
 def test_shape_custom_primary():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,7 @@ def test_shape_stays_in_sync():
         dm.area = np.zeros((10, 10))
         assert dm.shape == (42, 23)
 
-        # since BasicModel was init from nothing, shape reverts to None
+        # primary array deleted, shape reverts to None
         del dm.data
         assert dm.shape is None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,9 +55,22 @@ def test_shape_stays_in_sync():
         dm.area = np.zeros((10, 10))
         assert dm.shape == (42, 23)
 
-        # deleting primary should set shape to None
+        # since BasicModel was init from nothing, shape reverts to None
         del dm.data
         assert dm.shape is None
+
+
+def test_shape_reverts_to_original():
+    with BasicModel((50, 50)) as dm:
+        # deleting primary should reset shape to init value
+        del dm.data
+        assert dm.shape == (50, 50)
+
+        # making primary None should reset shape to init value
+        # this happens even if primary array is set in the meantime
+        dm.data = np.zeros((10, 10))
+        dm.data = None
+        assert dm.shape == (50, 50)
 
 
 def test_shape_custom_primary():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,6 +40,39 @@ def test_set_shape():
             dm.shape = (42, 23)
 
 
+def test_shape_stays_in_sync():
+    """Ensure shape attribute always reflects primary array shape."""
+    with BasicModel() as dm:
+        # None when primary unset
+        assert dm.shape is None
+        dm.data = np.zeros((50, 50))
+        assert dm.shape == (50, 50)
+
+        dm.data = np.zeros((42, 23))
+        assert dm.shape == (42, 23)
+
+        # modifying non-primary does not change shape
+        dm.area = np.zeros((10, 10))
+        assert dm.shape == (42, 23)
+
+        # deleting primary should set shape to None
+        del dm.data
+        assert dm.shape is None
+
+
+def test_shape_custom_primary():
+    with DefaultsModel((50, 50)) as dm:
+        assert dm.shape == (50, 50)
+        assert dm.primary.shape == (50, 50)
+        assert not dm.hasattr("data")
+
+        dm.primary = np.zeros((42, 23))
+        assert dm.shape == (42, 23)
+
+        dm.data = np.zeros((10, 10))
+        assert dm.shape == (42, 23)
+
+
 def test_broadcast():
     with BasicModel((50, 50)) as dm:
         data = np.zeros((50,))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -280,6 +280,17 @@ def test_get_default_arr():
         np.testing.assert_allclose(default_data, 3.0)
 
 
+def test_get_default_primary_modified():
+    """Test get_default stays in sync with shape attribute."""
+    with DefaultsModel((10, 10)) as im:
+        new_shp = (9, 9)
+        im.primary = np.zeros(new_shp)
+        default_primary = im.get_default("primary")
+        data = im.get_default("data")
+        assert data.shape == new_shp
+        assert default_primary.shape == new_shp
+
+
 def test_hasattr_in_inconsistency():
     """
     Test that hasattr returns True for schema-defined attributes even if they are not set in the instance.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,10 +60,25 @@ def test_shape_stays_in_sync():
         assert dm.shape is None
 
 
-def test_shape_returns_none_when_primary_deleted():
+@pytest.mark.parametrize("delete_how", ["del", "set_none"])
+def test_shape_primary_removed(delete_how):
     with BasicModel((50, 50)) as dm:
-        del dm.data
+        if delete_how == "del":
+            del dm.data
+        elif delete_how == "set_none":
+            dm.data = None
+
+        # shape should be None now
         assert dm.shape is None
+
+        # get_default should return empty array
+        default_primary = dm.get_default("data")
+        assert isinstance(default_primary, np.ndarray)
+        assert default_primary.size == 0
+
+        default_non_primary = dm.get_default("area")
+        assert isinstance(default_non_primary, np.ndarray)
+        assert default_non_primary.size == 0
 
 
 def test_shape_returns_none_when_primary_set_to_none():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially addresses [JP-4293](https://jira.stsci.edu/browse/JP-4293)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #681 

<!-- describe the changes comprising this PR here -->
This PR causes the `model.shape` attribute to always query the primary array shape and return that, fixing a bug where `model.shape` could become stale when the primary array was re-set.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
