### PR TITLE
preindex hdulist during mapping to improve performance

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -894,6 +894,9 @@ def from_fits_asdf(
 
 
 def _map_hdulist_to_arrays(hdulist, af):
+    # hdulist[key] is very inefficient so pre-index hdus
+    hdu_index = {(h.name, h.ver): h for h in hdulist}
+
     def callback(node):
         if (
             isinstance(node, NDArrayType)
@@ -912,8 +915,8 @@ def _map_hdulist_to_arrays(hdulist, af):
                 if parts.group("name"):
                     pair = (parts.group("name"), ver)
                 else:
-                    pair = ver
-            data = hdulist[pair].data
+                    pair = (ver, 1)
+            data = hdu_index[pair].data
             return data
         return node
 


### PR DESCRIPTION
During investigation of MultiSlitModel performance with @emolter it was uncovered that `hdulist[key]` iterates through all hdus to find the key. For files with a large number of hdus this results in very poor performance during hdu to array mapping.

This PR pre-indexes the hdulist by key once prior to mapping. For a test file this sped up reading a 500 slit file from 1 minute 15 seconds to 22 seconds.

A follow-up issue will be opened to investigate over uses of `hdulist[key]` for performance.

Attempt at regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/31595885924 (all passed)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
