### PR TITLE
run jwst with devdeps with python 3.13

### DIFF
--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -78,4 +78,4 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py311-jwst-devdeps-xdist
+        - linux: py313-jwst-devdeps-xdist


### PR DESCRIPTION
No regtests run as this is a CI-only change.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
