### PR TITLE
JP-4279: Update  rscd model for new MIRI subarrays

### DIFF
--- a/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
@@ -12,9 +12,9 @@ allOf:
       fits_hdu: RSCD_GROUP_SKIP
       datatype:
       - name: subarray
-        datatype: [ascii, 13]
+        datatype: [ascii, 17]
       - name: readpatt
-        datatype: [ascii, 8]
+        datatype: [ascii, 12]
       - name: group_skip1
         datatype: int32
       - name: group_skip


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Is needed for   https://jira.stsci.edu/browse/JWSTMIRI-506
<!-- If this PR closes a GitHub issue, reference it here by its number -->

In support of [JP-4279](https://jira.stsci.edu/browse/JP-4279)
and  [JP-4144](https://jira.stsci.edu/browse/JP-4144)
<!-- describe the changes comprising this PR here -->
This PR increases the `subarray` and `readpatt` string length in the RSCD datamodels to accommodate the longer string
names for the new MIRI subarrays (SLITLESSPRISM_IP, SLITLESSPRIM_IPS)  and new readout pattern: FASTGRPAVE8.

This PR needs to be merged before the new RSCD reference file with the new subarray can be delivered to CRDS

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
