### PR TITLE
JP-3959: Add the WCS tag to datamodels schemas

### DIFF
--- a/changes/746.bugfix.rst
+++ b/changes/746.bugfix.rst
@@ -1,0 +1,1 @@
+Add ``meta.wcs`` to the core schema and add wcs tag validation, fixing a bug where ``hasattr(model.meta, "wcs")`` would return False if ``wcs`` was schema-defined but not present, which is inconsistent with other attributes. Also allows TAB-expansion to show the wcs attribute.

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -13,7 +13,7 @@ from asdf import schema as asdf_schema
 from asdf import tagged, treeutil
 from asdf.exceptions import ValidationError
 from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
-from asdf.util import HashableDict
+from asdf.util import HashableDict, uri_match
 from astropy import time
 from astropy.io import fits
 from astropy.utils.exceptions import AstropyWarning
@@ -376,17 +376,32 @@ def _get_validators(hdulist):
     fits_context = FitsContext(hdulist)
 
     validators = HashableDict(asdf_schema.YAML_VALIDATORS)
-    tag_validator = validators["tag"]
 
-    def validate_tag(validator, tag_pattern, instance, schema):
-        af = asdf.AsdfFile()
-        if af.extension_manager.handles_type(instance.__class__):
-            for tag in af.extension_manager.get_converter_for_type(instance.__class__).tags:
-                tag_validator(validator, tag_pattern, tag, schema)
+    # create an extension_manager for validate_tag
+    extension_manager = asdf.AsdfFile().extension_manager
+
+    def validate_tag(validator, tag_pattern, instance, schema, extension_manager=extension_manager):
+        if not extension_manager.handles_type(instance.__class__):
+            yield ValidationError(
+                f"Unsupported {instance} does not have a tag matching pattern {tag_pattern}"
+            )
             return
-        raise ValidationError(
-            f"Unsupported {instance} does not have a tag matching pattern {tag_pattern}"
-        )
+
+        # we don't know yet which of these tags will be used so check them all
+        tags = extension_manager.get_converter_for_type(instance.__class__).tags
+
+        # did we find tags?
+        if not tags:
+            yield ValidationError(
+                f"type '{instance.__class__}' has no valid tags to check against '{tag_pattern}'"
+            )
+            return
+
+        # select_tag requires a SerializationContext which we don't have so check all tags
+        match = all(uri_match(tag_pattern, tag) for tag in tags)
+        if not match:
+            yield ValidationError(f"tags '{tags}' do not match pattern '{tag_pattern}'")
+            return
 
     partial_fits_array_writer = partial(_fits_array_writer, fits_context)
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -11,6 +11,7 @@ import asdf
 import numpy as np
 from asdf import schema as asdf_schema
 from asdf import tagged, treeutil
+from asdf.exceptions import ValidationError
 from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict
 from astropy import time
@@ -375,6 +376,17 @@ def _get_validators(hdulist):
     fits_context = FitsContext(hdulist)
 
     validators = HashableDict(asdf_schema.YAML_VALIDATORS)
+    tag_validator = validators["tag"]
+
+    def validate_tag(validator, tag_pattern, instance, schema):
+        af = asdf.AsdfFile()
+        if af.extension_manager.handles_type(instance.__class__):
+            for tag in af.extension_manager.get_converter_for_type(instance.__class__).tags:
+                tag_validator(validator, tag_pattern, tag, schema)
+            return
+        raise ValidationError(
+            f"Unsupported {instance} does not have a tag matching pattern {tag_pattern}"
+        )
 
     partial_fits_array_writer = partial(_fits_array_writer, fits_context)
 
@@ -387,6 +399,7 @@ def _get_validators(hdulist):
             "items": partial(_fits_item_recurse, fits_context),
             "properties": partial(_fits_comment_section_handler, fits_context),
             "type": partial(_fits_type, fits_context),
+            "tag": validate_tag,
         }
     )
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -11,6 +11,7 @@ import asdf
 import numpy as np
 from asdf import schema as asdf_schema
 from asdf import tagged, treeutil
+from asdf.exceptions import ValidationError
 from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict
 from astropy import time
@@ -373,6 +374,17 @@ def _get_validators(hdulist):
     fits_context = FitsContext(hdulist)
 
     validators = HashableDict(asdf_schema.YAML_VALIDATORS)
+    tag_validator = validators["tag"]
+
+    def validate_tag(validator, tag_pattern, instance, schema):
+        af = asdf.AsdfFile()
+        if af.extension_manager.handles_type(instance.__class__):
+            for tag in af.extension_manager.get_converter_for_type(instance.__class__).tags:
+                tag_validator(validator, tag_pattern, tag, schema)
+            return
+        raise ValidationError(
+            f"Unsupported {instance} does not have a tag matching pattern {tag_pattern}"
+        )
 
     partial_fits_array_writer = partial(_fits_array_writer, fits_context)
 
@@ -385,6 +397,7 @@ def _get_validators(hdulist):
             "items": partial(_fits_item_recurse, fits_context),
             "properties": partial(_fits_comment_section_handler, fits_context),
             "type": partial(_fits_type, fits_context),
+            "tag": validate_tag,
         }
     )
 

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2891,3 +2891,8 @@ properties:
             type: number
             fits_keyword: BKGD_SCL
             blend_table: True
+      wcs:
+        title: WCS object
+        anyOf:
+          - tag: tag:stsci.edu:gwcs/wcs-*
+          - type: "null"

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2893,6 +2893,4 @@ properties:
             blend_table: True
       wcs:
         title: WCS object
-        anyOf:
-          - tag: tag:stsci.edu:gwcs/wcs-*
-          - type: "null"
+        tag: tag:stsci.edu:gwcs/wcs-*

--- a/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/core.schema.yaml
@@ -2944,3 +2944,8 @@ properties:
             type: number
             fits_keyword: BKGD_SCL
             blend_table: True
+      wcs:
+        title: WCS object
+        anyOf:
+          - tag: tag:stsci.edu:gwcs/wcs-*
+          - type: "null"

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -1110,3 +1110,11 @@ def test_nested_get_dtype():
         dm.spec.append(SpecModel())
         dtype = dm.spec[0].get_dtype("spec_table")
         assert isinstance(dtype, np.dtype)
+
+
+def test_wcs_hasattr():
+    """Cover a bug where hasattr('wcs') had different behavior than other attributes."""
+    with ImageModel() as dm:
+        assert hasattr(dm.meta, "wcs")
+        assert not dm.meta.hasattr("wcs")
+        assert "wcs" not in dm.meta

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -1045,3 +1045,11 @@ def test_nested_get_dtype():
         dm.spec.append(SpecModel())
         dtype = dm.spec[0].get_dtype("spec_table")
         assert isinstance(dtype, np.dtype)
+
+
+def test_wcs_hasattr():
+    """Cover a bug where hasattr('wcs') had different behavior than other attributes."""
+    with ImageModel() as dm:
+        assert hasattr(dm.meta, "wcs")
+        assert not dm.meta.hasattr("wcs")
+        assert "wcs" not in dm.meta

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -19,9 +19,8 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 @pytest.fixture
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
-    w = {"inputs": "test"}
-    w["outputs"] = w
-    return w
+    from gwcs import examples
+    return examples.gwcs_2d_shift_scale()
 
 
 @pytest.fixture

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -20,6 +20,7 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
     from gwcs import examples
+
     return examples.gwcs_2d_shift_scale()
 
 

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -18,7 +18,7 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 
 
 @pytest.fixture
-def recursive_tree():
+def example_wcs():
     """Create a recursive tree to substitute for a WCS object"""
     return examples.gwcs_2d_shift_scale()
 

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -24,12 +24,12 @@ def example_wcs():
 
 
 @pytest.fixture
-def imagemodel(recursive_tree):
+def imagemodel(example_wcs):
     """Create an imagemodel with meta attributes and data array."""
     data = np.zeros((10, 10), dtype=np.float32)
     model = dm.ImageModel(data)
     model.meta.instrument.filter = FILT
-    model.meta.wcs = recursive_tree
+    model.meta.wcs = example_wcs
 
     model.cal_logs = {
         "assign_wcs": ["baz", "qux"],

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.time import Time
+from gwcs import examples
 
 import stdatamodels.jwst.datamodels as dm
 from stdatamodels.jwst.datamodels.util import _to_flat_dict, read_metadata
@@ -19,10 +20,7 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 @pytest.fixture
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
-    # return examples.gwcs_2d_shift_scale()
-    w = {"inputs": "test"}
-    w["outputs"] = w
-    return w
+    return examples.gwcs_2d_shift_scale()
 
 
 @pytest.fixture

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.time import Time
+from gwcs import examples
 
 import stdatamodels.jwst.datamodels as dm
 from stdatamodels.jwst.datamodels.util import _to_flat_dict, read_metadata
@@ -19,8 +20,6 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 @pytest.fixture
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
-    from gwcs import examples
-
     return examples.gwcs_2d_shift_scale()
 
 

--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.time import Time
-from gwcs import examples
 
 import stdatamodels.jwst.datamodels as dm
 from stdatamodels.jwst.datamodels.util import _to_flat_dict, read_metadata
@@ -20,7 +19,10 @@ INPUT_TIME = "2021-01-01 00:00:00.000"
 @pytest.fixture
 def recursive_tree():
     """Create a recursive tree to substitute for a WCS object"""
-    return examples.gwcs_2d_shift_scale()
+    # return examples.gwcs_2d_shift_scale()
+    w = {"inputs": "test"}
+    w["outputs"] = w
+    return w
 
 
 @pytest.fixture

--- a/tests/jwst/datamodels/test_validation.py
+++ b/tests/jwst/datamodels/test_validation.py
@@ -57,7 +57,6 @@ def test_wcs_validation_on_assignment(value, error, strict):
             dm.meta.wcs = value
         if error:
             assert dm.meta.wcs is None
-            dm.meta.instance["wcs"] = value
         else:
             assert dm.meta.wcs is value
 

--- a/tests/jwst/datamodels/test_validation.py
+++ b/tests/jwst/datamodels/test_validation.py
@@ -1,9 +1,13 @@
+import contextlib
 from datetime import datetime
 
+import numpy as np
 import pytest
 from asdf.exceptions import ValidationError
 from astropy import time
+from gwcs.examples import gwcs_2d_shift_scale
 
+from stdatamodels.exceptions import ValidationWarning
 from stdatamodels.jwst.datamodels import JwstDataModel
 
 
@@ -28,3 +32,58 @@ def test_strict_validation_date():
         assert isinstance(time_obj, time.Time)
         date_obj = datetime.strptime(dm.meta.date, "%Y-%m-%dT%H:%M:%S.%f")
         assert isinstance(date_obj, datetime)
+
+
+@pytest.mark.parametrize(
+    "value, error",
+    [
+        [None, False],
+        [1, True],
+        [np.array([1, 2, 3]), True],
+        [gwcs_2d_shift_scale(), False],
+    ],
+)
+@pytest.mark.parametrize("strict", [True, False])
+def test_wcs_validation_on_assignment(value, error, strict):
+    if error:
+        if strict:
+            ctx = pytest.raises(ValidationError)
+        else:
+            ctx = pytest.warns(ValidationWarning)
+    else:
+        ctx = contextlib.nullcontext()
+    with JwstDataModel(strict_validation=strict) as dm:
+        with ctx:
+            dm.meta.wcs = value
+        if error:
+            assert dm.meta.wcs is None
+            dm.meta.instance["wcs"] = value
+        else:
+            assert dm.meta.wcs is value
+
+
+@pytest.mark.parametrize(
+    "value, error",
+    [
+        [None, False],
+        [1, True],
+        [np.array([1, 2, 3]), True],
+        [gwcs_2d_shift_scale(), False],
+    ],
+)
+@pytest.mark.parametrize("strict", [True, False])
+@pytest.mark.parametrize("ext", ["fits", "asdf"])
+def test_wcs_validation_on_save(tmp_path, ext, value, error, strict):
+    fn = tmp_path / f"test.{ext}"
+    if error:
+        ctx = pytest.raises(ValidationError)
+        if ext == "asdf":
+            pytest.xfail(
+                "saving to asdf does not correctly trigger wcs (or other custom) validation"
+            )
+    else:
+        ctx = contextlib.nullcontext()
+    with JwstDataModel(strict_validation=strict) as dm:
+        dm.meta.instance["wcs"] = value
+        with ctx:
+            dm.save(fn)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-3959](https://jira.stsci.edu/browse/JP-3959)

Fixes https://github.com/spacetelescope/jwst/issues/7020

<!-- describe the changes comprising this PR here -->
This PR addresses an oversight in the schemas where the WCS tag is missing from the schemas and never validated.

The side effects of this change are:
- TAB-expansion now shows the `wcs` attribute.
- `hasattr(model.meta, "wcs")` now returns `True` if the wcs attribute is schema-defined but not present, consistent with the behavior of other attributes.  Prior to this PR it would return False in that case, which was a unique behavior of `model.meta.wcs` specifically.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
