### PR TITLE
fix read cache for nameless hdus

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -908,7 +908,7 @@ def from_fits_asdf(
 
 def _map_hdulist_to_arrays(hdulist, af):
     # hdulist[key] is very inefficient so pre-index hdus
-    hdu_index = {(h.name, h.ver): h for h in hdulist}
+    hdu_index = {(h.name or i, h.ver): h for i, h in enumerate(hdulist)}
 
     def callback(node):
         if (

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -193,3 +193,14 @@ def test_open_asdf_in_fits_hdu(saved_array_model, test_array):
             assert_array_almost_equal(af["data"], test_array)
         # make sure file was not closed with context
         assert not hdu.fileinfo(0)["file"].closed
+
+
+def test_non_named_hdus(tmp_path):
+    fn = tmp_path / "test.fits"
+    ff = fits.HDUList([fits.PrimaryHDU()] + [fits.ImageHDU([i]) for i in range(10)])
+    tree = {"hdus": [hdu.data for hdu in ff[1:]]}
+    asdf_in_fits.write(fn, tree, ff)
+
+    with asdf_in_fits.open(fn) as af:
+        for i, hdu in enumerate(tree["hdus"]):
+            assert hdu.data[0] == i


### PR DESCRIPTION
Closes #796

I marked this no-changelog since the PR that introduced the bug had no changelog and hasn't been released.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/32065090952

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
