### PR TITLE
JP-4144: Update number of characters in SUBARRAY and READPATT table entries

### DIFF
--- a/changes/759.feature.rst
+++ b/changes/759.feature.rst
@@ -1,0 +1,1 @@
+Update multiple data models to accommodate additional characters in the MIRI SUBARRAY and READPATT table entries.

--- a/changes/759.feature.rst
+++ b/changes/759.feature.rst
@@ -1,1 +1,1 @@
-Update multiple data models to accommodate additional characters in the MIRI SUBARRAY and READPATT table entries.
+Update multiple data models to accommodate additional characters in the MIRI SUBARRAY table entries.

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
@@ -17,7 +17,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: eefraction
         datatype: float32
       - name: radius

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_apcorr.schema.yaml
@@ -17,7 +17,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: eefraction
         datatype: float32
       - name: radius

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -18,7 +18,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -32,7 +32,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -48,7 +48,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -70,7 +70,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -18,7 +18,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -32,7 +32,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -48,7 +48,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -70,7 +70,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
@@ -15,7 +15,7 @@ allOf:
       fits_hdu: APCORR
       datatype:
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: wavelength
         datatype: float32
         ndim: 1

--- a/src/stdatamodels/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirlrs_apcorr.schema.yaml
@@ -15,7 +15,7 @@ allOf:
       fits_hdu: APCORR
       datatype:
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: wavelength
         datatype: float32
         ndim: 1

--- a/src/stdatamodels/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
@@ -18,7 +18,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -43,7 +43,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -59,7 +59,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -81,7 +81,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirlrs_photom.schema.yaml
@@ -18,7 +18,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -43,7 +43,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -59,7 +59,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -81,7 +81,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/mirwfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirwfss_photom.schema.yaml
@@ -30,7 +30,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -55,7 +55,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -71,7 +71,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -93,7 +93,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 17]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/mirwfss_photom.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/mirwfss_photom.schema.yaml
@@ -30,7 +30,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: photmjsr
         datatype: float32
       - name: uncertainty
@@ -55,7 +55,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -71,7 +71,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD
@@ -93,7 +93,7 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: subarray
-        datatype: [ascii, 15]
+        datatype: [ascii, 20]
       - name: t0
         datatype: float32
         description: Reference day in MJD

--- a/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
@@ -12,9 +12,9 @@ allOf:
       fits_hdu: RSCD_GROUP_SKIP
       datatype:
       - name: subarray
-        datatype: [ascii, 13]
+        datatype: [ascii, 20]
       - name: readpatt
-        datatype: [ascii, 8]
+        datatype: [ascii, 15]
       - name: group_skip1
         datatype: int32
       - name: group_skip

--- a/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/rscd.schema.yaml
@@ -12,9 +12,9 @@ allOf:
       fits_hdu: RSCD_GROUP_SKIP
       datatype:
       - name: subarray
-        datatype: [ascii, 20]
+        datatype: [ascii, 13]
       - name: readpatt
-        datatype: [ascii, 15]
+        datatype: [ascii, 8]
       - name: group_skip1
         datatype: int32
       - name: group_skip


### PR DESCRIPTION
Partially resolves [JP-4144](https://jira.stsci.edu/browse/JP-4144) by increasing the number of characters available to the SUBARRAY keyword for various data models.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
