### PR TITLE
Fix to_fits signature to correctly raise NotImplementedError

### DIFF
--- a/src/stdatamodels/jwst/datamodels/tsophot.py
+++ b/src/stdatamodels/jwst/datamodels/tsophot.py
@@ -37,7 +37,7 @@ class TsoPhotModel(ReferenceFileModel):
     def on_save(self, path=None):  # noqa: D102
         self.meta.reftype = self.reftype
 
-    def to_fits(self):  # noqa: D102
+    def to_fits(self, *args, **kwargs):  # noqa: D102
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):  # noqa: D102

--- a/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
+++ b/src/stdatamodels/jwst/datamodels/wcs_ref_models.py
@@ -92,7 +92,7 @@ class _SimpleModel(ReferenceFileModel):
         """
         raise NotImplementedError
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         """Override base class to specify that reference files are not writable to FITS."""
         raise NotImplementedError("FITS format is not supported for this file.")
 
@@ -218,7 +218,7 @@ class DistortionMRSModel(ReferenceFileModel):
         self.meta.input_units = u.pix
         self.meta.output_units = u.arcsec
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -377,7 +377,7 @@ class NIRCAMGrismModel(ReferenceFileModel):
             else:
                 warnings.warn(traceback.format_exc(), ValidationWarning, stacklevel=2)
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
 
@@ -459,7 +459,7 @@ class NIRISSGrismModel(ReferenceFileModel):
             else:
                 warnings.warn(traceback.format_exc(), ValidationWarning, stacklevel=2)
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
 
@@ -541,7 +541,7 @@ class MiriWFSSSpecwcsModel(ReferenceFileModel):
             else:
                 warnings.warn(traceback.format_exc(), ValidationWarning, stacklevel=2)
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
 
@@ -686,7 +686,7 @@ class RegionsModel(ReferenceFileModel):
     def on_save(self, path=None):
         self.meta.reftype = self.reftype
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -780,7 +780,7 @@ class WavelengthrangeModel(ReferenceFileModel):
     def on_save(self, path=None):
         self.meta.reftype = self.reftype
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file")
 
     def validate(self):
@@ -860,7 +860,7 @@ class FPAModel(ReferenceFileModel):
         NRS_MIMF|NRS_MSATA|NRS_WATA|NRS_LAMP|NRS_BRIGHTOBJ|"
         self.meta.exposure.type = "N/A"
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -923,7 +923,7 @@ class IFUPostModel(ReferenceFileModel):
         self.meta.exposure.type = "NRS_IFU"
         self.meta.exposure.p_exptype = "NRS_IFU"
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -969,7 +969,7 @@ class IFUSlicerModel(ReferenceFileModel):
         self.meta.exposure.type = "NRS_IFU"
         self.meta.exposure.p_exptype = "NRS_IFU"
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -1019,7 +1019,7 @@ class MSAModel(ReferenceFileModel):
         NRS_MIMF|NRS_MSATA|NRS_WATA|NRS_LAMP|NRS_BRIGHTOBJ|"
         self.meta.exposure.type = "N/A"
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):
@@ -1124,7 +1124,7 @@ class DisperserModel(ReferenceFileModel):
         NRS_MIMF|NRS_MSATA|NRS_WATA|NRS_LAMP|NRS_BRIGHTOBJ|"
         self.meta.exposure.type = "N/A"
 
-    def to_fits(self):
+    def to_fits(self, *args, **kwargs):
         raise NotImplementedError("FITS format is not supported for this file.")
 
     def validate(self):

--- a/tests/jwst/datamodels/test_wcs.py
+++ b/tests/jwst/datamodels/test_wcs.py
@@ -44,9 +44,10 @@ def test_simple_model_to_fits_not_implemented():
     not TypeError (which was the bug before the *args, **kwargs signature fix).
     See https://github.com/spacetelescope/stdatamodels/pull/744
     """
-    import tempfile
     import os
+    import tempfile
     import warnings
+
     from stdatamodels.jwst.datamodels import DistortionModel
 
     with warnings.catch_warnings():

--- a/tests/jwst/datamodels/test_wcs.py
+++ b/tests/jwst/datamodels/test_wcs.py
@@ -36,3 +36,36 @@ def test_wcs_ref_models():
         fo.meta.instrument.channel = "SHORT"
         fo.meta.instrument.module = "A"
         fo.validate()
+
+
+def test_simple_model_to_fits_not_implemented():
+    """
+    Test that _SimpleModel subclasses raise NotImplementedError on to_fits(),
+    not TypeError (which was the bug before the *args, **kwargs signature fix).
+    See https://github.com/spacetelescope/stdatamodels/pull/744
+    """
+    import tempfile
+    import os
+    import warnings
+    from stdatamodels.jwst.datamodels import DistortionModel
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with DistortionModel(distort_type="test", pupil="TEST", strict_validation=False) as m:
+            m.meta.description = "test"
+            m.meta.reftype = "distortion"
+            m.meta.author = "test"
+            m.meta.pedigree = "GROUND"
+            m.meta.useafter = "2015-10-01"
+            m.meta.instrument.name = "NIRCAM"
+            m.validate()
+
+            with tempfile.NamedTemporaryFile(suffix=".fits", delete=False) as f:
+                tmp = f.name
+
+            try:
+                with pytest.raises(NotImplementedError, match="FITS format is not supported"):
+                    m.save(tmp)
+            finally:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)


### PR DESCRIPTION
Closes #742

**Description**

When `save()` calls `to_fits(output_path, *args, **kwargs)` from the base model, any subclasses that override `to_fits` without accepting `*args, **kwargs` will throw a `TypeError` (e.g., unexpected keyword argument 'overwrite') before the intended `NotImplementedError` can be raised.

This PR simply updates the signature of `to_fits` in the affected reference models (in `wcs_ref_models.py` and `tsophot.py`) to accept `*args` and `**kwargs`, allowing the `NotImplementedError` to surface correctly with the intended message.
