### PR TITLE
JP-4251: Allow coordinate tables for axes 1 and 2

### DIFF
--- a/changes/780.schema.rst
+++ b/changes/780.schema.rst
@@ -1,0 +1,1 @@
+Add coordinate table keywords for axis 1 and 2 to the ``wcsinfo`` schema.

--- a/src/stdatamodels/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/src/stdatamodels/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -239,6 +239,26 @@ properties:
             fits_keyword: CD2_2
             fits_hdu: SCI
             blend_table: True
+          ps1_0:
+            title: Coordinate table extension name
+            type: string
+            fits_keyword: PS1_0
+            fits_hdu: SCI
+          ps1_1:
+            title: Coordinate table column name
+            type: string
+            fits_keyword: PS1_1
+            fits_hdu: SCI
+          ps2_0:
+            title: Coordinate table extension name
+            type: string
+            fits_keyword: PS2_0
+            fits_hdu: SCI
+          ps2_1:
+            title: Coordinate table column name
+            type: string
+            fits_keyword: PS2_1
+            fits_hdu: SCI
           ps3_0:
             title: Coordinate table extension name
             type: string


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-4251](https://jira.stsci.edu/browse/JP-4251)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
To support a FITS WCS for resampled spectral images, the wcsinfo schema needs to allow coordinate table keywords for axes 1 and 2.  Axis 3 is already allowed, in support of the wavelength dimension for IFU cube products.

Associated with jwst PR: https://github.com/spacetelescope/jwst/pull/10740

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
