### PR TITLE
JP-4240: Add inverse coeffs to linearity model

### DIFF
--- a/changes/749.feature.rst
+++ b/changes/749.feature.rst
@@ -1,0 +1,1 @@
+Add inverse linearity coefficients as an optional array to LinearityModel.

--- a/src/stdatamodels/jwst/datamodels/linearity.py
+++ b/src/stdatamodels/jwst/datamodels/linearity.py
@@ -11,11 +11,13 @@ class LinearityModel(ReferenceFileModel, DefaultDQMixin):
     Attributes
     ----------
     coeffs : numpy float32 array
-         Linearity coefficients
+        Linearity coefficients
+    inv_coeffs : numpy float32 array, optional
+        Inverse linearity coefficients
     dq : numpy uint32 array
-         Data quality flags
+        Data quality flags
     dq_def : numpy table
-         DQ flag definitions
+        DQ flag definitions
     """
 
     schema_url = "http://stsci.edu/schemas/jwst_datamodel/linearity.schema"

--- a/src/stdatamodels/jwst/datamodels/schemas/linearity.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/linearity.schema.yaml
@@ -19,7 +19,7 @@ allOf:
       datatype: float32
     inv_coeffs:
       title: Inverse linearity coefficients
-      fits_hdu: INV_COEF
+      fits_hdu: INV_COEFFS
       ndim: 3
       datatype: float32
     dq:

--- a/src/stdatamodels/jwst/datamodels/schemas/linearity.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/linearity.schema.yaml
@@ -17,6 +17,11 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
+    inv_coeffs:
+      title: Inverse linearity coefficients
+      fits_hdu: INV_COEF
+      ndim: 3
+      datatype: float32
     dq:
       title: Data quality flags
       fits_hdu: DQ


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4240](https://jira.stsci.edu/browse/JP-4240)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds storage capability for inverse coefficients in the linearity model.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
