### PR TITLE
fix and improve nameless hdu asdf_in_fits test

### DIFF
--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -201,10 +201,12 @@ def test_non_named_hdus(tmp_path):
     # give a few names so that the index of nameless hdus
     # doesn't match the index of all hdus
     ff[5].name = "FOO"
+    ff[5].ver = 1
     ff[7].name = "FOO"
+    ff[7].ver = 2
     tree = {"hdus": [hdu.data for hdu in ff[1:]]}
     asdf_in_fits.write(fn, tree, ff)
 
     with asdf_in_fits.open(fn) as af:
-        for i, hdu in enumerate(tree["hdus"]):
-            assert hdu.data[0] == i
+        for i, hdu in enumerate(af.tree["hdus"]):
+            assert hdu[0] == i

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -198,6 +198,10 @@ def test_open_asdf_in_fits_hdu(saved_array_model, test_array):
 def test_non_named_hdus(tmp_path):
     fn = tmp_path / "test.fits"
     ff = fits.HDUList([fits.PrimaryHDU()] + [fits.ImageHDU([i]) for i in range(10)])
+    # give a few names so that the index of nameless hdus
+    # doesn't match the index of all hdus
+    ff[5].name = "FOO"
+    ff[7].name = "FOO"
     tree = {"hdus": [hdu.data for hdu in ff[1:]]}
     asdf_in_fits.write(fn, tree, ff)
 


### PR DESCRIPTION
Fix an issue in a unit test noted in https://github.com/spacetelescope/stdatamodels/pull/797#discussion_r3805536200 where the test checked the incorrect data structure. Also expands the test to cover HDULists that contain a mix of named and unnamed hdus.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
