### PR TITLE
Fix jwst downstream by configuring tox/pytest use jwst pytest configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,4 @@ jobs:
       cache-path: ${{ needs.data.outputs.crds_path }}
       cache-key: crds-${{ needs.data.outputs.crds_context }}
       envs: |
-        - linux: py313-jwst-cov-xdist
-          coverage: codecov
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        - linux: py313-jwst-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
 
 [testenv]
 allowlist_externals =
-    jwst: touch
+    jwst: bash
+    jwst: git
 description =
     run tests
     xdist: using parallel processing
@@ -23,19 +24,22 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
 package=
     cov: editable
     !cov: wheel
+change_dir =
+    jwst: {env_tmp_dir}
 commands_pre =
-    devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
+    jwst: bash -c "pip freeze -q | grep 'stdatamodels @' > {env_tmp_dir}/requirements.txt"
+    jwst: git clone https://github.com/spacetelescope/jwst.git
+    jwst: pip install -e jwst[test]
+    devdeps: pip install -r {toxinidir}/requirements-dev.txt -U --upgrade-strategy eager
+    jwst: pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
-# make an empty pytest.ini so jwst tests don't use the settings in pyproject.toml
-    jwst: touch pytest.ini
 commands =
     pytest \
     xdist: -n auto \
     cov: --cov=src --cov-report=term-missing --cov-report=xml \
-    jwst: --pyargs jwst --ignore-glob=*/scripts/* -Werror \
+    jwst: jwst \
     nocrds: --no-crds
     {posargs}


### PR DESCRIPTION
Update the jwst tox environment to use the jwst pytest configuration (to fix the current failures due to a warning ignored in the jwst configuration not being ignored here and instead turning into an error).

This also drops the coverage measurement of stdatamodels code during jwst tests. It seems reasonable to not include downstream tests as part of coverage measurement and this only drops coverage by 4%. I will update the branch protection rules after merging.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
