### PR TITLE
convert test to use uint8 columns

### DIFF
--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -654,8 +654,8 @@ def test_table_linking(tmp_path):
                 "title": "Test table",
                 "fits_hdu": "TESTTABL",
                 "datatype": [
-                    {"name": "A_COL", "datatype": "int8"},
-                    {"name": "B_COL", "datatype": "int8"},
+                    {"name": "A_COL", "datatype": "uint8"},
+                    {"name": "B_COL", "datatype": "uint8"},
                 ],
             },
         },


### PR DESCRIPTION
Update a test to use `uint8` instead of `int8` columns.

`int8` columns are essentially "not supported" in astropy (https://github.com/astropy/astropy/issues/11963) since they do not actually represent `int8` values and instead are forced to be "boolean-like" values (https://github.com/astropy/astropy/pull/19940) and in 8.0.1 will produce an exception if a non-boolean-like value is provided.

I think as long as we're using FITS as a format and astropy to support FITS we're stuck with this limitation.

Fixes: #764

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
