### PR TITLE
fix test for pytest 9.1

### DIFF
--- a/tests/jwst/datamodels/test_read_metadata.py
+++ b/tests/jwst/datamodels/test_read_metadata.py
@@ -167,9 +167,10 @@ def test_read_metadata_multislit_nested(multislit_path):
     assert meta["slits"][1]["name"] == "slit1"
 
 
-@pytest.mark.parametrize("multislit_path", ["fits"], indirect=True)
-def test_multislit_fits_update(multislit_path):
+def test_multislit_fits_update(tmp_path, multislitmodel):
     """Ensure a fits_update is done for slit metadata, even though slits is list-like."""
+    multislit_path = tmp_path / (MULTISLITFILE_ROOT + ".fits")
+    multislitmodel.save(multislit_path)
     new_slitname = "foo"
     new_filename = "multislit_modified.fits"
     new_path = multislit_path.with_name(new_filename)


### PR DESCRIPTION
pytest 9.1 produces an error:
tests/jwst/datamodels/test_read_metadata.py::test_multislit_fits_update: duplicate parametrization of 'multislit_path'

https://github.com/spacetelescope/stdatamodels/actions/runs/27542208715/job/81406612583#step:11:103

due to a re-parameterization via an indirectly used fixture. This simplifies the test to make it compatible with pytest 9.1

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
