### PR TITLE
JP-2518: Improve round-trip accuracy for NIRCam grism

### DIFF
--- a/changes/793.feature.rst
+++ b/changes/793.feature.rst
@@ -1,0 +1,2 @@
+For the NIRCam grism backward dispersion model, update linear interpolation method to cubic spline for better roundtrip accuracy.
+Also, allow paired 1D vector inputs to the backward transform, returning a 1D vector output.

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1483,7 +1483,6 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
             The inverse dispersion value for the given wavelength
         """
         t0 = np.linspace(0.0, 1.0, int(self.sampling))
-
         if len(model) < 2:
             # Handle legacy versions of the trace model
             xr = _evaluate_transform_guess_form(model, x=x0, y=y0, t=t0)
@@ -1507,13 +1506,16 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
         if (x0.ndim > 1 or wavelength.ndim > 1) and x0.shape != wavelength.shape:
             raise ValueError("Inputs are >1D but array shapes do not match")
 
-        # Most common use case is a single unique x0, y0 value for all input,
-        # but it is technically possible to transform different x0, y0 values
-        # at the same time. Fit t as a function of wavelength
+        # It is possible to transform different x0, y0 values at the same time
+        # (e.g., for WFSS sources). Fit t as a function of wavelength
         # for each set of x0, y0 in the input and use it to get the output t value.
         x_y_pairs = np.unique(np.stack([x0.flat, y0.flat], axis=1), axis=0)
         t_out = np.full_like(wavelength * x0, np.nan)
         for xref, yref in x_y_pairs:
+            # If invalid, skip this pair: t_out will be NaN for this input.
+            if np.isnan(xref) or np.isnan(yref):
+                continue
+
             # Get w for each sampled t0
             w_t = trace_function(t0, np.full_like(t0, xref), np.full_like(t0, yref))
             idx = np.argsort(w_t)
@@ -1536,7 +1538,7 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
                 # shapes match
                 t_out[xy_idx] = spl(wavelength[xy_idx])
 
-        # Clip t to 0 - 1
+        # Clip real t values to 0 - 1 (NaNs will remain)
         t_out = np.clip(t_out, 0, 1)
 
         return t_out

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -1419,15 +1419,11 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
         Parameters
         ----------
         x, y : float
-            Input x, y pixel(s). If a 2-D array, it is assumed that the model
-            is being called on a grid where all wavelengths are the same along the first axis,
-            and all the x,y coordinates are the same along the second axis. In this case,
-            x0, y0, and wavelength must all have the same shape.
+            Input x, y pixel(s). If a 2-D array, x0, y0, and wavelength must
+            all have the same shape.
         wavelength : float
-            Wavelength(s) in microns. If a 2-D array, it is assumed that the model
-            is being called on a grid where all wavelengths are the same along the first axis,
-            and all the x,y coordinates are the same along the second axis. In this case,
-            x0, y0, and wavelength must all have the same shape.
+            Wavelength(s) in microns. If a 2-D array, x0, y0, and wavelength
+            must all have the same shape.
         order : int
             Input spectral order
 
@@ -1471,19 +1467,15 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
 
         Parameters
         ----------
-        model : tuple[:class:`astropy.modeling.polynomial.Polynomial2D`]
+        model : tuple of :class:`astropy.modeling.polynomial.Polynomial2D`
             The models encoding the x, y dependence of the trace model's
             polynomial coefficients.
-        x0, y0 : float or np.ndarray
-            Source object x-center, y-center. If a 2-D array, it is assumed that the model
-            is being called on a grid where all wavelengths are the same along the first axis,
-            and all the x,y coordinates are the same along the second axis. In this case,
-            x0, y0, and wavelength must all have the same shape.
-        wavelength : float or np.ndarray
-            Wavelength(s) in microns. If a 2-D array, it is assumed that the model
-            is being called on a grid where all wavelengths are the same along the first axis,
-            and all the x,y coordinates are the same along the second axis. In this case,
-            x0, y0, and wavelength must all have the same shape.
+        x0, y0 : np.ndarray
+            Source object x-center, y-center. If a 2-D array, x0, y0, and
+            wavelength must all have the same shape.
+        wavelength : np.ndarray
+            Wavelength(s) in microns. If a 2-D array, x0, y0, and wavelength must
+            all have the same shape.
 
         Returns
         -------
@@ -1500,28 +1492,53 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
                 f[i] = np.interp(w, xr, t0)
             return f
 
-        if x0.ndim == 2:
-            # Assume we're calling this on a grid where all wavelengths are the same
-            # in one dimension, and all the x,y coordinates are the same in the other dimension.
-            x0 = x0[0].flatten()
-            y0 = y0[0].flatten()
-            wavelength = wavelength[:, 0].flatten()
-
+        # Wavelength function with x, y dependence
         trace_function = partial(_poly_with_spatial_dependence, model=model)
 
-        # Create a grid of t0, x0, and y0 values
-        tt, yy = np.meshgrid(t0, y0, indexing="ij")
-        xx = np.meshgrid(t0, x0, indexing="ij")[1]
-        wave_grid = trace_function(tt, xx, yy)
-        t_out = np.empty((len(wavelength), len(x0)))
-        for i, w in enumerate(wavelength):
-            # do a first order interpolation to find the t0 where residuals are minimized
-            # at each x,y location
-            resid = (wave_grid - w) ** 2
-            t_out[i, :] = _find_min_with_linear_interpolation(resid, t0)
+        # Check for empty input
+        if x0.size == 0 or y0.size == 0:
+            return np.array([])
 
-        if t_out.shape[0] == 1:
-            t_out = t_out[0, :]
+        # Check for matching x0, y0
+        if x0.shape != y0.shape:
+            raise ValueError("x0 and y0 array shapes must match")
+
+        # Check that if any of the arrays are 2D, they all have the same shape
+        if (x0.ndim > 1 or wavelength.ndim > 1) and x0.shape != wavelength.shape:
+            raise ValueError("Inputs are >1D but array shapes do not match")
+
+        # Most common use case is a single unique x0, y0 value for all input,
+        # but it is technically possible to transform different x0, y0 values
+        # at the same time. Fit t as a function of wavelength
+        # for each set of x0, y0 in the input and use it to get the output t value.
+        x_y_pairs = np.unique(np.stack([x0.flat, y0.flat], axis=1), axis=0)
+        t_out = np.full_like(wavelength * x0, np.nan)
+        for xref, yref in x_y_pairs:
+            # Get w for each sampled t0
+            w_t = trace_function(t0, np.full_like(t0, xref), np.full_like(t0, yref))
+            idx = np.argsort(w_t)
+
+            # Spline fit to invert, for t as a function of wavelength
+            splbase = Spline1D()
+            fitter = SplineSmoothingFitter()
+            spl = fitter(splbase, w_t[idx], t0[idx], s=0)
+
+            # Set t_out for matching x,y values
+            xy_idx = (x0 == xref) & (y0 == yref)
+            if x0.size == 1:
+                # only 1 x0, y0 input: set all t_out values at once
+                t_out = spl(wavelength)
+            elif wavelength.size == 1:
+                # multiple x, y, only 1 wavelength
+                t_out[xy_idx] = spl(wavelength)
+            else:
+                # Multiple x0, y0 and wavelength input: assume
+                # shapes match
+                t_out[xy_idx] = spl(wavelength[xy_idx])
+
+        # Clip t to 0 - 1
+        t_out = np.clip(t_out, 0, 1)
+
         return t_out
 
 

--- a/src/stdatamodels/jwst/transforms/models.py
+++ b/src/stdatamodels/jwst/transforms/models.py
@@ -21,6 +21,7 @@ from astropy.modeling.models import math as astmath
 from astropy.modeling.parameters import InputParameterError, Parameter
 from gwcs.spectroscopy import SellmeierGlass, SellmeierZemax, Snell3D
 from gwcs.utils import to_index
+from scipy.interpolate import make_interp_spline
 
 from stdatamodels.properties import ListNode
 
@@ -1521,9 +1522,7 @@ class NIRCAMBackwardGrismDispersion(_BackwardGrismDispersionBase):
             idx = np.argsort(w_t)
 
             # Spline fit to invert, for t as a function of wavelength
-            splbase = Spline1D()
-            fitter = SplineSmoothingFitter()
-            spl = fitter(splbase, w_t[idx], t0[idx], s=0)
+            spl = make_interp_spline(w_t[idx], t0[idx])
 
             # Set t_out for matching x,y values
             xy_idx = (x0 == xref) & (y0 == yref)

--- a/tests/jwst/transforms/test_transforms.py
+++ b/tests/jwst/transforms/test_transforms.py
@@ -416,10 +416,8 @@ def _invdisp_interp_old(model, x0, y0, wavelength):
     return f
 
 
-@pytest.mark.parametrize("n_coeffs", [2, 3])
-def test_nircam_backward_grism_dispersion(n_coeffs):
-    """Ensure algorithm change works similarly to legacy code."""
-
+@pytest.fixture
+def nircam_backward_grism_dispersion():
     def _mock_coeff(x, y):
         """
         Simulate dependence of the polynomial coefficients on the detector position.
@@ -430,73 +428,142 @@ def test_nircam_backward_grism_dispersion(n_coeffs):
         """
         return (x / 100) * 1e-6
 
+    n_coeffs = 3
     lmodel = [_mock_coeff] * n_coeffs
 
     orders = [1, 2]
     lmodels = [lmodel] * len(orders)
     xmodels = [Identity(1)] * len(orders)
     ymodels = [Identity(1)] * len(orders)
-
     sampling = 80
-    # imagine we are dispersing a square 5x5 source
-    # then x0, y0 are expected to be flattened arrays of the grid
-    # such that each (x0[i], y0[i]) corresponds to a unique pixel in the source
-    # but x0 or y0 itself can and usually will have repeated values
+    model = models.NIRCAMBackwardGrismDispersion(
+        orders, lmodels, xmodels, ymodels, sampling=sampling
+    )
+    return model
+
+
+def test_nircam_backward_grism_dispersion(nircam_backward_grism_dispersion):
+    """Ensure algorithm change works similarly to legacy code."""
+    model = nircam_backward_grism_dispersion
+
+    # Test a set of input x0 and y0 values. This is unrealistic
+    # for a real exposure, which will have a single x0, y0 value for
+    # all pixels, but is technically allowed by the transform.
     x = np.linspace(100, 200, 5)
     y = np.linspace(90, 190, 5)
     x0, y0 = np.meshgrid(x, y, indexing="ij")
     x0 = x0.flatten()
     y0 = y0.flatten()
 
+    # Test a range of wavelengths at each x0, y0
     wl = np.linspace(1.5e-6, 2.5e-6, 21)  # 2 microns
-    model = models.NIRCAMBackwardGrismDispersion(
-        orders, lmodels, xmodels, ymodels, sampling=sampling
-    )
-    t_out = model.invdisp_interp(lmodels[0], x0, y0, wl)
 
-    # for this version we need to make x0, y0, wl all have same shape
+    # Expand input arrays to 2D
+    x02d = np.empty((21, 25))
+    y02d = np.empty((21, 25))
+    wl2d = np.empty((21, 25))
+    x02d[:, :] = x0[None, :]
+    y02d[:, :] = y0[None, :]
+    wl2d[:, :] = wl[:, None]
+
+    t_out = model.invdisp_interp(model.lmodels[0], x02d, y02d, wl2d)
+
+    # Compare to older method
     t2_out = np.empty_like(t_out)
     for i, this_wl in enumerate(wl):
         wl2 = this_wl * np.ones_like(x0)
-        t2 = _invdisp_interp_old(lmodels[0], x0, y0, wl2)
+        t2 = _invdisp_interp_old(model.lmodels[0], x0, y0, wl2)
         t2_out[i] = t2
-
     assert_allclose(t_out, t2_out, atol=1e-3, rtol=0)
 
 
-def test_nircam_backward_grism_dispersion_single():
+def test_nircam_backward_grism_dispersion_single(nircam_backward_grism_dispersion):
     """Smoke test to ensure works on single-valued inputs as well."""
-
-    def _mock_coeff(x, y):
-        return (x / 100) * 1e-6
-
-    lmodel = [_mock_coeff] * 2
-
+    model = nircam_backward_grism_dispersion
     orders = np.array([1])
-    lmodels = [lmodel] * len(orders)
-    xmodels = [Identity(1)] * len(orders)
-    ymodels = [Identity(1)] * len(orders)
 
     # many wavelengths, single x0, y0
     x0 = 150
     y0 = 140
     wl = np.linspace(1.5e-6, 2.5e-6, 21)  # 2 microns
-    model = models.NIRCAMBackwardGrismDispersion(orders, lmodels, xmodels, ymodels)
     xi, yi, x, y, order = model.evaluate(x0, y0, wl, orders)
     assert xi.size == wl.size
     assert yi.size == wl.size
     assert x == x0
     assert y == y0
-    assert_allclose(order, orders[0])
+    assert_allclose(order, model.orders[0])
 
     # many x0, y0, single wavelength
     x0 = np.linspace(100, 200, 11)
     y0 = np.linspace(90, 190, 11)
     wl = 2e-6  # 2 microns
-    model = models.NIRCAMBackwardGrismDispersion(orders, lmodels, xmodels, ymodels)
     xi, yi, x, y, order = model.evaluate(x0, y0, wl, orders)
     assert xi.size == x0.size
     assert yi.size == y0.size
+
+
+def test_nircam_backward_grism_dispersion_paired_1d(nircam_backward_grism_dispersion):
+    """
+    Test the paired 1-D case of NIRCam backward grism dispersion.
+
+    When x0, y0, and wavelength are 1-D arrays of the same length N > 1,
+    each wavelength[i] is paired with source position (x0[i], y0[i]).
+    The output should have shape (N,) and agree with element-wise calls
+    through the general code path.
+    """
+    model = nircam_backward_grism_dispersion
+    orders = np.array([1])
+
+    # N source positions, each paired with a unique wavelength
+    N = 8
+    x0 = np.linspace(100, 200, N)
+    y0 = np.linspace(90, 190, N)
+    wl = np.linspace(1.5e-6, 2.5e-6, N)
+    xi, yi, x0_out, y0_out, order_out = model.evaluate(x0, y0, wl, orders)
+    assert xi.shape == (N,)
+    assert yi.shape == (N,)
+
+    # Run individually and ensure the results are the same as the vectorized version
+    xi_individual = np.array([model.evaluate(x0[i], y0[i], wl[i], orders)[0][0] for i in range(N)])
+    yi_individual = np.array([model.evaluate(x0[i], y0[i], wl[i], orders)[1][0] for i in range(N)])
+    assert_allclose(xi, xi_individual, atol=1e-6, rtol=0)
+    assert_allclose(yi, yi_individual, atol=1e-6, rtol=0)
+
+
+def test_nircam_backward_grism_empty_xy(nircam_backward_grism_dispersion):
+    model = nircam_backward_grism_dispersion
+    x, y, x0, y0, order = model([], [], 2.2, 1)
+    assert x.size == 0
+    assert y.size == 0
+    assert x0.size == 0
+    assert y0.size == 0
+    assert order == 1.0
+
+
+def test_nircam_backward_grism_empty_wavelength(nircam_backward_grism_dispersion):
+    model = nircam_backward_grism_dispersion
+    x, y, x0, y0, order = model(10, 20, [], 1)
+    assert x.size == 0
+    assert y.size == 0
+    assert x0 == 10
+    assert y0 == 20
+    assert order == 1.0
+
+
+def test_nircam_backward_grism_xy_mismatch(nircam_backward_grism_dispersion):
+    model = nircam_backward_grism_dispersion
+    with pytest.raises(ValueError, match="x0 and y0 array shapes must match"):
+        model(10, [20, 30], 2.2, 1)
+
+
+@pytest.mark.parametrize(
+    "x,y,w",
+    [(np.ones((3, 3)), np.ones((3, 3)), 2.2), (np.ones((3, 3)), np.ones((3, 3)), np.arange(3))],
+)
+def test_nircam_backward_grism_xy_w_mismatch(nircam_backward_grism_dispersion, x, y, w):
+    model = nircam_backward_grism_dispersion
+    with pytest.raises(ValueError, match="array shapes do not match"):
+        model(x, y, w, 1)
 
 
 @pytest.mark.parametrize("direction", ["row", "column"])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number, 
for example JP-1234: <Fix a bug> -->
Resolves [JP-2518](https://jira.stsci.edu/browse/JP-2518)

Closes #687 

Related but independent jwst PR: https://github.com/spacetelescope/jwst/pull/10783

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

The NIRCam backward grism dispersion transform currently uses a linear interpolation over 40 sampled points to invert the wavelength model to recover the x index.   This can lead to round trip errors that vary over the dispersion axis.  For one example (jw01366002001_04103_00001), round trip error at x0 = [100, 1000, 1500], y0 = 34 with 
```x, y, _ = wcs.backward_transform(*wcs(x0, y0, 1))```
gives x - x0 of [-0.00420179  0.01182850  0.02396645].

Similar to the changes for WFSS transform in #779, we can use a spline fit for a smoother inversion instead of the linear interpolation.  With these changes, the round trip error in x is smaller and more even:
`x - x0 = [0.00020418 0.00020306 0.00020273]`

Also, this transform currently does not correctly handle input 1D vectors: it should be possible to input paired x, y, lambda values in 1D vector form and get back a 1D vector.  This PR also updates output handling to support more general 1D and 2D cases, replacing draft PR #687.  For simplicity, the transform still requires that if any input array is 2D, the input arrays all match in shape.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
