### PR TITLE
Update existing FITS checksums on save

### DIFF
--- a/src/stdatamodels/model_base.py
+++ b/src/stdatamodels/model_base.py
@@ -668,6 +668,10 @@ class DataModel(properties.ObjectNode):
                 # Avoid this.
                 if "ASDF" in hdulist:
                     del hdulist["ASDF"]
+            if "checksum" not in kwargs and any(
+                "CHECKSUM" in hdu.header or "DATASUM" in hdu.header for hdu in hdulist
+            ):
+                kwargs["checksum"] = True
             hdulist.writeto(init, *args, **kwargs)
 
     @property

--- a/tests/test_checksum_preservation.py
+++ b/tests/test_checksum_preservation.py
@@ -1,0 +1,39 @@
+import numpy as np
+from astropy.io import fits
+
+from .models import FitsModel
+
+
+def test_save_recalculates_existing_checksums(tmp_path):
+    """Saving a checksummed FITS model recalculates checksums after modification."""
+    source = tmp_path / "checksummed.fits"
+    output = tmp_path / "checksummed_updated.fits"
+    data = np.arange(4, dtype=np.float32).reshape(2, 2)
+
+    with FitsModel(data=data) as model:
+        model.save(source, checksum=True)
+
+    with FitsModel(source) as model:
+        model.data[0, 0] = 42
+        model.save(output)
+
+    with fits.open(output) as hdulist:
+        assert all(hdu.verify_checksum() == 1 for hdu in hdulist)
+        assert all(hdu.verify_datasum() == 1 for hdu in hdulist)
+
+
+def test_save_does_not_add_checksums_when_absent(tmp_path):
+    """Saving an unchecked FITS model does not introduce checksum keywords."""
+    source = tmp_path / "unchecked.fits"
+    output = tmp_path / "unchecked_updated.fits"
+    data = np.arange(4, dtype=np.float32).reshape(2, 2)
+
+    with FitsModel(data=data) as model:
+        model.save(source)
+
+    with FitsModel(source) as model:
+        model.save(output)
+
+    with fits.open(output) as hdulist:
+        assert all("CHECKSUM" not in hdu.header for hdu in hdulist)
+        assert all("DATASUM" not in hdu.header for hdu in hdulist)


### PR DESCRIPTION
Closes #736.

## Context

When a FITS-backed data model already contains `CHECKSUM` and `DATASUM` keywords, modifying the model and saving it currently preserves the old checksum values. The resulting FITS file therefore contains checksum metadata that no longer describes its actual contents.

This can cause the saved product to fail standard verification tools such as `fitsverify`, `fitscheck` and CRDS certification.

## Root cause

The FITS writer copies the existing header metadata into the output HDU, including any pre-existing `CHECKSUM` and `DATASUM` cards, but does not request Astropy to recalculate those values after the model contents have changed.

## Implementation

- detect whether the input HDU already contains FITS checksum metadata
- recalculate `CHECKSUM` and `DATASUM` when writing those HDUs after a model has been modified
- preserve the existing behaviour for files that did not contain checksums in the first place
- add regression coverage for both checksum-preserving and checksum-free inputs

## Impact

Data models saved from checksum-enabled FITS files will now contain checksum values that match the actual serialized contents. This restores compatibility with standard FITS integrity verification and CRDS validation workflows.

The change does not modify science data, metadata mapping, ASDF serialization or the behaviour of files that were originally written without FITS checksums.

## Validation

- full stdatamodels test matrix passed across the tested Python versions and platforms
- regression coverage verifies that existing checksums are recalculated after model changes
- regression coverage also verifies that checksums are not added to an input file that did not previously contain them

## Scope

This PR is intentionally limited to maintaining the integrity of pre-existing FITS checksum metadata. It does not enable checksums globally for all stdatamodels output.