### PR TITLE
Switch oifits FLAG columns from int8 to bool8 in schemas

### DIFF
--- a/changes/769.bugfix.rst
+++ b/changes/769.bugfix.rst
@@ -1,0 +1,1 @@
+Switch oifits FLAG columns from int8 to bool8 in schemas and disallow int8 datatype in schemas.

--- a/src/stdatamodels/jwst/datamodels/schemas/oifits.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/oifits.schema.yaml
@@ -308,7 +308,7 @@ allOf:
         datatype: int16
         shape: [3]
       - name: FLAG
-        datatype: int8
+        datatype: bool8
     vis:
       title: OIFITS OI_VIS table
       fits_hdu: OI_VIS
@@ -338,7 +338,7 @@ allOf:
         datatype: int16
         shape: [2]
       - name: FLAG
-        datatype: int8
+        datatype: bool8
     vis2:
       title: OIFITS OI_VIS2 table
       fits_hdu: OI_VIS2
@@ -364,7 +364,7 @@ allOf:
         datatype: int16
         shape: [2]
       - name: FLAG
-        datatype: int8
+        datatype: bool8
     q4:
       title: OIFITS OI_Q4 table
       fits_hdu: OI_Q4
@@ -406,7 +406,7 @@ allOf:
         datatype: int16
         shape: [4]
       - name: FLAG
-        datatype: int8
+        datatype: bool8
     wavelength:
       title: OIFITS OI_WAVELENGTH table
       fits_hdu: OI_WAVELENGTH

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -138,8 +138,22 @@ def _as_fitsrec(val):
         coldefs = fits.ColDefs(val)
         uint = any(c._pseudo_unsigned_ints for c in coldefs)
         if any(c.format == "L" for c in coldefs):
-            # Copy so we can modify the values to match what astropy expects.
-            fits_rec = fits.FITS_rec(val.copy())
+            # Logical (format "L") columns are stored as int8 bytes
+            # in FITS files (ord('T')=84 for True, ord('F')=70 for False).
+            # When the input has bool dtype, writing ord('T')/ord('F')
+            # into a bool array would set both to True (both are non-zero),
+            # so convert bool columns to int8 before creating the FITS_rec.
+            if any(c.format == "L" and np.issubdtype(val.dtype[c.name], np.bool_) for c in coldefs):
+                new_dtype = []
+                for c in coldefs:
+                    if c.format == "L" and np.issubdtype(val.dtype[c.name], np.bool_):
+                        new_dtype.append((c.name, np.int8))
+                    else:
+                        new_dtype.append((c.name, val.dtype[c.name]))
+                fits_rec = fits.FITS_rec(val.astype(new_dtype))
+            else:
+                # Copy so we can modify the values to match what astropy expects.
+                fits_rec = fits.FITS_rec(val.copy())
             for c in coldefs:
                 if c.format == "L":
                     d = fits_rec[c.name]

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -165,6 +165,22 @@ def _safe_asanyarray(a, dtype):
             for old_col, new_col in zip(a.dtype.names, result.dtype.names, strict=False):
                 result[new_col] = a[old_col]
             return result
+        # For logical (format "L") columns, astropy stores int8 bytes
+        # (ord('T')=84, ord('F')=70, 0=NULL) but reports them as bool.
+        # A direct int8->bool cast would map 70 (F) to True (non-zero).
+        # Convert column-by-column so logical columns map correctly.
+        if dtype.fields is not None and a.dtype.fields is not None:
+            logical_cols = {c.name for c in a.columns if c.format == "L"}
+            if logical_cols:
+                result = np.zeros(a.shape, dtype=dtype)
+                for old_col, new_col in zip(a.dtype.names, result.dtype.names, strict=False):
+                    if old_col in logical_cols and np.issubdtype(result.dtype[new_col], np.bool_):
+                        # Map T (84) -> True, F (70) and NULL (0) -> False
+                        raw = np.asarray(a)[old_col]
+                        result[new_col] = raw == ord("T")
+                    else:
+                        result[new_col] = a[old_col]
+                return result
 
     result = np.asanyarray(a, dtype=dtype)
     if isinstance(result, fits.fitsrec.FITS_rec) and isinstance(a, fits.fitsrec.FITS_rec):

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -160,6 +160,12 @@ def _validate_datatype(validator, schema_datatype, instance, schema):
                 compare_schema_type = schema_type
 
             # Using 'equiv' so that we can be flexible on byte order:
+            # bool8 and int8 are equivalent for FITS logical columns
+            # (astropy stores both as int8 bytes in FITS files).
+            if compare_instance_type == np.bool_ and compare_schema_type == np.int8:
+                continue
+            if compare_instance_type == np.int8 and compare_schema_type == np.bool_:
+                continue
             if not np.can_cast(compare_instance_type, compare_schema_type, "equiv"):
                 yield ValidationError(
                     f"Array datatype '{instance_datatype}' is not "

--- a/tests/jwst/test_schemas.py
+++ b/tests/jwst/test_schemas.py
@@ -95,3 +95,38 @@ def test_unit_is_fits(schema_id):
             continue
         fits_unit = astropy.units.Unit(unit).to_string("fits")
         assert unit == fits_unit
+
+
+@pytest.mark.parametrize("schema_id", SCHEMA_IDS)
+def test_no_int8_in_schemas(schema_id):
+    """
+    int8 is not supported by astropy when writing to FITS (it forces values
+    to T/F/\x00). Schemas should use bool8 instead of int8 for FLAG columns
+    and uint8 for DQ flag arrays.
+    """
+    schema = asdf.schema.load_schema(schema_id, resolve_references=True)
+
+    def callback(schema, path, combiner, ctx, recurse):
+        if "datatype" not in schema:
+            return
+        datatype = schema["datatype"]
+        if isinstance(datatype, list):
+            for item in datatype:
+                if isinstance(item, dict) and item.get("datatype") == "int8":
+                    raise AssertionError(
+                        f"int8 datatype found at {path} in {schema_id} "
+                        f"(column {item.get('name', '?')}). "
+                        "Use bool8 for FLAG columns or uint8 for DQ arrays."
+                    )
+                elif item == "int8":
+                    raise AssertionError(
+                        f"int8 datatype found at {path} in {schema_id}. "
+                        "Use bool8 for FLAG columns or uint8 for DQ arrays."
+                    )
+        elif datatype == "int8":
+            raise AssertionError(
+                f"int8 datatype found at {path} in {schema_id}. "
+                "Use bool8 for FLAG columns or uint8 for DQ arrays."
+            )
+
+    walk_schema(schema, callback)


### PR DESCRIPTION
Closes #766

This PR switches OIFITS FLAG columns from `int8` to `bool8` in the oifits schema and disallows `int8` as a datatype in schemas.

## Background

Astropy does not support saving `int8` to FITS and instead forces values to `T`/`F`/`\x00` (targeting astropy 8.0.1). PR #738 fixed the handling of logical int8 columns in `_as_fitsrec`; this PR completes the fix by switching the schemas to `bool8` and adding a test to prevent `int8` from being reintroduced.

## Changes

- **`oifits.schema.yaml`**: 4 FLAG columns `int8` → `bool8` (t3, vis, vis2, q4 tables)
- **`properties.py`** (`_as_fitsrec`): Convert bool → int8 before T/F substitution. Writing `ord('T')` (84) or `ord('F')` (70) into a bool array sets both to True since both values are non-zero.
- **`util.py`** (`_safe_asanyarray`): Convert int8 FITS logical bytes to bool correctly (`T`=84→True, `F`=70→False, `NULL`=0→False) instead of `np.asanyarray` which maps 70 (F) → True (non-zero).
- **`validate.py`** (`_validate_datatype`): Allow `bool8`↔`int8` equivalence for FITS logical columns (astropy stores both as int8 bytes in FITS files).
- **`tests/jwst/test_schemas.py`**: Add `test_no_int8_in_schemas` to prevent reintroduction.

## Test Results

All 1928 tests pass (1 unrelated CRDS network test excluded). All 6 `test_amioi_logical_flag` parametrized tests now pass (previously 4/6).

## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream?
  - [x] write news fragment(s) in `changes/`: `changes/769.bugfix.rst`
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/karlhillx/stdatamodels@fix/oifits-int8-to-bool"`)