### PR TITLE
JP-4014 alternative: use QTable

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -16,6 +16,7 @@ from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict, uri_match
 from astropy import time
 from astropy.io import fits
+from astropy.table import QTable
 from astropy.utils.exceptions import AstropyWarning
 
 from . import properties, util, validate
@@ -303,17 +304,26 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
 
     instance_id = id(instance)
 
-    instance = np.asanyarray(instance)
+    if isinstance(instance, QTable):
+        # Use the underlying structured array for shape/dtype validation
+        array_for_validation = instance.as_array()
+    else:
+        instance = np.asanyarray(instance)
+        array_for_validation = instance
 
-    if not len(instance.shape):
+    if not len(array_for_validation.shape):
         return
 
     if "ndim" in schema:
-        yield from ndarray.validate_ndim(validator, schema["ndim"], instance, schema)
+        yield from ndarray.validate_ndim(validator, schema["ndim"], array_for_validation, schema)
     if "max_ndim" in schema:
-        yield from ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
+        yield from ndarray.validate_max_ndim(
+            validator, schema["max_ndim"], array_for_validation, schema
+        )
     if "datatype" in schema:
-        yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
+        yield from validate._validate_datatype(
+            validator, schema["datatype"], array_for_validation, schema
+        )
 
     hdu_name = _get_hdu_name(schema)
     _assert_non_primary_hdu(hdu_name)
@@ -321,15 +331,41 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
     if index is None:
         index = 0
 
-    hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
-    hdu = _get_or_make_hdu(fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type)
+    if isinstance(instance, QTable):
+        # Resolve weakref to access the hdulist directly
+        hdulist_ref = fits_context.hdulist
+        hdulist = hdulist_ref() if isinstance(hdulist_ref, weakref.ReferenceType) else hdulist_ref
 
-    hdu.data = instance
+        # Preserve any non-builtin header keywords from an existing HDU
+        # (keywords already written earlier in the schema walk)
+        try:
+            existing_hdu = get_hdu(hdulist, hdu_name, index)
+            extra_cards = [
+                (k, v, existing_hdu.header.comments[k])
+                for k, v in existing_hdu.header.items()
+                if not is_builtin_fits_keyword(k)
+            ]
+            hdulist.remove(existing_hdu)
+        except AttributeError:
+            extra_cards = []
+
+        # use fits.BinTableHDU(qtable) to write TUNITn for columns with astropy units
+        hdu = fits.BinTableHDU(instance, name=hdu_name)
+        hdu.ver = index + 1
+        for k, v, c in extra_cards:
+            # Add back the other header info
+            hdu.header.append((k, v, c), end=True)
+        hdulist.append(hdu)
+    else:
+        hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
+        hdu = _get_or_make_hdu(fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type)
+        hdu.data = instance
+        hdu.ver = index + 1
+
     if instance_id in fits_context.extension_array_links:
         if fits_context.extension_array_links[instance_id]() is not hdu:
             raise ValueError("Linking one array to multiple hdus is not supported")
     fits_context.extension_array_links[instance_id] = weakref.ref(hdu)
-    hdu.ver = index + 1
 
 
 # This is copied from jsonschema._validators and modified to keep track
@@ -923,7 +959,11 @@ def _map_hdulist_to_arrays(hdulist, af):
 
 def from_fits_hdu(hdu, schema):
     """
-    Read the data from a FITS HDU into a numpy ndarray.
+    Read the data from a FITS HDU into a numpy ndarray or QTable.
+
+    For structured (table) HDUs, returns a `~astropy.table.QTable` with
+    column units populated from the FITS ``TUNITn`` keywords.  For image
+    HDUs, returns a plain `numpy.ndarray`.
 
     Parameters
     ----------
@@ -934,25 +974,10 @@ def from_fits_hdu(hdu, schema):
 
     Returns
     -------
-    data : numpy.ndarray
+    data : numpy.ndarray or astropy.table.QTable
         The data from the FITS HDU
     """
-    data = hdu.data
-
-    # Save the column listeners for possible restoration
-    if hasattr(data, "_coldefs"):
-        listeners = data._coldefs._listeners
-    else:
-        listeners = None
-
-    # Cast array to type mentioned in schema
-    data = properties._cast(data, schema)
-
-    # Casting a table loses the column listeners, so restore them
-    if listeners is not None:
-        data._coldefs._listeners = listeners
-
-    return data
+    return properties._cast(hdu.data, schema)
 
 
 def _can_skip_fits_update(hdulist, asdf_struct, context):

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 import numpy as np
 from asdf.tags.core import ndarray
 from astropy.io import fits
+from astropy.table import QTable
 
 from . import schema as mschema
 from . import util, validate
@@ -82,21 +83,21 @@ def _cast(val, schema):
                 if "shape" not in t:
                     t["shape"] = shape
 
-        dtype = ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
-
-        # save columns in case this is cast back to a fitsrec
-        if hasattr(val, "columns"):
-            cols = val.columns
+        # Convert structured arrays to QTable
+        if isinstance(val, QTable):
+            pass
+        elif isinstance(val, fits.FITS_rec) and hasattr(val, "columns"):
+            # Encountered when loading table from FITS
+            # Need to convert to a ColDefs, then a BinTableHDU, then a QTable to get the units right
+            val = fits.BinTableHDU.from_columns(val.columns)
+            val = QTable.read(val)
+            # may also need some way to call gentle_asarray here?
         else:
-            cols = None
-        val = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
-
-        if dtype.fields is not None:
-            val = _as_fitsrec(val)
-            if cols is not None:
-                for col in cols:
-                    if col.name in val.names and col.unit is not None:
-                        val.columns[col.name].unit = col.unit
+            dtype = ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
+            val = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
+            if dtype.fields is not None:
+                # If the input is a structured array, convert to a QTable
+                val = QTable(val)
 
     if "ndim" in schema and len(val.shape) != schema["ndim"]:
         raise ValueError(
@@ -116,43 +117,6 @@ def _cast(val, schema):
         val = val.item()
 
     return val
-
-
-def _as_fitsrec(val):
-    """
-    Convert a numpy record into a FITS record if it is not one already.
-
-    Parameters
-    ----------
-    val : numpy.ndarray
-        The numpy record to convert.
-
-    Returns
-    -------
-    fits.FITS_rec
-        The converted FITS record.
-    """
-    if isinstance(val, fits.FITS_rec):
-        return val
-    else:
-        coldefs = fits.ColDefs(val)
-        uint = any(c._pseudo_unsigned_ints for c in coldefs)
-        if any(c.format == "L" for c in coldefs):
-            # Copy so we can modify the values to match what astropy expects.
-            fits_rec = fits.FITS_rec(val.copy())
-            for c in coldefs:
-                if c.format == "L":
-                    d = fits_rec[c.name]
-                    m = d.astype(bool)
-                    d[m] = ord("T")
-                    d[~m] = ord("F")
-        else:
-            fits_rec = fits.FITS_rec(val)
-        fits_rec._coldefs = coldefs
-        # FITS_rec needs to know if it should be operating in pseudo-unsigned-ints mode,
-        # otherwise it won't properly convert integer columns with TZEROn before saving.
-        fits_rec._uint = uint
-        return fits_rec
 
 
 def _get_schema_type(schema):

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -8,6 +8,7 @@ import numpy as np
 from asdf import treeutil
 from asdf.treeutil import RemoveNode
 from astropy.io import fits
+from astropy.table import QTable
 from numpy.lib.recfunctions import merge_arrays
 
 
@@ -335,8 +336,9 @@ def convert_fitsrec_to_array_in_tree(tree):
     def _convert_fitsrec(node):
         if isinstance(node, fits.FITS_rec):
             return _fits_rec_to_array(node)
-        else:
-            return node
+        if isinstance(node, QTable):
+            return node.as_array()
+        return node
 
     return treeutil.walk_and_modify(tree, _convert_fitsrec)
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -4,6 +4,7 @@ import asdf.schema
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.table import QTable
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
 from stdatamodels import DataModel, fits_support
@@ -383,8 +384,10 @@ def test_table_with_unsigned_int(tmp_path):
                 # The table dtype and field dtype are stored separately, and may not
                 # necessarily agree.
                 assert np.can_cast(model.test_table.dtype[idx], col_data.dtype, "equiv")
-                assert np.can_cast(model.test_table.field(col_name).dtype, col_data.dtype, "equiv")
-                assert np.array_equal(model.test_table.field(col_name), col_data)
+                assert np.can_cast(
+                    model.test_table[col_name.upper()].dtype, col_data.dtype, "equiv"
+                )
+                assert np.array_equal(model.test_table[col_name.upper()], col_data)
 
         # The datamodel casts our array to FITS_rec on assignment, so here we're
         # checking that the data survived the casting.
@@ -664,9 +667,9 @@ def test_table_linking(tmp_path):
     with DataModel(schema=schema) as dm:
         test_array = np.array([(1, 2), (3, 4)], dtype=[("A_COL", "i1"), ("B_COL", "i1")])
 
-        # assigning to the model will convert the array to a FITS_rec
+        # assigning to the model will convert the array to a QTable
         dm.test_table = test_array
-        assert isinstance(dm.test_table, fits.FITS_rec)
+        assert isinstance(dm.test_table, QTable)
 
         # save the model (with the table)
         dm.save(file_path)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
