### PR TITLE
Fix FITS bug for list-type metadata

### DIFF
--- a/changes/748.bugfix.rst
+++ b/changes/748.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in saving datamodels to FITS files that caused extra HDUs to be created for datamodels with list-type metadata.

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -338,15 +338,12 @@ def _fits_item_recurse(fits_context, validator, items, instance, schema):
         return
 
     if validator.is_type(items, "object"):
+        initial_index = fits_context.sequence_index
         for index, item in enumerate(instance):
-            # Update the FITS sequence index if it is a list of objects,
-            # to support things like lists of slits or spectra. No need
-            # if it is just a simple list of items.
-            if validator.is_type(item, "object"):
-                fits_context.sequence_index = index
-
+            fits_context.sequence_index = index
             for error in validator.descend(item, items, path=index):
                 yield error
+        fits_context.sequence_index = initial_index
     else:
         # We don't do the index trick on "tuple validated" sequences
         for (index, item), subschema in zip(enumerate(instance), items, strict=False):

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -339,7 +339,12 @@ def _fits_item_recurse(fits_context, validator, items, instance, schema):
 
     if validator.is_type(items, "object"):
         for index, item in enumerate(instance):
-            fits_context.sequence_index = index
+            # Update the FITS sequence index if it is a list of objects,
+            # to support things like lists of slits or spectra. No need
+            # if it is just a simple list of items.
+            if validator.is_type(item, "object"):
+                fits_context.sequence_index = index
+
             for error in validator.descend(item, items, path=index):
                 yield error
     else:

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -700,3 +700,84 @@ def test_fitsrec_for_non_schema_data(tmp_path):
     )
     fn = tmp_path / "test.fits"
     m.save(fn)
+
+
+def test_simple_array(tmp_path):
+    """Test that list-type metadata does not generate empty output HDUs."""
+    file_path = tmp_path / "test.fits"
+    data_array_schema = {
+        "allOf": [
+            asdf.schema.load_schema(
+                "http://example.com/schemas/core_metadata", resolve_references=True
+            ),
+            {
+                "type": "object",
+                "properties": {
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            # store a simple array in metadata
+                            "simple_array": {
+                                "type": "array",
+                                "items": {"type": "array", "items": {"type": "number"}},
+                            },
+                            # add more metadata after the list
+                            "other_metadata": {"type": "string", "fits_keyword": "TEST"},
+                        },
+                    },
+                    "data_array": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "fits_hdu": "SCI",
+                                    "default": 0.0,
+                                    "ndim": 2,
+                                    "datatype": "float64",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+    }
+
+    # Make a model with 3 data arrays, a simple array of metadata values, and one
+    # other metadata item that comes after the simple array in the schema.
+    rng = np.random.default_rng(42)
+    array1 = rng.random((5, 5))
+    array2 = rng.random((5, 5))
+    array3 = rng.random((5, 5))
+    list_items = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12, 13]]
+    with DataModel(schema=data_array_schema) as x:
+        x.meta.other_metadata = "VALUE"
+        for array_item in [array1, array2, array3]:
+            x.data_array.append(x.data_array.item(data=array_item))
+        assert len(x.data_array) == 3
+
+        x.meta.simple_array = list_items
+        assert len(x.meta.simple_array) == len(list_items)
+
+        x.validate()
+        x.to_fits(file_path)
+
+    # FITS file has new extensions for the data arrays, but no extra extensions
+    # for the simple array
+    with fits.open(file_path) as hdulist:
+        # one primary, 3 SCI extensions, 1 ASDF
+        assert len(hdulist) == 5
+        assert hdulist[0].header["TEST"] == "VALUE"
+        for i, array_item in enumerate([array1, array2, array3]):
+            hdu = hdulist[i + 1]
+            assert hdu.name == "SCI"
+            assert hdu.header["EXTVER"] == i + 1
+            assert np.allclose(hdu.data, array_item)
+
+    # All data and metadata roundtrip from the FITS file
+    with DataModel(file_path, schema=data_array_schema) as x:
+        assert len(x.data_array) == 3
+        assert len(x.meta.simple_array) == len(list_items)
+        assert x.meta.simple_array == list_items
+        assert x.meta.other_metadata == "VALUE"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Toward [JP-4313](https://jira.stsci.edu/browse/JP-4313)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
<!-- describe the changes comprising this PR here -->

To produce accurate rate values, some multistripe modes will require explicit read times for all readout frames in each group.  See #739 for the draft implementation to support this, which stores the read time values in a list of lists inside `meta.exposure.read_times`.  This is similar to the `meta.exposure.read_pattern` metadata stored for Roman datamodels: https://github.com/spacetelescope/rad/blob/b7879d2c36bdac7006a57c9971b8ae8dbb157ee4/src/rad/resources/schemas/meta/exposure-1.2.0.yaml#L197

Using this draft implementation, I noticed that RampModels saved as FITS files with `meta.exposure.read_times` set generated many extra FITS extensions, mostly empty.  I tracked it down to the `_fits_item_recurse` validator, which sets a sequence index whenever it encounters list-type attributes.  This is appropriate for lists of objects, like slits or spectra, since this is how it knows to start a new extension version for a new slit or spectrum.  It is not appropriate for list-type primary metadata: when encountered, the update to the sequence index makes any metadata defined later in the schema think it's supposed to go into a new primary header extension.

The fix here is to update the sequence index only if the list-type item contains an object.   This works for the use case I need it for, and shouldn't break any other existing JWST schemas, but it may be fragile to other kinds of stored metadata.  I'm open to alternate fixes if anyone can think of a more general one, or a better way to store the necessary metadata in #739.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
