### PR TITLE
JP-4432: Allow extra_fits to use caching and clean up FITS writer a bit

### DIFF
--- a/changes/794.feature.rst
+++ b/changes/794.feature.rst
@@ -1,0 +1,1 @@
+Refactor FITS writer so extra_fits takes advantage of caching and HDUList is built at the very end

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -340,12 +340,10 @@ class FitsContext:
             self.hdu_cache = {("PRIMARY", 0): fits.PrimaryHDU()}
         else:
             self.hdu_cache = {}
-            nameless_idx = 0
-            for hdu in hdulist:
+            for i, hdu in enumerate(hdulist):
                 if hdu.name in [None, ""]:
-                    # give any nameless HDUs a ver to differentiate them
-                    nameless_idx += 1
-                    hdu.ver = nameless_idx
+                    # give nameless HDUs a ver equal to their index in the file
+                    hdu.ver = i
                 self.hdu_cache[(hdu.name, hdu.ver - 1)] = hdu
 
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -970,7 +970,7 @@ def _can_skip_fits_update(hdulist, asdf_struct, context):
 
     # Check for FITS hash and compare to current. If equal, automatically skip.
     if asdf_struct.tree.get(FITS_HASH_KEY, None) is not None:
-        if asdf_struct.tree[FITS_HASH_KEY] == fits_hash(list(hdulist)):
+        if asdf_struct.tree[FITS_HASH_KEY] == fits_hash(hdulist):
             log.debug("FITS hash matches. Skipping FITS updating.")
             return True
 
@@ -986,7 +986,7 @@ def fits_hash(hdus):
 
     Parameters
     ----------
-    hdus : list[HDU]
+    hdus : `astropy.io.fits.HDUList` or plain list of HDUs
         All the HDUs.
 
     Returns

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -886,14 +886,12 @@ def _map_hdulist_to_arrays(hdulist, af):
                 "((?P<name>[ -~]+),)?(?P<ver>[0-9]+)",
                 source[len(_FITS_SOURCE_PREFIX) :],
             )
-            if parts is not None:
-                ver = int(parts.group("ver"))
-                if parts.group("name"):
-                    pair = (parts.group("name"), ver)
-                else:
-                    pair = ("", ver)
-            data = hdu_index[pair].data
-            return data
+            ver = int(parts.group("ver"))
+            if parts.group("name"):
+                pair = (parts.group("name"), ver)
+            else:
+                pair = ("", ver)
+            return hdu_index[pair].data
         return node
 
     # don't assign to af.tree to avoid an extra validation

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -339,7 +339,14 @@ class FitsContext:
         if hdulist is None:
             self.hdu_cache = {("PRIMARY", 0): fits.PrimaryHDU()}
         else:
-            self.hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
+            self.hdu_cache = {}
+            nameless_idx = 0
+            for hdu in hdulist:
+                if hdu.name in [None, ""]:
+                    # give any nameless HDUs a ver to differentiate them
+                    nameless_idx += 1
+                    hdu.ver = nameless_idx
+                self.hdu_cache[(hdu.name, hdu.ver - 1)] = hdu
 
 
 def _get_validators(fits_context):
@@ -440,7 +447,10 @@ def _create_tagged_dict_for_fits_array(hdu):
         hdu.data.dtype, include_byteorder=True, override_byteorder="big"
     )
 
-    source = f"{_FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
+    if hdu.name == "":
+        source = f"{_FITS_SOURCE_PREFIX}{hdu.ver}"
+    else:
+        source = f"{_FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
 
     return tagged.TaggedDict(
         data={
@@ -861,7 +871,7 @@ def from_fits_asdf(
 
 def _map_hdulist_to_arrays(hdulist, af):
     # hdulist[key] is very inefficient so pre-index hdus
-    hdu_index = {(h.name or i, h.ver): h for i, h in enumerate(hdulist)}
+    hdu_index = {(h.name, h.ver): h for h in hdulist}
 
     def callback(node):
         if (
@@ -881,7 +891,7 @@ def _map_hdulist_to_arrays(hdulist, af):
                 if parts.group("name"):
                     pair = (parts.group("name"), ver)
                 else:
-                    pair = (ver, 1)
+                    pair = ("", ver)
             data = hdu_index[pair].data
             return data
         return node

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -118,7 +118,7 @@ def _get_hdu_type(hdu_name, schema=None, value=None):
 
 
 def _get_hdu_pair(hdu_name, index=None):
-    if hdu_name == 0:
+    if hdu_name in [0, "PRIMARY"]:
         return ("PRIMARY", 0)
     if index is None:
         index = 0
@@ -152,12 +152,7 @@ def get_hdu(hdulist, hdu_name, index=None, _cache=None):
         hdu = hdulist[pair]
     except (KeyError, IndexError, AttributeError):
         try:
-            if isinstance(pair, str):
-                hdu = hdulist[(pair, 1)]
-            elif isinstance(pair, tuple) and index in [0, None]:
-                hdu = hdulist[pair[0]]
-            else:
-                raise
+            hdu = hdulist[pair[0]]
         except (KeyError, IndexError, AttributeError) as err:
             raise AttributeError(
                 f"Property missing because FITS file has no '{pair!r}' HDU"
@@ -191,54 +186,30 @@ def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
     return hdu
 
 
-def _get_or_make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None, _cache=None):
-    if isinstance(hdulist, weakref.ReferenceType):
-        ref = hdulist()
-        result = _get_or_make_hdu(
-            ref, hdu_name, index=index, hdu_type=hdu_type, value=value, _cache=_cache
-        )
-        # While likely not needed (as ref will fall out of scope on
-        # return), del ref to remove the reference to the hdulist we
-        # resolved from the weakref. weakref is important here as
-        # this function is called within a validator which will be
-        # cached holding referenced objects in memory.
-        # https://github.com/spacetelescope/stdatamodels/pull/109
-        del ref
-        return result
-    # Bypass get_hdu when there's a cache because try: hdulist[pair] is slow.
+def _get_or_make_hdu(fits_context, hdu_name, hdu_type=None, value=None):
+    hdulist = fits_context.hdulist()
+    index = fits_context.sequence_index
+    _cache = fits_context.hdu_cache
+
     # We know that if the pair isn't in the cache it needs to be made.
-    if _cache is not None:
-        pair = _get_hdu_pair(hdu_name, index=index)
-        if pair in _cache:
-            hdu = _cache[pair]
-            if hdu_type is not None and not isinstance(hdu, hdu_type):
-                # this is used for Table-like hdus
-                new_hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-                for key, val in hdu.header.items():
-                    if not is_builtin_fits_keyword(key):
-                        new_hdu.header[key] = val
-                hdulist.remove(hdu)
-                hdu = new_hdu
-            return hdu
-        hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-        # add new HDU to the cache
-        _cache[pair] = hdu
-        return hdu
-    # original behavior, currently still used for extra_fits handling
-    try:
-        hdu = get_hdu(hdulist, hdu_name, index=index)
-    except AttributeError:
-        hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-    else:
+    pair = _get_hdu_pair(hdu_name, index=index)
+    if pair in _cache:
+        hdu = _cache[pair]
         if hdu_type is not None and not isinstance(hdu, hdu_type):
+            # this is used for Table-like hdus
             new_hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
             for key, val in hdu.header.items():
                 if not is_builtin_fits_keyword(key):
                     new_hdu.header[key] = val
             hdulist.remove(hdu)
             hdu = new_hdu
-        elif value is not None:
+        if value is not None:
             hdu.data = value
+        return hdu
+
+    hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
+    # add new HDU to the cache
+    _cache[pair] = hdu
     return hdu
 
 
@@ -273,17 +244,13 @@ def _fits_comment_section_handler(fits_context, validator, properties, instance,
         current_comment_stack.pop(-1)
 
 
-def _fits_element_writer(
-    fits_context, validator, fits_keyword, instance, schema, fits_hdu_cache=None
-):
+def _fits_element_writer(fits_context, validator, fits_keyword, instance, schema):
     if schema.get("type", "object") == "array":
         raise ValueError("'fits_keyword' is not valid with type of 'array'")
 
     hdu_name = _get_hdu_name(schema)
 
-    hdu = _get_or_make_hdu(
-        fits_context.hdulist, hdu_name, index=fits_context.sequence_index, _cache=fits_hdu_cache
-    )
+    hdu = _get_or_make_hdu(fits_context, hdu_name)
 
     for comment in fits_context.comment_stack:
         hdu.header.append((" ", ""), end=True)
@@ -302,7 +269,7 @@ def _fits_element_writer(
         hdu.header.append((fits_keyword, instance, comment), end=True)
 
 
-def _fits_array_writer(fits_context, validator, _, instance, schema, fits_hdu_cache=None):
+def _fits_array_writer(fits_context, validator, _, instance, schema):
     if instance is None:
         return
 
@@ -322,21 +289,16 @@ def _fits_array_writer(fits_context, validator, _, instance, schema, fits_hdu_ca
 
     hdu_name = _get_hdu_name(schema)
     _assert_non_primary_hdu(hdu_name)
-    index = fits_context.sequence_index
-    if index is None:
-        index = 0
 
     hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
-    hdu = _get_or_make_hdu(
-        fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type, _cache=fits_hdu_cache
-    )
+    hdu = _get_or_make_hdu(fits_context, hdu_name, hdu_type=hdu_type)
 
     hdu.data = instance
     if instance_id in fits_context.extension_array_links:
         if fits_context.extension_array_links[instance_id]() is not hdu:
             raise ValueError("Linking one array to multiple hdus is not supported")
     fits_context.extension_array_links[instance_id] = weakref.ref(hdu)
-    hdu.ver = index + 1
+    hdu.ver = fits_context.sequence_index + 1
 
 
 # This is copied from jsonschema._validators and modified to keep track
@@ -375,12 +337,12 @@ class FitsContext:
     def __init__(self, hdulist):
         self.hdulist = weakref.ref(hdulist)
         self.comment_stack = []
-        self.sequence_index = None
+        self.sequence_index = 0
         self.extension_array_links = {}
+        self.hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
 
 
-def _get_validators(hdulist):
-    fits_context = FitsContext(hdulist)
+def _get_validators(fits_context):
 
     validators = HashableDict(asdf_schema.YAML_VALIDATORS)
 
@@ -410,17 +372,10 @@ def _get_validators(hdulist):
             yield ValidationError(f"tags '{tags}' do not match pattern '{tag_pattern}'")
             return
 
-    # Initialize a cache of HDUs for the validator.
-    # This allows bypassing very slow indexing into hdulist
-    fits_hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
-    partial_fits_array_writer = partial(
-        _fits_array_writer, fits_context, fits_hdu_cache=fits_hdu_cache
-    )
+    partial_fits_array_writer = partial(_fits_array_writer, fits_context)
     validators.update(
         {
-            "fits_keyword": partial(
-                _fits_element_writer, fits_context, fits_hdu_cache=fits_hdu_cache
-            ),
+            "fits_keyword": partial(_fits_element_writer, fits_context),
             "ndim": partial_fits_array_writer,
             "max_ndim": partial_fits_array_writer,
             "datatype": partial_fits_array_writer,
@@ -434,7 +389,7 @@ def _get_validators(hdulist):
     return validators, fits_context
 
 
-def _save_from_schema(hdulist, tree, schema):
+def _save_from_schema(fits_context, tree, schema):
     def datetime_callback(node):
         if isinstance(node, datetime.datetime):
             node = time.Time(node)
@@ -448,7 +403,7 @@ def _save_from_schema(hdulist, tree, schema):
 
     kwargs = {"_visit_repeat_nodes": True}
 
-    validators, context = _get_validators(hdulist)
+    validators, context = _get_validators(fits_context)
     validator = asdf_schema.get_validator(schema, None, validators, **kwargs)
 
     # This actually kicks off the saving
@@ -459,16 +414,16 @@ def _save_from_schema(hdulist, tree, schema):
     def callback(node):
         if id(node) in context.extension_array_links:
             hdu = context.extension_array_links[id(node)]()
-            return _create_tagged_dict_for_fits_array(hdu, hdulist.index(hdu))
+            return _create_tagged_dict_for_fits_array(hdu)
         elif isinstance(node, (np.ndarray, NDArrayType)):
             # in addition to links generated during validation
             # replace arrays in the tree that are identical to HDU arrays
             # with ndarray-1.0.0 tagged objects with special source values
             # that represent links to the surrounding FITS file.
             # This is important for general ASDF-in-FITS support
-            for hdu_index, hdu in enumerate(hdulist):
+            for hdu in fits_context.hdulist():
                 if hdu.data is not None and node is hdu.data:
-                    return _create_tagged_dict_for_fits_array(hdu, hdu_index)
+                    return _create_tagged_dict_for_fits_array(hdu)
         return node
 
     tree = treeutil.walk_and_modify(tree, callback)
@@ -476,7 +431,7 @@ def _save_from_schema(hdulist, tree, schema):
     return tree
 
 
-def _create_tagged_dict_for_fits_array(hdu, hdu_index):
+def _create_tagged_dict_for_fits_array(hdu):
     # Views over arrays stored in FITS files have some idiosyncrasies.
     # astropy.io.fits always writes arrays C-contiguous with big-endian
     # byte order, whereas asdf preserves the "contiguousity" and byte order
@@ -485,10 +440,7 @@ def _create_tagged_dict_for_fits_array(hdu, hdu_index):
         hdu.data.dtype, include_byteorder=True, override_byteorder="big"
     )
 
-    if hdu.name == "":
-        source = f"{_FITS_SOURCE_PREFIX}{hdu_index}"
-    else:
-        source = f"{_FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
+    source = f"{_FITS_SOURCE_PREFIX}{hdu.name},{hdu.ver}"
 
     return tagged.TaggedDict(
         data={
@@ -532,16 +484,16 @@ def _normalize_arrays(tree):
     return treeutil.walk_and_modify(tree, normalize_array)
 
 
-def _save_extra_fits(hdulist, tree):
+def _save_extra_fits(fits_context, tree):
     # Handle _extra_fits
     for hdu_name, parts in tree.get("extra_fits", {}).items():
         if "data" in parts:
             hdu_type = _get_hdu_type(hdu_name, value=parts["data"])
-            hdu = _get_or_make_hdu(hdulist, hdu_name, hdu_type=hdu_type, value=parts["data"])
-            node = _create_tagged_dict_for_fits_array(hdu, hdulist.index(hdu))
+            hdu = _get_or_make_hdu(fits_context, hdu_name, hdu_type=hdu_type, value=parts["data"])
+            node = _create_tagged_dict_for_fits_array(hdu)
             tree["extra_fits"][hdu_name]["data"] = node
         if "header" in parts:
-            hdu = _get_or_make_hdu(hdulist, hdu_name)
+            hdu = _get_or_make_hdu(fits_context, hdu_name)
             for key, val, comment in parts["header"]:
                 if is_builtin_fits_keyword(key):
                     continue
@@ -593,8 +545,11 @@ def to_fits(tree, schema, hdulist=None):
         hdulist.append(fits.PrimaryHDU())
 
     tree = _normalize_arrays(tree)
-    tree = _save_from_schema(hdulist, tree, schema)
-    tree = _save_extra_fits(hdulist, tree)
+    fits_context = FitsContext(hdulist)
+    tree = _save_from_schema(fits_context, tree, schema)
+    tree = _save_extra_fits(fits_context, tree)
+    hdulist = fits_context.hdulist()
+
     _save_history(hdulist, tree)
 
     # Store the FITS hash in the tree

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -296,7 +296,6 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
         if fits_context.extension_array_links[instance_id]() is not hdu:
             raise ValueError("Linking one array to multiple hdus is not supported")
     fits_context.extension_array_links[instance_id] = weakref.ref(hdu)
-    # fits_context.extension_array_links[instance_id] = hdu
     hdu.ver = fits_context.sequence_index + 1
 
 
@@ -551,11 +550,12 @@ def to_fits(tree, schema, hdulist=None):
     _save_history(fits_context, tree)
     hdus = list(fits_context.hdu_cache.values())
 
+    # Store the FITS hash in the tree
+    tree[FITS_HASH_KEY] = fits_hash(hdus)
+
     # delete any ASDF extension if present
     hdus = [hdu for hdu in hdus if hdu.name != _ASDF_EXTENSION_NAME]
 
-    # Store the FITS hash in the tree
-    tree[FITS_HASH_KEY] = fits_hash(hdus)
     hdus.append(_create_asdf_hdu(tree))
 
     return fits.HDUList(hdus)

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -167,7 +167,7 @@ def get_hdu(hdulist, hdu_name, index=None, _cache=None):
     return hdu
 
 
-def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
+def _make_hdu(hdu_name, index=None, hdu_type=None, value=None):
     if isinstance(value, NDArrayType):
         value = np.asarray(value)
 
@@ -182,12 +182,10 @@ def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
         hdu = hdu_type(value, name=hdu_name)
     if index is not None:
         hdu.ver = index + 1
-    hdulist.append(hdu)
     return hdu
 
 
 def _get_or_make_hdu(fits_context, hdu_name, hdu_type=None, value=None):
-    hdulist = fits_context.hdulist()
     index = fits_context.sequence_index
     _cache = fits_context.hdu_cache
 
@@ -197,17 +195,17 @@ def _get_or_make_hdu(fits_context, hdu_name, hdu_type=None, value=None):
         hdu = _cache[pair]
         if hdu_type is not None and not isinstance(hdu, hdu_type):
             # this is used for Table-like hdus
-            new_hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
+            new_hdu = _make_hdu(hdu_name, index=index, hdu_type=hdu_type, value=value)
             for key, val in hdu.header.items():
                 if not is_builtin_fits_keyword(key):
                     new_hdu.header[key] = val
-            hdulist.remove(hdu)
             hdu = new_hdu
+            _cache[pair] = new_hdu
         if value is not None:
             hdu.data = value
         return hdu
 
-    hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
+    hdu = _make_hdu(hdu_name, index=index, hdu_type=hdu_type, value=value)
     # add new HDU to the cache
     _cache[pair] = hdu
     return hdu
@@ -298,6 +296,7 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
         if fits_context.extension_array_links[instance_id]() is not hdu:
             raise ValueError("Linking one array to multiple hdus is not supported")
     fits_context.extension_array_links[instance_id] = weakref.ref(hdu)
+    # fits_context.extension_array_links[instance_id] = hdu
     hdu.ver = fits_context.sequence_index + 1
 
 
@@ -335,11 +334,13 @@ def _fits_type(fits_context, validator, items, instance, schema):
 
 class FitsContext:
     def __init__(self, hdulist):
-        self.hdulist = weakref.ref(hdulist)
         self.comment_stack = []
         self.sequence_index = 0
         self.extension_array_links = {}
-        self.hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
+        if hdulist is None:
+            self.hdu_cache = {("PRIMARY", 0): fits.PrimaryHDU()}
+        else:
+            self.hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
 
 
 def _get_validators(fits_context):
@@ -403,7 +404,7 @@ def _save_from_schema(fits_context, tree, schema):
 
     kwargs = {"_visit_repeat_nodes": True}
 
-    validators, context = _get_validators(fits_context)
+    validators, fits_context = _get_validators(fits_context)
     validator = asdf_schema.get_validator(schema, None, validators, **kwargs)
 
     # This actually kicks off the saving
@@ -412,8 +413,8 @@ def _save_from_schema(fits_context, tree, schema):
     # Now link extensions to items in the tree
 
     def callback(node):
-        if id(node) in context.extension_array_links:
-            hdu = context.extension_array_links[id(node)]()
+        if id(node) in fits_context.extension_array_links:
+            hdu = fits_context.extension_array_links[id(node)]()
             return _create_tagged_dict_for_fits_array(hdu)
         elif isinstance(node, (np.ndarray, NDArrayType)):
             # in addition to links generated during validation
@@ -421,7 +422,7 @@ def _save_from_schema(fits_context, tree, schema):
             # with ndarray-1.0.0 tagged objects with special source values
             # that represent links to the surrounding FITS file.
             # This is important for general ASDF-in-FITS support
-            for hdu in fits_context.hdulist():
+            for hdu in list(fits_context.hdu_cache.values()):
                 if hdu.data is not None and node is hdu.data:
                     return _create_tagged_dict_for_fits_array(hdu)
         return node
@@ -502,9 +503,11 @@ def _save_extra_fits(fits_context, tree):
     return tree
 
 
-def _save_history(hdulist, tree):
+def _save_history(fits_context, tree):
     if "history" not in tree:
         return
+
+    primary_header = fits_context.hdu_cache[("PRIMARY", 0)].header
 
     # Support the older way of representing ASDF history entries
     if isinstance(tree["history"], list):
@@ -519,7 +522,7 @@ def _save_history(hdulist, tree):
                 history[i] = HistoryEntry(history[i])
             else:
                 history[i] = HistoryEntry({"description": str(history[i])})
-        hdulist[0].header["HISTORY"] = history[i]["description"]
+        primary_header["HISTORY"] = history[i]["description"]
 
 
 def to_fits(tree, schema, hdulist=None):
@@ -540,27 +543,22 @@ def to_fits(tree, schema, hdulist=None):
     hdulist : astropy.io.fits.HDUList
         The HDU list.
     """
-    if hdulist is None:
-        hdulist = fits.HDUList()
-        hdulist.append(fits.PrimaryHDU())
-
     tree = _normalize_arrays(tree)
     fits_context = FitsContext(hdulist)
     tree = _save_from_schema(fits_context, tree, schema)
     tree = _save_extra_fits(fits_context, tree)
-    hdulist = fits_context.hdulist()
 
-    _save_history(hdulist, tree)
+    _save_history(fits_context, tree)
+    hdus = list(fits_context.hdu_cache.values())
+
+    # delete any ASDF extension if present
+    hdus = [hdu for hdu in hdus if hdu.name != _ASDF_EXTENSION_NAME]
 
     # Store the FITS hash in the tree
-    tree[FITS_HASH_KEY] = fits_hash(hdulist)
+    tree[FITS_HASH_KEY] = fits_hash(hdus)
+    hdus.append(_create_asdf_hdu(tree))
 
-    if _ASDF_EXTENSION_NAME in hdulist:
-        del hdulist[_ASDF_EXTENSION_NAME]
-
-    hdulist.append(_create_asdf_hdu(tree))
-
-    return hdulist
+    return fits.HDUList(hdus)
 
 
 def _create_asdf_hdu(tree):
@@ -964,7 +962,7 @@ def _can_skip_fits_update(hdulist, asdf_struct, context):
 
     # Check for FITS hash and compare to current. If equal, automatically skip.
     if asdf_struct.tree.get(FITS_HASH_KEY, None) is not None:
-        if asdf_struct.tree[FITS_HASH_KEY] == fits_hash(hdulist):
+        if asdf_struct.tree[FITS_HASH_KEY] == fits_hash(list(hdulist)):
             log.debug("FITS hash matches. Skipping FITS updating.")
             return True
 
@@ -972,7 +970,7 @@ def _can_skip_fits_update(hdulist, asdf_struct, context):
     return False
 
 
-def fits_hash(hdulist):
+def fits_hash(hdus):
     """
     Calculate a hash based on all HDU headers.
 
@@ -980,8 +978,8 @@ def fits_hash(hdulist):
 
     Parameters
     ----------
-    hdulist : astropy.fits.HDUList
-        The FITS structure.
+    hdus : list[HDU]
+        All the HDUs.
 
     Returns
     -------
@@ -994,7 +992,7 @@ def fits_hash(hdulist):
     # Such issues are inconsequential to hash calculation.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", AstropyWarning)
-        fits_hash.update("".join(str(hdu.header) for hdu in hdulist if hdu.name != "ASDF").encode())
+        fits_hash.update("".join(str(hdu.header) for hdu in hdus if hdu.name != "ASDF").encode())
     return fits_hash.hexdigest()
 
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -869,7 +869,7 @@ def from_fits_asdf(
 
 def _map_hdulist_to_arrays(hdulist, af):
     # hdulist[key] is very inefficient so pre-index hdus
-    hdu_index = {(h.name, h.ver): h for h in hdulist}
+    hdu_index = {(h.name, h.ver or i): h for i, h in enumerate(hdulist)}
 
     def callback(node):
         if (

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -342,8 +342,9 @@ class FitsContext:
             self.hdu_cache = {}
             for i, hdu in enumerate(hdulist):
                 if hdu.name in [None, ""]:
-                    # give nameless HDUs a ver equal to their index in the file
-                    hdu.ver = i
+                    # give nameless HDUs a name equal to their index in the file
+                    hdu.name = str(i)
+                    hdu.ver = 1
                 self.hdu_cache[(hdu.name, hdu.ver - 1)] = hdu
 
 
@@ -869,7 +870,7 @@ def from_fits_asdf(
 
 def _map_hdulist_to_arrays(hdulist, af):
     # hdulist[key] is very inefficient so pre-index hdus
-    hdu_index = {(h.name, h.ver or i): h for i, h in enumerate(hdulist)}
+    hdu_index = {(h.name or i, h.ver): h for i, h in enumerate(hdulist)}
 
     def callback(node):
         if (
@@ -884,12 +885,14 @@ def _map_hdulist_to_arrays(hdulist, af):
                 "((?P<name>[ -~]+),)?(?P<ver>[0-9]+)",
                 source[len(_FITS_SOURCE_PREFIX) :],
             )
-            ver = int(parts.group("ver"))
-            if parts.group("name"):
-                pair = (parts.group("name"), ver)
-            else:
-                pair = ("", ver)
-            return hdu_index[pair].data
+            if parts is not None:
+                ver = int(parts.group("ver"))
+                if parts.group("name"):
+                    pair = (parts.group("name"), ver)
+                else:
+                    pair = (ver, 1)
+            data = hdu_index[pair].data
+            return data
         return node
 
     # don't assign to af.tree to avoid an extra validation

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -344,7 +344,6 @@ class FitsContext:
                 if hdu.name in [None, ""]:
                     # give nameless HDUs a name equal to their index in the file
                     hdu.name = str(i)
-                    hdu.ver = 1
                 self.hdu_cache[(hdu.name, hdu.ver - 1)] = hdu
 
 

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -210,3 +210,39 @@ def test_non_named_hdus(tmp_path):
     with asdf_in_fits.open(fn) as af:
         for i, hdu in enumerate(af.tree["hdus"]):
             assert hdu[0] == i
+
+
+def test_expected_source_indexing(tmp_path):
+    """
+    Test that expected indexing scheme of FITS extensions can be read.
+
+    The ASDF extension references FITS extensions using a specific indexing scheme,
+    with named extensions having NAME,IDX where IDX is the index among extensions with
+    that exact name, and unnamed extensions have just IDX, where IDX is the index
+    among all extensions.
+    It's possible to break the indexing scheme on write but also update the indexing scheme
+    on read to match, such that we would be silently breaking read of old files.
+    This test catches that case by explicitly defining the asdf bytes with the expected
+    indexing scheme and forcing the reader to be able to parse that correctly.
+    """
+    ff = fits.HDUList()
+    ff.append(fits.PrimaryHDU())
+    ff.append(fits.ImageHDU([0]))
+    ff.append(fits.ImageHDU([1], name="SCI"))
+    ff.append(fits.ImageHDU([2]))
+
+    asdf_bytes = b"#ASDF 1.0.0\n#ASDF_STANDARD 1.6.0\n%YAML 1.1\n%TAG ! tag:stsci.edu:asdf/\n--- !core/asdf-1.1.0\narrs:\n- !core/ndarray-1.1.0\n  source: fits:1\n  datatype: int64\n  byteorder: big\n  shape: [1]\n- !core/ndarray-1.1.0\n  source: fits:SCI,1\n  datatype: int64\n  byteorder: big\n  shape: [1]\n- !core/ndarray-1.1.0\n  source: fits:3\n  datatype: int64\n  byteorder: big\n  shape: [1]\n..."
+
+    data = np.frombuffer(asdf_bytes, dtype=np.uint8)[None, :]
+    fmt = f"{len(data[0])}B"
+    column = fits.Column(array=data, format=fmt, name="ASDF_METADATA")
+    ff.append(fits.BinTableHDU.from_columns([column], name="ASDF"))
+
+    foo_fn = tmp_path / "foo.fits"
+    ff.writeto(foo_fn, overwrite=True)
+
+    af = asdf_in_fits.open(foo_fn)
+    assert af["arrs"][0][0] == 0
+    assert af["arrs"][1][0] == 1
+    assert af["arrs"][2][0] == 2
+    assert af["arrs"][2][0] == 2

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -240,9 +240,10 @@ def test_expected_source_indexing(tmp_path):
 
     foo_fn = tmp_path / "foo.fits"
     ff.writeto(foo_fn, overwrite=True)
+    ff.close()
 
-    af = asdf_in_fits.open(foo_fn)
-    assert af["arrs"][0][0] == 0
-    assert af["arrs"][1][0] == 1
-    assert af["arrs"][2][0] == 2
-    assert af["arrs"][2][0] == 2
+    with asdf_in_fits.open(foo_fn) as af:
+        assert af["arrs"][0][0] == 0
+        assert af["arrs"][1][0] == 1
+        assert af["arrs"][2][0] == 2
+        assert af["arrs"][2][0] == 2


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #792 

<!-- describe the changes comprising this PR here -->
This PR refactors the FITS writer.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [x] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
