### PR TITLE
add 3.15 testing

### DIFF
--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -66,6 +66,8 @@ jobs:
         - macos: py311-xdist
         - windows: py311-xdist-nocrds
         - linux: py3-devdeps-xdist
+        - linux: py315-devdeps-xdist
+          python-version: 3.15
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1  # v3.0.2
     needs: [ data ]


### PR DESCRIPTION
Blocked by lack of scipy 3.15 wheels:
https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scipy/

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
