### PR TITLE
JP-4014: Use Astropy Table for table-type data

### DIFF
--- a/src/stdatamodels/dynamicdq.py
+++ b/src/stdatamodels/dynamicdq.py
@@ -28,12 +28,7 @@ def dynamic_mask(input_model, mnemonic_map, inv=False):
     """
     dq_table = input_model.dq_def
     # Get the DQ array and the flag definitions
-    if (
-        (dq_table is not None)
-        and (not np.isscalar(dq_table))
-        and (len(dq_table.shape))
-        and (len(dq_table))
-    ):
+    if (dq_table is not None) and (not np.isscalar(dq_table)) and (len(dq_table)):
         #
         # Make an empty mask
         dqmask = np.zeros(input_model.dq.shape, dtype=input_model.dq.dtype)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -978,8 +978,10 @@ def from_fits_hdu(hdu, schema):
     """
     if isinstance(hdu, fits.BinTableHDU):
         # Table.read populates units from TUNIT keywords automatically.
+        # unit_parse_strict='silent' avoids UnitsWarning for non-standard unit strings
+        # (e.g. 'micron', 'pixel') that appear in real JWST reference files.
         # Then _cast coerces column dtypes to match the schema (e.g. schema_wide float64).
-        return properties._cast(Table.read(hdu), schema)
+        return properties._cast(Table.read(hdu, unit_parse_strict="silent"), schema)
     # Image HDU: cast to schema dtype
     return properties._cast(hdu.data, schema)
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -16,6 +16,7 @@ from asdf.tags.core import HistoryEntry, NDArrayType, ndarray
 from asdf.util import HashableDict, uri_match
 from astropy import time
 from astropy.io import fits
+from astropy.table import Table
 from astropy.utils.exceptions import AstropyWarning
 
 from . import properties, util, validate
@@ -103,20 +104,6 @@ _keyword_indices = [
 FITS_HASH_KEY = "_fits_hash"
 
 
-def _get_indexed_keyword(keyword, i):
-    for sub, max_value, r in _keyword_indices:
-        if sub in keyword:
-            if i >= max_value:
-                raise ValueError(f"Too many entries for given keyword '{keyword}'")
-            if r is None:
-                val = str(i)
-            else:
-                val = r[i]
-            keyword = keyword.replace(sub, val)
-
-    return keyword
-
-
 def _get_hdu_name(schema):
     hdu_name = schema.get("fits_hdu")
     if hdu_name in (None, "PRIMARY"):
@@ -133,7 +120,9 @@ def _get_hdu_type(hdu_name, schema=None, value=None):
         if dtype.fields is not None:
             hdu_type = fits.BinTableHDU
     elif value is not None:
-        if hasattr(value, "dtype") and value.dtype.names is not None:
+        if isinstance(value, Table):
+            hdu_type = fits.BinTableHDU
+        elif hasattr(value, "dtype") and value.dtype.names is not None:
             hdu_type = fits.BinTableHDU
     return hdu_type
 
@@ -297,34 +286,86 @@ def _fits_element_writer(fits_context, validator, fits_keyword, instance, schema
         hdu.header.append((fits_keyword, instance, comment), end=True)
 
 
+def _make_table_hdu(hdulist, hdu_name, index, table):
+    """
+    Create or replace a BinTableHDU from an astropy Table, preserving non-builtin header cards.
+
+    Parameters
+    ----------
+    hdulist : `~astropy.io.fits.HDUList` or `weakref.ReferenceType`
+        The HDU list to which the table HDU will be added.
+    hdu_name : str
+        The name of the HDU.
+    index : int
+        The index of the HDU in the sequence.
+    table : `~astropy.table.Table`
+        The table data to be written to the HDU.
+
+    Returns
+    -------
+    `~astropy.io.fits.BinTableHDU`
+        The created or replaced BinTableHDU.
+    """
+    if isinstance(hdulist, weakref.ReferenceType):
+        ref = hdulist()
+        result = _make_table_hdu(ref, hdu_name, index, table)
+        del ref
+        return result
+    hdu = fits.BinTableHDU(data=table, name=hdu_name)
+    hdu.ver = index + 1
+    try:
+        existing = get_hdu(hdulist, hdu_name, index=index)
+        for key, val, comment in existing.header.cards:
+            if not is_builtin_fits_keyword(key):
+                hdu.header.append((key, val, comment), end=True)
+        hdulist.remove(existing)
+    except AttributeError:
+        pass
+    hdulist.append(hdu)
+    return hdu
+
+
 def _fits_array_writer(fits_context, validator, _, instance, schema):
     if instance is None:
         return
 
     instance_id = id(instance)
 
-    instance = np.asanyarray(instance)
+    if isinstance(instance, Table):
+        # Validate against schema datatype
+        if "datatype" in schema:
+            yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
 
-    if not len(instance.shape):
-        return
+        hdu_name = _get_hdu_name(schema)
+        _assert_non_primary_hdu(hdu_name)
+        index = fits_context.sequence_index
+        if index is None:
+            index = 0
 
-    if "ndim" in schema:
-        yield from ndarray.validate_ndim(validator, schema["ndim"], instance, schema)
-    if "max_ndim" in schema:
-        yield from ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
-    if "datatype" in schema:
-        yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
+        hdu = _make_table_hdu(fits_context.hdulist, hdu_name, index, instance)
+    else:
+        instance = np.asanyarray(instance)
 
-    hdu_name = _get_hdu_name(schema)
-    _assert_non_primary_hdu(hdu_name)
-    index = fits_context.sequence_index
-    if index is None:
-        index = 0
+        if not len(instance.shape):
+            return
 
-    hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
-    hdu = _get_or_make_hdu(fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type)
+        if "ndim" in schema:
+            yield from ndarray.validate_ndim(validator, schema["ndim"], instance, schema)
+        if "max_ndim" in schema:
+            yield from ndarray.validate_max_ndim(validator, schema["max_ndim"], instance, schema)
+        if "datatype" in schema:
+            yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
 
-    hdu.data = instance
+        hdu_name = _get_hdu_name(schema)
+        _assert_non_primary_hdu(hdu_name)
+        index = fits_context.sequence_index
+        if index is None:
+            index = 0
+
+        hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
+        hdu = _get_or_make_hdu(fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type)
+        hdu.data = instance
+
     if instance_id in fits_context.extension_array_links:
         if fits_context.extension_array_links[instance_id]() is not hdu:
             raise ValueError("Linking one array to multiple hdus is not supported")
@@ -509,11 +550,7 @@ def _normalize_arrays(tree):
 
     def normalize_array(node):
         if isinstance(node, np.ndarray):
-            # We can't use np.ascontiguousarray because it converts FITS_rec
-            # to vanilla np.ndarray, which results in misinterpretation of
-            # unsigned int values.
-            if not node.flags.c_contiguous:
-                node = node.copy()
+            return np.ascontiguousarray(node)
         return node
 
     return treeutil.walk_and_modify(tree, normalize_array)
@@ -597,12 +634,7 @@ def to_fits(tree, schema, hdulist=None):
 
 def _create_asdf_hdu(tree):
     buffer = io.BytesIO()
-    # convert all FITS_rec instances to numpy arrays, this is needed as
-    # some arrays loaded from the FITS data for old files may not be defined
-    # in the current schemas. These will be loaded as FITS_rec instances but
-    # not linked back (and safely converted) on write if they are removed
-    # from the schema.
-    asdf.AsdfFile(util.convert_fitsrec_to_array_in_tree(tree)).write_to(buffer)
+    asdf.AsdfFile(tree).write_to(buffer)
     buffer.seek(0)
 
     data = np.array(buffer.getbuffer(), dtype=np.uint8)[None, :]
@@ -782,7 +814,10 @@ def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
 
             if hdu not in known_datas:
                 if hdu.data is not None:
-                    properties.put_value(["extra_fits", hdu.name, "data"], hdu.data, tree)
+                    # FITS_rec is just pushed into plain array
+                    # is this bad?
+                    data = np.asarray(hdu.data) if isinstance(hdu.data, fits.FITS_rec) else hdu.data
+                    properties.put_value(["extra_fits", hdu.name, "data"], data, tree)
 
 
 def _load_history(hdulist, tree):
@@ -923,7 +958,11 @@ def _map_hdulist_to_arrays(hdulist, af):
 
 def from_fits_hdu(hdu, schema):
     """
-    Read the data from a FITS HDU into a numpy ndarray.
+    Read the data from a FITS HDU.
+
+    For BinTableHDUs, returns an astropy Table (units are populated automatically
+    from TUNIT keywords by ``astropy.io.fits``).
+    For image HDUs, casts the numpy array to the dtype specified in the schema.
 
     Parameters
     ----------
@@ -934,25 +973,15 @@ def from_fits_hdu(hdu, schema):
 
     Returns
     -------
-    data : numpy.ndarray
+    data : astropy.table.Table or numpy.ndarray
         The data from the FITS HDU
     """
-    data = hdu.data
-
-    # Save the column listeners for possible restoration
-    if hasattr(data, "_coldefs"):
-        listeners = data._coldefs._listeners
-    else:
-        listeners = None
-
-    # Cast array to type mentioned in schema
-    data = properties._cast(data, schema)
-
-    # Casting a table loses the column listeners, so restore them
-    if listeners is not None:
-        data._coldefs._listeners = listeners
-
-    return data
+    if isinstance(hdu, fits.BinTableHDU):
+        # Table.read populates units from TUNIT keywords automatically.
+        # Then _cast coerces column dtypes to match the schema (e.g. schema_wide float64).
+        return properties._cast(Table.read(hdu), schema)
+    # Image HDU: cast to schema dtype
+    return properties._cast(hdu.data, schema)
 
 
 def _can_skip_fits_update(hdulist, asdf_struct, context):

--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -14,12 +14,13 @@ from asdf import AsdfFile
 from asdf import schema as asdf_schema
 from asdf.tags.core import NDArrayType
 from astropy.io import fits
+from astropy.table import Table
 from astropy.time import Time
 
 from . import filetype, fits_support, properties, validate
 from . import schema as mschema
 from .history import HistoryList
-from .util import convert_fitsrec_to_array_in_tree, get_envar_as_boolean, remove_none_from_tree
+from .util import get_envar_as_boolean, remove_none_from_tree
 
 # This minimal schema creates metadata fields that
 # are accessed to be available by the core DataModel code.
@@ -70,7 +71,8 @@ class DataModel(properties.ObjectNode):
 
         Parameters
         ----------
-        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, None
+        init : str, tuple, `~astropy.io.fits.HDUList`, ndarray, dict, \
+            `~astropy.table.Table`, None
 
             - None : Create a default data model with no shape.
 
@@ -85,7 +87,7 @@ class DataModel(properties.ObjectNode):
             - `~astropy.io.fits.HDUList` : Initialize from the given
               `~astropy.io.fits.HDUList`.
 
-            - A numpy array: Used to initialize the data array
+            - Table or numpy array: Used to initialize the data array
 
             - dict: The object model tree for the data model
 
@@ -189,7 +191,7 @@ class DataModel(properties.ObjectNode):
             # minimum version.
             asdffile._tree = init
 
-        elif isinstance(init, np.ndarray):
+        elif isinstance(init, np.ndarray | Table):
             asdffile = AsdfFile(ignore_unrecognized_tag=ignore_unrecognized_tag)
             is_array = True
 
@@ -635,12 +637,11 @@ class DataModel(properties.ObjectNode):
         """
         self.on_save(init)
         self.validate()  # required to trigger ValidationWarning
-        tree = convert_fitsrec_to_array_in_tree(self._instance)
         # Don't AsdfFile(tree) as this will cause a second validation of the tree
         # instead open an empty tree, then assign to the hidden '_tree'
         # This can be updated when asdf 4.0 is the minimum version.
         asdffile = AsdfFile()
-        asdffile._tree = tree
+        asdffile._tree = self._instance
         asdffile.write_to(init, *args, **kwargs)
 
     def to_fits(self, init, *args, **kwargs):
@@ -676,6 +677,8 @@ class DataModel(properties.ObjectNode):
         primary_array_name = self.get_primary_array_name()
         if primary_array_name and getattr(self, primary_array_name, None) is not None:
             primary_array = getattr(self, primary_array_name)
+            if isinstance(primary_array, Table):
+                return (len(primary_array),)
             return primary_array.shape
         return None
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -5,24 +5,12 @@ from collections.abc import Mapping
 
 import numpy as np
 from asdf.tags.core import ndarray
-from astropy.io import fits
+from astropy.table import Table
 
 from . import schema as mschema
 from . import util, validate
 
 __all__ = ["ListNode", "ObjectNode"]
-
-
-def _is_struct_array(val):
-    return (
-        isinstance(val, (np.ndarray, fits.FITS_rec))
-        and val.dtype.names is not None
-        and val.dtype.fields is not None
-    )
-
-
-def _is_struct_array_precursor(val):
-    return isinstance(val, list) and isinstance(val[0], tuple)
 
 
 def _is_struct_array_schema(schema):
@@ -39,64 +27,11 @@ def _cast(val, schema):
         if isinstance(val, ndarray.NDArrayType):
             val = val._make_array()
 
-        allow_extra_columns = False
-        if (
-            _is_struct_array_schema(schema)
-            and len(val)
-            and (_is_struct_array_precursor(val) or _is_struct_array(val))
-        ):
-            # we are dealing with a structured array. Because we may
-            # modify schema (to add shape), we make a deep copy of the
-            # schema here:
-            schema = copy.deepcopy(schema)
-
-            if "allow_extra_columns" in schema:
-                allow_extra_columns = schema["allow_extra_columns"]
-
-            for t, v in zip(schema["datatype"], val[0], strict=False):
-                if not isinstance(t, Mapping):
-                    continue
-
-                aval = np.asanyarray(v)
-                shape = aval.shape
-                val_ndim = len(shape)
-
-                # make sure that if 'ndim' is specified for a field,
-                # it matches the dimensionality of val's field:
-                if "ndim" in t and val_ndim != t["ndim"]:
-                    raise ValueError(
-                        "Array has wrong number of dimensions. Expected {}, got {}".format(
-                            t["ndim"], val_ndim
-                        )
-                    )
-
-                if "max_ndim" in t and val_ndim > t["max_ndim"]:
-                    raise ValueError(
-                        "Array has wrong number of dimensions. Expected <= {}, got {}".format(
-                            t["max_ndim"], val_ndim
-                        )
-                    )
-
-                # if shape of a field's value is not specified in the schema,
-                # add it to the schema based on the shape of the actual data:
-                if "shape" not in t:
-                    t["shape"] = shape
+        if _is_struct_array_schema(schema):
+            return _as_table(val, schema)
 
         dtype = ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
-
-        # save columns in case this is cast back to a fitsrec
-        if hasattr(val, "columns"):
-            cols = val.columns
-        else:
-            cols = None
-        val = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
-
-        if dtype.fields is not None:
-            val = _as_fitsrec(val)
-            if cols is not None:
-                for col in cols:
-                    if col.name in val.names and col.unit is not None:
-                        val.columns[col.name].unit = col.unit
+        val = util.gentle_asarray(val, dtype)
 
     if "ndim" in schema and len(val.shape) != schema["ndim"]:
         raise ValueError(
@@ -118,41 +53,78 @@ def _cast(val, schema):
     return val
 
 
-def _as_fitsrec(val):
+def _as_table(val, schema):
     """
-    Convert a numpy record into a FITS record if it is not one already.
+    Convert val to an astropy Table matching the schema's structured datatype.
 
     Parameters
     ----------
-    val : numpy.ndarray
-        The numpy record to convert.
+    val : array-like
+        Input data: numpy structured array, list of tuples, or existing astropy Table.
+    schema : dict
+        The schema describing the table structure.
 
     Returns
     -------
-    fits.FITS_rec
-        The converted FITS record.
+    astropy.table.Table
+        The data as an astropy Table with columns matching the schema.
+
+    Notes
+    -----
+    TODO: nontrivial example where a Table is input here, but it doesn't match
+    the schema, but it can be coerced to match the schema.
+    If there is no such example we could simplify this by just returning Table
+    TODO: is list of tuple supported? should it be?
     """
-    if isinstance(val, fits.FITS_rec):
-        return val
-    else:
-        coldefs = fits.ColDefs(val)
-        uint = any(c._pseudo_unsigned_ints for c in coldefs)
-        if any(c.format == "L" for c in coldefs):
-            # Copy so we can modify the values to match what astropy expects.
-            fits_rec = fits.FITS_rec(val.copy())
-            for c in coldefs:
-                if c.format == "L":
-                    d = fits_rec[c.name]
-                    m = d.astype(bool)
-                    d[m] = ord("T")
-                    d[~m] = ord("F")
-        else:
-            fits_rec = fits.FITS_rec(val)
-        fits_rec._coldefs = coldefs
-        # FITS_rec needs to know if it should be operating in pseudo-unsigned-ints mode,
-        # otherwise it won't properly convert integer columns with TZEROn before saving.
-        fits_rec._uint = uint
-        return fits_rec
+    allow_extra_columns = schema.get("allow_extra_columns", False)
+    schema_datatypes = schema["datatype"]
+
+    # Preserve column units from an input Table before converting to numpy.
+    units = {}
+    if isinstance(val, Table):
+        for col in val.columns.values():
+            if col.unit is not None:
+                units[col.name] = col.unit
+        val = np.array(val)
+
+    # Handle shape info for nested array columns, inferred from the first row.
+    if len(val):
+        schema_datatypes = copy.deepcopy(schema_datatypes)
+        for t, v in zip(schema_datatypes, val[0], strict=False):
+            if not isinstance(t, Mapping):
+                continue
+            aval = np.asanyarray(v)
+            shape = aval.shape
+            val_ndim = len(shape)
+            if "ndim" in t and val_ndim != t["ndim"]:
+                raise ValueError(
+                    "Array has wrong number of dimensions. Expected {}, got {}".format(
+                        t["ndim"], val_ndim
+                    )
+                )
+            if "max_ndim" in t and val_ndim > t["max_ndim"]:
+                raise ValueError(
+                    "Array has wrong number of dimensions. Expected <= {}, got {}".format(
+                        t["max_ndim"], val_ndim
+                    )
+                )
+            if "shape" not in t:
+                t["shape"] = shape
+
+    dtype = ndarray.asdf_datatype_to_numpy_dtype(schema_datatypes)
+
+    # Convert list of tuples to a numpy structured array first.
+    if isinstance(val, list):
+        val = np.array(val, dtype=dtype)
+
+    # Coerce to the target dtype/column names.
+    coerced = util.gentle_asarray(val, dtype, allow_extra_columns=allow_extra_columns)
+    result = Table(coerced)
+    # Restore units that were on the input Table.
+    for col_name, unit in units.items():
+        if col_name in result.columns:
+            result[col_name].unit = unit
+    return result
 
 
 def _get_schema_type(schema):
@@ -251,13 +223,16 @@ def _make_default_array(attr, schema, ctx):
     array = np.empty(shape, dtype=dtype)
     if default is not None:
         if isinstance(default, list):
-            # support multi-valued defaults for when array is recarray
+            # support multi-valued defaults for input recarray or Table
             try:
                 default = np.array(tuple(default), dtype=dtype)
             except ValueError:
-                msg = f"Invalid default value {default} for recarray dtype {dtype}"
+                msg = f"Invalid default value {default} for table dtype {dtype}"
                 raise ValueError(msg) from None
         array[...] = default
+
+    if dtype.names is not None:
+        return Table(array)
     return array
 
 

--- a/src/stdatamodels/properties.py
+++ b/src/stdatamodels/properties.py
@@ -57,6 +57,10 @@ def _as_table(val, schema):
     """
     Convert val to an astropy Table matching the schema's structured datatype.
 
+    If val is already Table, must still convert to array, then validate, then convert back.
+    This handles the case where a user-defined Table might have columns with incorrect data
+    type, or when a file is loaded with a different schema like in test_fits.test_replace_table.
+
     Parameters
     ----------
     val : array-like
@@ -68,13 +72,6 @@ def _as_table(val, schema):
     -------
     astropy.table.Table
         The data as an astropy Table with columns matching the schema.
-
-    Notes
-    -----
-    TODO: nontrivial example where a Table is input here, but it doesn't match
-    the schema, but it can be coerced to match the schema.
-    If there is no such example we could simplify this by just returning Table
-    TODO: is list of tuple supported? should it be?
     """
     allow_extra_columns = schema.get("allow_extra_columns", False)
     schema_datatypes = schema["datatype"]

--- a/src/stdatamodels/util.py
+++ b/src/stdatamodels/util.py
@@ -51,29 +51,19 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
         if np.can_cast(in_dtype, out_dtype, "equiv"):
             return a
         else:
-            return _safe_asanyarray(a, out_dtype)
+            return np.asanyarray(a, out_dtype)
 
     # one of these dtypes does not have fields
     if in_dtype.fields is None or out_dtype.fields is None:
-        return _safe_asanyarray(a, out_dtype)
+        return np.asanyarray(a, out_dtype)
 
     # this function should not handle nested structured dtypes
-    # as they aren't supported by FITS_rec and not handled well
-    # by merge_arrays below (which currently flattens the dtype)
+    # as they aren't handled well by merge_arrays (which currently flattens the dtype)
     for dt in (in_dtype, out_dtype):
         for n in dt.names:
             if dt[n].names is not None:
                 msg = f"gentle_asarray does not support nested structured dtypes: {dt}"
                 raise ValueError(msg)
-
-    # When a FITS file includes a pseudo-unsigned-int column, astropy will return
-    # a FITS_rec with an incorrect table dtype.
-    # It's also unsafe to directly cast any FITS_rec with a
-    # pseudo-unsigned column.
-    # https://github.com/astropy/astropy/issues/8862
-    if isinstance(a, fits.fitsrec.FITS_rec):
-        if any(c.bzero is not None for c in a.columns):
-            return _safe_asanyarray(a, out_dtype)
 
     if in_dtype == out_dtype:
         return a
@@ -88,7 +78,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
             return a.view(dtype=out_dtype)
         else:
             # else, use asanyarray and copy
-            return _safe_asanyarray(a, out_dtype)
+            return np.asanyarray(a, out_dtype)
 
     # names don't match
     # check if names match but the order is incorrect
@@ -102,7 +92,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
         if reordered_subdtypes == out_subdtypes:
             return reordered_array.view(out_dtype)
         else:
-            return _safe_asanyarray(reordered_array, out_dtype)
+            return np.asanyarray(reordered_array, out_dtype)
 
     # if extra columns are not allowed or they are (and the required columns are missing)
     # then raise an exception
@@ -117,7 +107,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
     # construct new dtype with required columns at start
     # in_dtype vs out_dtype
     # - might have inconsequential (since fitsrec is used) name differences
-    # - might have dtype differences (requiring _safe_asanyarray)
+    # - might have dtype differences (requiring np.asanyarray)
     # - in_dtype will have more columns (since we've handled everything else above)
     # if the first set of columns match (by name and dtype) the required dtype, return the array
     n_required = len(out_dtype)
@@ -134,7 +124,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
             return a.view(dtype=new_dtype)
         else:
             new_dtype = np.dtype(out_dtype.descr + new_dtype.descr[len(out_dtype.descr) :])
-            return _safe_asanyarray(a, new_dtype)
+            return np.asanyarray(a, new_dtype)
 
     # reorder columns so required columns are first
     required_names = [n for n in in_dtype.names if n.lower() in out_lower_names]
@@ -152,30 +142,7 @@ def gentle_asarray(a, dtype, allow_extra_columns=False):
     out_subdtypes = [out_dtype[n] for n in out_dtype.names]
     if reordered_subdtypes[:n_required] == out_subdtypes:
         return reordered_array.view(new_dtype)
-    return _safe_asanyarray(reordered_array, new_dtype)
-
-
-def _safe_asanyarray(a, dtype):
-    if isinstance(a, fits.fitsrec.FITS_rec):
-        if any(c.bzero is not None for c in a.columns):
-            # Due to an issue in astropy, it's not safe to directly cast
-            # a FITS_rec with a pseudo-unsigned column.
-            # See https://github.com/astropy/astropy/issues/8862
-            result = np.zeros(a.shape, dtype=dtype)
-            for old_col, new_col in zip(a.dtype.names, result.dtype.names, strict=False):
-                result[new_col] = a[old_col]
-            return result
-
-    result = np.asanyarray(a, dtype=dtype)
-    if isinstance(result, fits.fitsrec.FITS_rec) and isinstance(a, fits.fitsrec.FITS_rec):
-        for column in result.columns:
-            name = column.name
-            try:
-                matching_column = a.columns[name]
-            except KeyError:
-                continue
-            result.columns[name].unit = matching_column.unit
-    return result
+    return np.asanyarray(reordered_array, new_dtype)
 
 
 def create_history_entry(description, software=None):
@@ -315,58 +282,3 @@ def remove_none_from_tree(tree):
             return node
 
     return treeutil.walk_and_modify(tree, _remove_none)
-
-
-def convert_fitsrec_to_array_in_tree(tree):
-    """
-    Convert all FITS record array objects in a tree to numpy arrays.
-
-    Parameters
-    ----------
-    tree : dict
-        A tree that may contain FITS record arrays.
-
-    Returns
-    -------
-    object
-        A copy of the input tree with FITS record arrays converted to numpy arrays.
-    """
-
-    def _convert_fitsrec(node):
-        if isinstance(node, fits.FITS_rec):
-            return _fits_rec_to_array(node)
-        else:
-            return node
-
-    return treeutil.walk_and_modify(tree, _convert_fitsrec)
-
-
-def _rebuild_fits_rec_dtype(fits_rec):
-    dtype = fits_rec.dtype
-    new_dtype = []
-    for field_name in dtype.fields:
-        table_dtype = dtype[field_name]
-        shape = table_dtype.shape
-        if shape:
-            table_dtype = table_dtype.base
-        field_dtype = fits_rec.field(field_name).dtype
-        if np.issubdtype(table_dtype, np.signedinteger) and np.issubdtype(
-            field_dtype, np.unsignedinteger
-        ):
-            new_dtype.append((field_name, field_dtype, shape))
-        else:
-            new_dtype.append((field_name, table_dtype, shape))
-    return np.dtype((np.record, new_dtype))
-
-
-def _fits_rec_to_array(fits_rec):
-    bad_columns = [
-        n for n in fits_rec.dtype.fields if np.issubdtype(fits_rec[n].dtype, np.unsignedinteger)
-    ]
-    if not len(bad_columns):
-        return fits_rec.view(np.ndarray)
-    new_dtype = _rebuild_fits_rec_dtype(fits_rec)
-    arr = np.asarray(fits_rec, new_dtype).copy()
-    for name in bad_columns:
-        arr[name] = fits_rec[name]
-    return arr

--- a/src/stdatamodels/validate.py
+++ b/src/stdatamodels/validate.py
@@ -9,10 +9,11 @@ from asdf.exceptions import ValidationError
 from asdf.schema import YAML_VALIDATORS
 from asdf.tags.core import ndarray
 from asdf.util import HashableDict
+from astropy.table import Table
 
 from stdatamodels.exceptions import ValidationWarning
 
-from .util import convert_fitsrec_to_array_in_tree, remove_none_from_tree
+from .util import remove_none_from_tree
 
 # always show validation warnings unless another filter was added that
 # matches these warnings (by passing append=True)
@@ -96,6 +97,8 @@ def _validate_datatype(validator, schema_datatype, instance, schema):
             yield ValidationError("Not an array")
     elif isinstance(instance, (np.ndarray, ndarray.NDArrayType)):
         instance_datatype, _ = ndarray.numpy_dtype_to_asdf_datatype(instance.dtype)
+    elif isinstance(instance, Table):
+        instance_datatype, _ = ndarray.numpy_dtype_to_asdf_datatype(instance.as_array().dtype)
     else:
         yield ValidationError("Not an array")
 
@@ -200,7 +203,6 @@ def _check_value(value, schema, ctx):
         # converting to tagged tree, so that we don't have to descend
         # unnecessarily into nodes for custom types.
         value = remove_none_from_tree(value)
-        value = convert_fitsrec_to_array_in_tree(value)
         # without this "write_context" asdf will queue up blocks for writing
         # which will hold onto arrays after they have been overwritten
         with ctx._asdf._blocks.write_context(None):

--- a/tests/jwst/datamodels/test_models.py
+++ b/tests/jwst/datamodels/test_models.py
@@ -793,8 +793,9 @@ def test_amioi_model_oifits_datatable(tmp_path, oifits_ami_model, keep):
 @pytest.mark.parametrize("table_name", ["array", "target", "vis", "vis2", "t3", "q4", "wavelength"])
 def test_amioi_model_oifits_extra_columns(tmp_path, oifits_ami_model, table_name):
     table_data = getattr(oifits_ami_model, table_name)
+    table_arr = np.array(table_data) if hasattr(table_data, "columns") else table_data
     new_table_data = merge_arrays(
-        [table_data, np.zeros(table_data.size, dtype=[("extra", "f8")])], flatten=True
+        [table_arr, np.zeros(len(table_data), dtype=[("extra", "f8")])], flatten=True
     )
     setattr(oifits_ami_model, table_name, new_table_data)
     fn = tmp_path / "test.fits"
@@ -807,7 +808,7 @@ def test_amioi_model_extra_meta(tmp_path, oifits_ami_model):
     oifits_ami_model.save(fn)
 
 
-@pytest.mark.parametrize("value", [True, False, 0, 1, ord("T"), ord("F")])
+@pytest.mark.parametrize("value", [True, False, 0, 1])
 def test_amioi_logical_flag(tmp_path, value, oifits_ami_model):
     """
     Test that int8 stored "FLAG" columns accept bools.

--- a/tests/jwst/datamodels/test_photom_miriwfss_datamodel.py
+++ b/tests/jwst/datamodels/test_photom_miriwfss_datamodel.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import numpy as np
+import pytest
 from astropy import units as u
 from astropy.table import Table
 
@@ -93,9 +94,11 @@ def test_miri_wfss_photom():
     assert phot_model.meta.exposure.type == "MIR_WFSS"
     assert phot_model.phot_unit == p_unit_str
     assert phot_model.wave_unit == w_unit_str
-    assert phot_model.phot_table.filter == "P750L"
-    assert phot_model.phot_table.photmjsr == float(wfss_photmjsr.value)
-    assert phot_model.phot_table.uncertainty == float(wfss_photmjsr_error)
-    np.testing.assert_allclose(phot_model.phot_table.wavelength[0], wavelength.value, atol=1e-7)
-    np.testing.assert_allclose(phot_model.phot_table.relresponse[0], relresponse, atol=1e-7)
-    np.testing.assert_allclose(phot_model.phot_table.reluncertainty[0], reluncertainty, atol=1e-7)
+    assert phot_model.phot_table["filter"][0] == "P750L"
+    assert phot_model.phot_table["photmjsr"][0] == pytest.approx(float(wfss_photmjsr.value))
+    assert phot_model.phot_table["uncertainty"][0] == pytest.approx(float(wfss_photmjsr_error))
+    np.testing.assert_allclose(phot_model.phot_table["wavelength"][0], wavelength.value, atol=1e-7)
+    np.testing.assert_allclose(phot_model.phot_table["relresponse"][0], relresponse, atol=1e-7)
+    np.testing.assert_allclose(
+        phot_model.phot_table["reluncertainty"][0], reluncertainty, atol=1e-7
+    )

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -4,6 +4,7 @@ import asdf.schema
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.table import Table
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
 from stdatamodels import DataModel, fits_support
@@ -26,16 +27,12 @@ def records_equal(a, b):
 
 def test_from_new_hdulist():
     with pytest.raises(AttributeError):
-        from astropy.io import fits
-
         hdulist = fits.HDUList()
         with FitsModel(hdulist) as dm:
             dm.foo  # noqa: B018
 
 
 def test_from_new_hdulist2():
-    from astropy.io import fits
-
     hdulist = fits.HDUList()
     data = np.empty((50, 50), dtype=np.float32)
     primary = fits.PrimaryHDU()
@@ -49,8 +46,6 @@ def test_from_new_hdulist2():
 
 
 def test_setting_arrays_on_fits():
-    from astropy.io import fits
-
     hdulist = fits.HDUList()
     data = np.empty((50, 50), dtype=np.float32)
     primary = fits.PrimaryHDU()
@@ -151,8 +146,6 @@ def test_fits_comments(tmp_path):
         dm.meta.origin = "STScI"
         dm.save(file_path)
 
-    from astropy.io import fits
-
     with fits.open(file_path, memmap=False) as hdulist:
         assert any(
             c
@@ -166,8 +159,6 @@ def test_metadata_doesnt_override(tmp_path):
 
     with FitsModel() as dm:
         dm.save(file_path)
-
-    from astropy.io import fits
 
     with fits.open(file_path, mode="update", memmap=False) as hdulist:
         hdulist[0].header["ORIGIN"] = "UNDER THE COUCH"
@@ -249,8 +240,6 @@ def test_table_with_metadata(tmp_path):
         datamodel.meta.fluxinfo.exposure = "Exposure info"
         datamodel.save(file_path, overwrite=True)
         del datamodel
-
-    from astropy.io import fits
 
     with fits.open(file_path, memmap=False) as hdulist:
         assert len(hdulist) == 3
@@ -340,8 +329,9 @@ def test_replace_table(tmp_path):
         assert hdulist[1].header["TFORM2"] == "D"
 
 
-def test_table_with_unsigned_int(tmp_path):
-    file_path = tmp_path / "test.fits"
+@pytest.mark.parametrize("ext", ["fits", "asdf"])
+def test_table_with_unsigned_int(tmp_path, ext):
+    file_path = tmp_path / f"test.{ext}"
 
     schema = {
         "title": "Test data model",
@@ -377,16 +367,11 @@ def test_table_with_unsigned_int(tmp_path):
         )
 
         def assert_table_correct(model):
-            for idx, (col_name, col_data) in enumerate(
-                [("float64_col", float64_arr), ("uint32_col", uint32_arr)]
-            ):
-                # The table dtype and field dtype are stored separately, and may not
-                # necessarily agree.
-                assert np.can_cast(model.test_table.dtype[idx], col_data.dtype, "equiv")
-                assert np.can_cast(model.test_table.field(col_name).dtype, col_data.dtype, "equiv")
-                assert np.array_equal(model.test_table.field(col_name), col_data)
+            for col_name, col_data in [("FLOAT64_COL", float64_arr), ("UINT32_COL", uint32_arr)]:
+                assert np.can_cast(model.test_table[col_name].dtype, col_data.dtype, "equiv")
+                assert np.array_equal(model.test_table[col_name], col_data)
 
-        # The datamodel casts our array to FITS_rec on assignment, so here we're
+        # The datamodel casts our array to astropy Table on assignment, so here we're
         # checking that the data survived the casting.
         dm.test_table = test_table
         assert_table_correct(dm)
@@ -664,9 +649,9 @@ def test_table_linking(tmp_path):
     with DataModel(schema=schema) as dm:
         test_array = np.array([(1, 2), (3, 4)], dtype=[("A_COL", "i1"), ("B_COL", "i1")])
 
-        # assigning to the model will convert the array to a FITS_rec
+        # assigning to the model will convert the array to an astropy Table
         dm.test_table = test_array
-        assert isinstance(dm.test_table, fits.FITS_rec)
+        assert isinstance(dm.test_table, Table)
 
         # save the model (with the table)
         dm.save(file_path)
@@ -684,19 +669,16 @@ def test_table_linking(tmp_path):
         assert not len(unlinked_arrays), unlinked_arrays
 
 
-def test_fitsrec_for_non_schema_data(tmp_path):
-    # make a file where some non-schema data is linked between
-    # the asdf extension and another hdu. This simulates an old
-    # file where this condition might occur (perhaps after a schema
+def test_table_for_non_schema_data(tmp_path):
+    # make a file where some non-schema data is in the tree (not in the schema).
+    # This simulates an old file where this condition might occur (perhaps after a schema
     # update).
     m = DataModel()
-    m._instance["sneaky_table"] = fits.FITS_rec(
-        np.array(
-            [
-                ("a", 1),
-            ],
-            dtype=[("foo", "S3"), ("bar", "f4")],
-        )
+    m._instance["sneaky_table"] = np.array(
+        [
+            ("a", 1),
+        ],
+        dtype=[("foo", "S3"), ("bar", "f4")],
     )
     fn = tmp_path / "test.fits"
     m.save(fn)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,7 +50,7 @@ def test_gentle_asarray_array_input():
 
 def test_gentle_asarray_recarray_input():
     """
-    Test gentle_asarray input that is already an np.recarray.
+    Test gentle_asarray input that is an np.recarray.
     """
     # This is just the simple case where the dtype already matches
     # the desired output, but it follows a different code path
@@ -60,86 +60,6 @@ def test_gentle_asarray_recarray_input():
     result = util.gentle_asarray(inp, dtype=dtype)
     assert result.dtype == dtype
     assert_array_equal(result, inp)
-
-
-def test_gentle_asarray_fits_rec_input():
-    """
-    Test gentle_asarray with FITS_rec array input.
-    """
-    # 'e' is the FITS data type code for single-precision float:
-    cols = [fits.Column("col1", format="e", array=np.array([1, 2, 3, 4]))]
-    inp = fits.FITS_rec.from_columns(cols)
-    out_dtype = np.dtype([("col1", np.float32)])
-    result = util.gentle_asarray(inp, dtype=out_dtype)
-    assert result.dtype == out_dtype
-    assert_array_equal(result, inp)
-
-
-def test_gentle_asarray_fits_rec_pseudo_unsigned(tmp_path):
-    """
-    Test gentle_asarray handling of a FITS_rec with a pseudo unsigned
-    integer column, which is a special case due to a bug in astropy.
-    """
-    # 'j' is the FITS data type code for 32-bit integer.  A column
-    # is only considered "pseudo unsigned" for certain values of
-    # bezero, one of which is 2**31.
-    cols = [fits.Column("col1", format="j", array=np.array([1, 2, 3, 4], np.uint32), bzero=2**31)]
-    inp = fits.FITS_rec.from_columns(cols)
-    out_dtype = np.dtype([("col1", np.uint32)])
-    result = util.gentle_asarray(inp, dtype=out_dtype)
-    # If not handled, the astropy bug would result in a signed
-    # int column dtype:
-    assert result["col1"].dtype == np.uint32
-    assert result["col1"][0] == 1
-    assert result["col1"][1] == 2
-    assert result["col1"][2] == 3
-    assert result["col1"][3] == 4
-
-    # This tests the case where a table with a pseudo unsigned integer column
-    # is opened from a FITS file and needs to be cast.  This requires special
-    # handling on our end to dodge the bug.
-    file_path = tmp_path / "test.fits"
-
-    dtype = np.dtype(">u2")
-    data = np.array([(0,)], dtype=[("col1", dtype)])
-    hdu = fits.BinTableHDU()
-    hdu.data = data
-    hdul = fits.HDUList([fits.PrimaryHDU(), hdu])
-    hdul.writeto(file_path)
-
-    with fits.open(file_path) as hdul:
-        for dtype_str in (">u2", "<u2", ">i2", "<i2"):
-            dtype = np.dtype(dtype_str)
-            result = util.gentle_asarray(hdul[-1].data, dtype=[("col1", dtype)])
-            # Without the fix, the value in the array would be 128 due to bzero
-            # shift being applied twice.
-            assert result[0][0] == 0
-
-
-def test_gentle_asarray_fits_rec_pseudo_unsigned_shaped(tmp_path):
-    # This tests the case where a table with a pseudo unsigned integer column
-    # is opened from a FITS file and needs to be cast.  This requires special
-    # handling on our end to dodge the bug.
-    file_path = tmp_path / "test.fits"
-
-    data = np.array([((1, 2),), ((3, 4),)], dtype=[("col1", ">u2", 2)])
-    hdu = fits.BinTableHDU()
-    hdu.data = data
-    hdul = fits.HDUList([fits.PrimaryHDU(), hdu])
-    hdul.writeto(file_path)
-
-    with fits.open(file_path) as hdul:
-        for sdtype in (np.dtype(">i2"), np.dtype(">u2")):
-            result = util.gentle_asarray(hdul[-1].data, dtype=[("col1", sdtype, 2)])
-            assert result["col1"].dtype.base == sdtype
-            assert result.dtype["col1"].base == sdtype
-            assert result.dtype["col1"].shape == (2,)
-            assert result["col1"][0][0] == 1
-            assert result["col1"][0][1] == 2
-            assert result["col1"][1][0] == 3
-            assert result["col1"][1][1] == 4
-            assert result["col1"][[True, False]][0][0] == 1
-            assert result["col1"][[True, False]][0][1] == 2
 
 
 def test_gentle_asarray_nested_array():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

TODO:

- should `get_dtype` still return a numpy data type?
- test `get_default`
- what to do about FITS unit incompatibility with "micron", "pixels", "DN/s", etc?

A generative AI tool was used to help prepare this draft.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
