### PR TITLE
Expand FitsContext to further avoid direct use of hdulist

### DIFF
--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -206,13 +206,10 @@ def _fits_element_writer(fits_context, validator, fits_keyword, instance, schema
 
     hdu_name = schema.get("fits_hdu", "PRIMARY")
 
-    if fits_context.sequence_index is not None:
-        name = (hdu_name, fits_context.sequence_index)
-    else:
-        name = hdu_name
+    key = _name_to_key(hdu_name, fits_context.sequence_index)
 
-    if fits_context.has_name(name):
-        hdu = fits_context.by_name(name)
+    if fits_context.has_key(key):
+        hdu = fits_context.by_key(key)
     else:
         # make a new one
         hdu_type = _get_hdu_type(hdu_name, schema=schema)
@@ -264,14 +261,11 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
 
     hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
 
-    if fits_context.sequence_index is not None:
-        name = (hdu_name, fits_context.sequence_index)
-    else:
-        name = hdu_name
+    key = _name_to_key(hdu_name, fits_context.sequence_index)
 
     # Do we need to make an HDU?
-    if fits_context.has_name(name):
-        hdu = fits_context.by_name(name)
+    if fits_context.has_key(key):
+        hdu = fits_context.by_key(key)
 
         # is the type correct?
         if isinstance(hdu, hdu_type):
@@ -296,10 +290,10 @@ def _fits_array_writer(fits_context, validator, _, instance, schema):
         fits_context.append(hdu)
 
     if other_index := fits_context.extension_array_links.get(instance_id):
-        if fits_context.get_index(name) != other_index:
+        if fits_context.get_index(key) != other_index:
             raise ValueError("Linking one array to multiple hdus is not supported")
     else:
-        fits_context.extension_array_links[instance_id] = fits_context.get_index(name)
+        fits_context.extension_array_links[instance_id] = fits_context.get_index(key)
 
 
 # This is copied from jsonschema._validators and modified to keep track
@@ -334,6 +328,16 @@ def _fits_type(fits_context, validator, items, instance, schema):
     return asdf_schema.YAML_VALIDATORS["type"](validator, items, instance, schema)
 
 
+def _name_to_key(name, version=None):
+    if version:
+        return name.lower(), version
+    return name.lower()
+
+
+def _hdu_to_key(hdu):
+    return _name_to_key(hdu.name, hdu.header.get("EXTVER"))
+
+
 class FitsContext:
     def __init__(self, hdulist=None):
         self._preindex_hdulist(hdulist)
@@ -342,38 +346,31 @@ class FitsContext:
         self.extension_array_links = {}
 
     def get_index(self, name):
-        return self._name_to_index[name]
+        return self._key_to_index[name]
 
-    def by_name(self, name):
+    def by_key(self, name):
         return self._hdus[self.get_index(name)]
 
-    def has_name(self, name):
-        return name in self._name_to_index
+    def has_key(self, name):
+        return name in self._key_to_index
 
     def by_index(self, index):
         return self._hdus[index]
 
     def replace(self, hdu):
-        if ver := hdu.header.get("EXTVER"):
-            name = (hdu.name, ver)
-        else:
-            name = hdu.name
-        self._hdus[self.get_index(name)] = hdu
+        self._hdus[self.get_index(_hdu_to_key(hdu))] = hdu
 
     def append(self, hdu):
         self._hdus.append(hdu)
         index = len(self._hdus) - 1
-        if ver := hdu.header.get("EXTVER"):
-            name = (hdu.name, ver)
-        else:
-            name = hdu.name
-        self._name_to_index[name] = index
-        self._index_to_name[index] = name
+        key = _hdu_to_key(hdu)
+        self._key_to_index[key] = index
+        self._index_to_key[index] = key
 
     def _clear_hdus(self):
         self._hdus = []
-        self._name_to_index = {}
-        self._index_to_name = {}
+        self._key_to_index = {}
+        self._index_to_key = {}
 
     def _preindex_hdulist(self, hdulist=None):
         self._clear_hdus()
@@ -387,14 +384,11 @@ class FitsContext:
         for index, hdu in enumerate(self._hdus):
             # Only use version if EXTVER is defined as astropy
             # will return 1 for ver even if the HDU has no EXTVER
-            if ver := hdu.header.get("EXTVER"):
-                name = (hdu.name, ver)
-            else:
-                name = hdu.name
+            key = _hdu_to_key(hdu)
 
-            if name in self._name_to_index:
+            if key in self._key_to_index:
                 msg = (
-                    f"Multiple HDUs share {name}, this can issues with mapping FITS to ASDF. "
+                    f"Multiple HDUs share {key}, this can issues with mapping FITS to ASDF. "
                     "In the future this will be an error. Assign each HDU a unique name or "
                     "name/version to avoid this error"
                 )
@@ -402,14 +396,10 @@ class FitsContext:
                 # Only map the first name -> index to match astropy handling of name
                 # confusion where hdulist["SCI"] with 2x SCI returns the first.
             else:
-                self._name_to_index[name] = index
-            self._index_to_name[index] = name
+                self._key_to_index[key] = index
+            self._index_to_key[index] = key
 
     def to_hdulist(self, tree):
-        # TODO strip ASDF to appease a unit test, perhaps we remove the test?
-        if self.has_name(_ASDF_EXTENSION_NAME):
-            del self._hdus[self.get_index(_ASDF_EXTENSION_NAME)]
-
         # add hash
         tree[FITS_HASH_KEY] = fits_hash(self._hdus)
 
@@ -531,6 +521,10 @@ def _create_tagged_dict_for_fits_array(hdu, hdu_index):
 def _save_extra_fits(fits_context, tree):
     # Handle _extra_fits
     for hdu_name, parts in tree.get("extra_fits", {}).items():
+        # always skip ASDF
+        if hdu_name == _ASDF_EXTENSION_NAME:
+            continue
+
         # only consider non-builtin keywords
         cards = [
             fits.Card(*h) for h in parts.get("header", []) if not is_builtin_fits_keyword(h[0])
@@ -539,10 +533,12 @@ def _save_extra_fits(fits_context, tree):
         # first sort out expected type
         hdu_type = _get_hdu_type(hdu_name, value=parts.get("data"))
 
+        key = _name_to_key(hdu_name)
+
         # does the hdu exist?
-        if fits_context.has_name(hdu_name):
+        if fits_context.has_key(key):
             # get the existing hdu
-            hdu = fits_context.by_name(hdu_name)
+            hdu = fits_context.by_key(key)
 
             # is it the right type? only check if there is data
             if "data" in parts and not isinstance(hdu, hdu_type):
@@ -574,8 +570,8 @@ def _save_extra_fits(fits_context, tree):
         # update the tree with a reference to the data
         if "data" in parts:
             tree["extra_fits"][hdu_name]["data"] = _create_tagged_dict_for_fits_array(
-                fits_context.by_name(hdu_name),
-                fits_context.get_index(hdu_name),
+                fits_context.by_key(key),
+                fits_context.get_index(key),
             )
 
     return tree
@@ -598,7 +594,7 @@ def _save_history(fits_context, tree):
                 history[i] = HistoryEntry(history[i])
             else:
                 history[i] = HistoryEntry({"description": str(history[i])})
-        fits_context.by_name("PRIMARY").header["HISTORY"] = history[i]["description"]
+        fits_context.by_key("primary").header["HISTORY"] = history[i]["description"]
 
 
 def to_fits(tree, schema, hdulist=None):

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -329,9 +329,7 @@ def _fits_type(fits_context, validator, items, instance, schema):
 
 
 def _name_to_key(name, version=None):
-    if version:
-        return name.lower(), version
-    return name.lower()
+    return name.lower(), version
 
 
 def _hdu_to_key(hdu):
@@ -594,7 +592,7 @@ def _save_history(fits_context, tree):
                 history[i] = HistoryEntry(history[i])
             else:
                 history[i] = HistoryEntry({"description": str(history[i])})
-        fits_context.by_key("primary").header["HISTORY"] = history[i]["description"]
+        fits_context.by_key(_name_to_key("PRIMARY")).header["HISTORY"] = history[i]["description"]
 
 
 def to_fits(tree, schema, hdulist=None):

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -4,7 +4,6 @@ import io
 import logging
 import re
 import warnings
-import weakref
 from functools import partial
 
 import asdf
@@ -104,17 +103,15 @@ def _get_hdu_name(schema):
 
 
 def _get_hdu_type(hdu_name, schema=None, value=None):
-    hdu_type = None
     if hdu_name in (0, "PRIMARY"):
-        hdu_type = fits.PrimaryHDU
-    elif schema is not None:
-        dtype = ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"])
-        if dtype.fields is not None:
-            hdu_type = fits.BinTableHDU
-    elif value is not None:
+        return fits.PrimaryHDU
+    if schema is not None and "dataype" in schema:
+        if ndarray.asdf_datatype_to_numpy_dtype(schema["datatype"]).fields is not None:
+            return fits.BinTableHDU
+    if value is not None:
         if hasattr(value, "dtype") and value.dtype.names is not None:
-            hdu_type = fits.BinTableHDU
-    return hdu_type
+            return fits.BinTableHDU
+    return fits.ImageHDU
 
 
 def _get_hdu_pair(hdu_name, index=None):
@@ -172,76 +169,6 @@ def get_hdu(hdulist, hdu_name, index=None, _cache=None):
     return hdu
 
 
-def _make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
-    if isinstance(value, NDArrayType):
-        value = np.asarray(value)
-
-    if hdu_type is None:
-        hdu_type = _get_hdu_type(hdu_name, value=value)
-        if hdu_type is None:
-            hdu_type = fits.ImageHDU
-
-    if hdu_type == fits.PrimaryHDU:
-        hdu = hdu_type(value)
-    else:
-        hdu = hdu_type(value, name=hdu_name)
-    if index is not None:
-        hdu.ver = index + 1
-    hdulist.append(hdu)
-    return hdu
-
-
-def _get_or_make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None, _cache=None):
-    if isinstance(hdulist, weakref.ReferenceType):
-        ref = hdulist()
-        result = _get_or_make_hdu(
-            ref, hdu_name, index=index, hdu_type=hdu_type, value=value, _cache=_cache
-        )
-        # While likely not needed (as ref will fall out of scope on
-        # return), del ref to remove the reference to the hdulist we
-        # resolved from the weakref. weakref is important here as
-        # this function is called within a validator which will be
-        # cached holding referenced objects in memory.
-        # https://github.com/spacetelescope/stdatamodels/pull/109
-        del ref
-        return result
-    # Bypass get_hdu when there's a cache because try: hdulist[pair] is slow.
-    # We know that if the pair isn't in the cache it needs to be made.
-    if _cache is not None:
-        pair = _get_hdu_pair(hdu_name, index=index)
-        if pair in _cache:
-            hdu = _cache[pair]
-            if hdu_type is not None and not isinstance(hdu, hdu_type):
-                # this is used for Table-like hdus
-                new_hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-                for key, val in hdu.header.items():
-                    if not is_builtin_fits_keyword(key):
-                        new_hdu.header[key] = val
-                hdulist.remove(hdu)
-                hdu = new_hdu
-            return hdu
-        hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-        # add new HDU to the cache
-        _cache[pair] = hdu
-        return hdu
-    # original behavior, currently still used for extra_fits handling
-    try:
-        hdu = get_hdu(hdulist, hdu_name, index=index)
-    except AttributeError:
-        hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-    else:
-        if hdu_type is not None and not isinstance(hdu, hdu_type):
-            new_hdu = _make_hdu(hdulist, hdu_name, index=index, hdu_type=hdu_type, value=value)
-            for key, val in hdu.header.items():
-                if not is_builtin_fits_keyword(key):
-                    new_hdu.header[key] = val
-            hdulist.remove(hdu)
-            hdu = new_hdu
-        elif value is not None:
-            hdu.data = value
-    return hdu
-
-
 def _assert_non_primary_hdu(hdu_name):
     if hdu_name in (None, 0, "PRIMARY"):
         raise ValueError("Schema for data property does not specify a non-primary hdu name")
@@ -273,17 +200,29 @@ def _fits_comment_section_handler(fits_context, validator, properties, instance,
         current_comment_stack.pop(-1)
 
 
-def _fits_element_writer(
-    fits_context, validator, fits_keyword, instance, schema, fits_hdu_cache=None
-):
+def _fits_element_writer(fits_context, validator, fits_keyword, instance, schema):
     if schema.get("type", "object") == "array":
         raise ValueError("'fits_keyword' is not valid with type of 'array'")
 
-    hdu_name = _get_hdu_name(schema)
+    hdu_name = schema.get("fits_hdu", "PRIMARY")
 
-    hdu = _get_or_make_hdu(
-        fits_context.hdulist, hdu_name, index=fits_context.sequence_index, _cache=fits_hdu_cache
-    )
+    if fits_context.sequence_index is not None:
+        name = (hdu_name, fits_context.sequence_index)
+    else:
+        name = hdu_name
+
+    if fits_context.has_name(name):
+        hdu = fits_context.by_name(name)
+    else:
+        # make a new one
+        hdu_type = _get_hdu_type(hdu_name, schema=schema)
+        if hdu_type is fits.PrimaryHDU:
+            hdu = hdu_type()
+        else:
+            hdu = hdu_type(name=hdu_name, ver=fits_context.sequence_index)
+
+        # add it to the context
+        fits_context.append(hdu)
 
     for comment in fits_context.comment_stack:
         hdu.header.append((" ", ""), end=True)
@@ -302,7 +241,7 @@ def _fits_element_writer(
         hdu.header.append((fits_keyword, instance, comment), end=True)
 
 
-def _fits_array_writer(fits_context, validator, _, instance, schema, fits_hdu_cache=None):
+def _fits_array_writer(fits_context, validator, _, instance, schema):
     if instance is None:
         return
 
@@ -320,23 +259,47 @@ def _fits_array_writer(fits_context, validator, _, instance, schema, fits_hdu_ca
     if "datatype" in schema:
         yield from validate._validate_datatype(validator, schema["datatype"], instance, schema)
 
-    hdu_name = _get_hdu_name(schema)
+    hdu_name = schema.get("fits_hdu", "PRIMARY")
     _assert_non_primary_hdu(hdu_name)
-    index = fits_context.sequence_index
-    if index is None:
-        index = 0
 
     hdu_type = _get_hdu_type(hdu_name, schema=schema, value=instance)
-    hdu = _get_or_make_hdu(
-        fits_context.hdulist, hdu_name, index=index, hdu_type=hdu_type, _cache=fits_hdu_cache
-    )
 
-    hdu.data = instance
-    if instance_id in fits_context.extension_array_links:
-        if fits_context.extension_array_links[instance_id]() is not hdu:
+    if fits_context.sequence_index is not None:
+        name = (hdu_name, fits_context.sequence_index)
+    else:
+        name = hdu_name
+
+    # Do we need to make an HDU?
+    if fits_context.has_name(name):
+        hdu = fits_context.by_name(name)
+
+        # is the type correct?
+        if isinstance(hdu, hdu_type):
+            # TODO can we avoid assigning to data
+            hdu.data = instance
+        else:
+            # make a new hdu with the existing header
+            header = fits.Header(
+                [card for card in hdu.header.cards if not is_builtin_fits_keyword(card.keyword)]
+            )
+            hdu = hdu_type(
+                data=instance, name=hdu_name, ver=fits_context.sequence_index, header=header
+            )
+
+            # replace the existing hdu
+            fits_context.replace(hdu)
+    else:
+        # make a new hdu
+        hdu = hdu_type(data=instance, name=hdu_name, ver=fits_context.sequence_index)
+
+        # add it to the context
+        fits_context.append(hdu)
+
+    if other_index := fits_context.extension_array_links.get(instance_id):
+        if fits_context.get_index(name) != other_index:
             raise ValueError("Linking one array to multiple hdus is not supported")
-    fits_context.extension_array_links[instance_id] = weakref.ref(hdu)
-    hdu.ver = index + 1
+    else:
+        fits_context.extension_array_links[instance_id] = fits_context.get_index(name)
 
 
 # This is copied from jsonschema._validators and modified to keep track
@@ -348,7 +311,7 @@ def _fits_item_recurse(fits_context, validator, items, instance, schema):
     if validator.is_type(items, "object"):
         initial_index = fits_context.sequence_index
         for index, item in enumerate(instance):
-            fits_context.sequence_index = index
+            fits_context.sequence_index = index + 1
             for error in validator.descend(item, items, path=index):
                 yield error
         fits_context.sequence_index = initial_index
@@ -372,16 +335,91 @@ def _fits_type(fits_context, validator, items, instance, schema):
 
 
 class FitsContext:
-    def __init__(self, hdulist):
-        self.hdulist = weakref.ref(hdulist)
+    def __init__(self, hdulist=None):
+        self._preindex_hdulist(hdulist)
         self.comment_stack = []
         self.sequence_index = None
         self.extension_array_links = {}
 
+    def get_index(self, name):
+        return self._name_to_index[name]
 
-def _get_validators(hdulist):
-    fits_context = FitsContext(hdulist)
+    def by_name(self, name):
+        return self._hdus[self.get_index(name)]
 
+    def has_name(self, name):
+        return name in self._name_to_index
+
+    def by_index(self, index):
+        return self._hdus[index]
+
+    def replace(self, hdu):
+        if ver := hdu.header.get("EXTVER"):
+            name = (hdu.name, ver)
+        else:
+            name = hdu.name
+        self._hdus[self.get_index(name)] = hdu
+
+    def append(self, hdu):
+        self._hdus.append(hdu)
+        index = len(self._hdus) - 1
+        if ver := hdu.header.get("EXTVER"):
+            name = (hdu.name, ver)
+        else:
+            name = hdu.name
+        self._name_to_index[name] = index
+        self._index_to_name[index] = name
+
+    def _clear_hdus(self):
+        self._hdus = []
+        self._name_to_index = {}
+        self._index_to_name = {}
+
+    def _preindex_hdulist(self, hdulist=None):
+        self._clear_hdus()
+
+        if not hdulist:
+            self._hdus = [fits.PrimaryHDU()]
+        else:
+            # Don't include any previous ASDF HDU
+            self._hdus = [hdu for hdu in hdulist if hdu.name != _ASDF_EXTENSION_NAME]
+
+        for index, hdu in enumerate(self._hdus):
+            # Only use version if EXTVER is defined as astropy
+            # will return 1 for ver even if the HDU has no EXTVER
+            if ver := hdu.header.get("EXTVER"):
+                name = (hdu.name, ver)
+            else:
+                name = hdu.name
+
+            if name in self._name_to_index:
+                raise Exception(f"Multiple HDUs share {name}, this is unsupported")
+
+            self._name_to_index[name] = index
+            self._index_to_name[index] = name
+
+    def to_hdulist(self, tree):
+        # TODO strip ASDF to appease a unit test, perhaps we remove the test?
+        if self.has_name(_ASDF_EXTENSION_NAME):
+            del self._hdus[self.get_index(_ASDF_EXTENSION_NAME)]
+
+        # add hash
+        tree[FITS_HASH_KEY] = fits_hash(self._hdus)
+
+        # add ASDF
+        self._hdus.append(_create_asdf_hdu(tree))
+
+        # convert to hdulist
+        hdulist = fits.HDUList(self._hdus)
+
+        # wipe all references to HDUs since this context will
+        # be cached with the validator partial
+        self._clear_hdus()
+
+        return hdulist
+
+
+def _get_validators(fits_context):
     validators = HashableDict(asdf_schema.YAML_VALIDATORS)
 
     # create an extension_manager for validate_tag
@@ -412,15 +450,10 @@ def _get_validators(hdulist):
 
     # Initialize a cache of HDUs for the validator.
     # This allows bypassing very slow indexing into hdulist
-    fits_hdu_cache = {(hdu.name, hdu.ver - 1): hdu for hdu in hdulist}
-    partial_fits_array_writer = partial(
-        _fits_array_writer, fits_context, fits_hdu_cache=fits_hdu_cache
-    )
+    partial_fits_array_writer = partial(_fits_array_writer, fits_context)
     validators.update(
         {
-            "fits_keyword": partial(
-                _fits_element_writer, fits_context, fits_hdu_cache=fits_hdu_cache
-            ),
+            "fits_keyword": partial(_fits_element_writer, fits_context),
             "ndim": partial_fits_array_writer,
             "max_ndim": partial_fits_array_writer,
             "datatype": partial_fits_array_writer,
@@ -431,42 +464,29 @@ def _get_validators(hdulist):
         }
     )
 
-    return validators, fits_context
+    return validators
 
 
-def _save_from_schema(hdulist, tree, schema):
-    def datetime_callback(node):
-        if isinstance(node, datetime.datetime):
-            node = time.Time(node)
-
-        if isinstance(node, time.Time):
-            node = str(time.Time(node, format="iso"))
-
-        return node
-
-    tree = treeutil.walk_and_modify(tree, datetime_callback)
-
+def _save_from_schema(fits_context, tree, schema):
     kwargs = {"_visit_repeat_nodes": True}
 
-    validators, context = _get_validators(hdulist)
+    validators = _get_validators(fits_context)
     validator = asdf_schema.get_validator(schema, None, validators, **kwargs)
 
     # This actually kicks off the saving
     validator.validate(tree, _schema=schema)
 
     # Now link extensions to items in the tree
-
     def callback(node):
-        if id(node) in context.extension_array_links:
-            hdu = context.extension_array_links[id(node)]()
-            return _create_tagged_dict_for_fits_array(hdu, hdulist.index(hdu))
+        if hdu_index := fits_context.extension_array_links.get(id(node)):
+            return _create_tagged_dict_for_fits_array(fits_context.by_index(hdu_index), hdu_index)
         elif isinstance(node, (np.ndarray, NDArrayType)):
             # in addition to links generated during validation
             # replace arrays in the tree that are identical to HDU arrays
             # with ndarray-1.0.0 tagged objects with special source values
             # that represent links to the surrounding FITS file.
             # This is important for general ASDF-in-FITS support
-            for hdu_index, hdu in enumerate(hdulist):
+            for hdu_index, hdu in enumerate(fits_context._hdus):
                 if hdu.data is not None and node is hdu.data:
                     return _create_tagged_dict_for_fits_array(hdu, hdu_index)
         return node
@@ -501,56 +521,60 @@ def _create_tagged_dict_for_fits_array(hdu, hdu_index):
     )
 
 
-def _normalize_arrays(tree):
-    """
-    Convert arrays in the tree to C-contiguous.
-
-    They are written to disk by astropy.io.fits in C-contiguous, and we
-    don't want the asdf library to notice the change in memory
-    layout and duplicate the array in the embedded ASDF.
-
-    Parameters
-    ----------
-    tree : dict
-        The ASDF tree.
-
-    Returns
-    -------
-    tree : dict
-        The ASDF tree with all arrays converted to C-contiguous.
-    """
-
-    def normalize_array(node):
-        if isinstance(node, np.ndarray):
-            # We can't use np.ascontiguousarray because it converts FITS_rec
-            # to vanilla np.ndarray, which results in misinterpretation of
-            # unsigned int values.
-            if not node.flags.c_contiguous:
-                node = node.copy()
-        return node
-
-    return treeutil.walk_and_modify(tree, normalize_array)
-
-
-def _save_extra_fits(hdulist, tree):
+def _save_extra_fits(fits_context, tree):
     # Handle _extra_fits
     for hdu_name, parts in tree.get("extra_fits", {}).items():
+        # only consider non-builtin keywords
+        cards = [
+            fits.Card(*h) for h in parts.get("header", []) if not is_builtin_fits_keyword(h[0])
+        ]
+
+        # first sort out expected type
+        hdu_type = _get_hdu_type(hdu_name, value=parts.get("data"))
+
+        # does the hdu exist?
+        if fits_context.has_name(hdu_name):
+            # get the existing hdu
+            hdu = fits_context.by_name(hdu_name)
+
+            # is it the right type? only check if there is data
+            if "data" in parts and not isinstance(hdu, hdu_type):
+                # sort out the new header
+                merged_cards = [
+                    card for card in hdu.header.cards if not is_builtin_fits_keyword(card.keyword)
+                ] + cards
+
+                # make a new hdu
+                hdu = hdu_type(data=parts.get("data"), header=fits.Header(merged_cards))
+
+                # replace the old one
+                fits_context.replace(hdu)
+            else:
+                # update the data
+                # TODO can we avoid assigning to data?
+                if "data" in parts:
+                    hdu.data = parts.get("data")
+
+                # add to the header
+                hdu.header.extend(cards, end=True)
+        else:
+            # make a new hdu
+            hdu = hdu_type(name=hdu_name, data=parts.get("data"), header=fits.Header(cards))
+
+            # add this to the context
+            fits_context.append(hdu)
+
+        # update the tree with a reference to the data
         if "data" in parts:
-            hdu_type = _get_hdu_type(hdu_name, value=parts["data"])
-            hdu = _get_or_make_hdu(hdulist, hdu_name, hdu_type=hdu_type, value=parts["data"])
-            node = _create_tagged_dict_for_fits_array(hdu, hdulist.index(hdu))
-            tree["extra_fits"][hdu_name]["data"] = node
-        if "header" in parts:
-            hdu = _get_or_make_hdu(hdulist, hdu_name)
-            for key, val, comment in parts["header"]:
-                if is_builtin_fits_keyword(key):
-                    continue
-                hdu.header.append((key, val, comment), end=True)
+            tree["extra_fits"][hdu_name]["data"] = _create_tagged_dict_for_fits_array(
+                fits_context.by_name(hdu_name),
+                fits_context.get_index(hdu_name),
+            )
 
     return tree
 
 
-def _save_history(hdulist, tree):
+def _save_history(fits_context, tree):
     if "history" not in tree:
         return
 
@@ -567,7 +591,7 @@ def _save_history(hdulist, tree):
                 history[i] = HistoryEntry(history[i])
             else:
                 history[i] = HistoryEntry({"description": str(history[i])})
-        hdulist[0].header["HISTORY"] = history[i]["description"]
+        fits_context.by_name("PRIMARY").header["HISTORY"] = history[i]["description"]
 
 
 def to_fits(tree, schema, hdulist=None):
@@ -588,24 +612,31 @@ def to_fits(tree, schema, hdulist=None):
     hdulist : astropy.io.fits.HDUList
         The HDU list.
     """
-    if hdulist is None:
-        hdulist = fits.HDUList()
-        hdulist.append(fits.PrimaryHDU())
+    fits_context = FitsContext(hdulist)
 
-    tree = _normalize_arrays(tree)
-    tree = _save_from_schema(hdulist, tree, schema)
-    tree = _save_extra_fits(hdulist, tree)
-    _save_history(hdulist, tree)
+    # cleanup tree
+    def node_callback(node):
+        # convert datetime to astropy Time
+        if isinstance(node, datetime.datetime):
+            node = time.Time(node)
 
-    # Store the FITS hash in the tree
-    tree[FITS_HASH_KEY] = fits_hash(hdulist)
+        # convert astropy Time to iso string
+        if isinstance(node, time.Time):
+            node = str(time.Time(node, format="iso"))
 
-    if _ASDF_EXTENSION_NAME in hdulist:
-        del hdulist[_ASDF_EXTENSION_NAME]
+        # copy arrays if not c_contiguous
+        if isinstance(node, np.ndarray) and not node.flags.c_contiguous:
+            node = node.copy()
 
-    hdulist.append(_create_asdf_hdu(tree))
+        return node
 
-    return hdulist
+    tree = treeutil.walk_and_modify(tree, node_callback)
+
+    tree = _save_from_schema(fits_context, tree, schema)
+    tree = _save_extra_fits(fits_context, tree)
+    _save_history(fits_context, tree)
+
+    return fits_context.to_hdulist(tree)
 
 
 def _create_asdf_hdu(tree):
@@ -709,7 +740,9 @@ def _load_from_schema(
     # Check if there are any table HDU's. If not, this whole process
     # can be skipped.
     if skip_fits_update:
-        if not any(isinstance(hdu, fits.BinTableHDU) for hdu in hdulist if hdu.name != "ASDF"):
+        if not any(
+            isinstance(hdu, fits.BinTableHDU) for hdu in hdulist if hdu.name != _ASDF_EXTENSION_NAME
+        ):
             log.debug("Skipping FITS updating completely.")
             return known_keywords, known_datas
         log.debug(
@@ -782,7 +815,7 @@ def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
     # Add header keywords and data not in schema to extra_fits
     for hdu in hdulist:
         # Don't add ASDF hdus to extra_fits for any reason
-        if hdu.name != "ASDF":
+        if hdu.name != _ASDF_EXTENSION_NAME:
             known = known_keywords.get(hdu, set())
 
             cards = []
@@ -1025,7 +1058,7 @@ def fits_hash(hdulist):
 
     Parameters
     ----------
-    hdulist : astropy.fits.HDUList
+    hdulist : astropy.fits.HDUList or list of astropy.fits.HDU
         The FITS structure.
 
     Returns
@@ -1039,7 +1072,9 @@ def fits_hash(hdulist):
     # Such issues are inconsequential to hash calculation.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", AstropyWarning)
-        fits_hash.update("".join(str(hdu.header) for hdu in hdulist if hdu.name != "ASDF").encode())
+        fits_hash.update(
+            "".join(str(hdu.header) for hdu in hdulist if hdu.name != _ASDF_EXTENSION_NAME).encode()
+        )
     return fits_hash.hexdigest()
 
 

--- a/src/stdatamodels/fits_support.py
+++ b/src/stdatamodels/fits_support.py
@@ -393,9 +393,16 @@ class FitsContext:
                 name = hdu.name
 
             if name in self._name_to_index:
-                raise Exception(f"Multiple HDUs share {name}, this is unsupported")
-
-            self._name_to_index[name] = index
+                msg = (
+                    f"Multiple HDUs share {name}, this can issues with mapping FITS to ASDF. "
+                    "In the future this will be an error. Assign each HDU a unique name or "
+                    "name/version to avoid this error"
+                )
+                warnings.warn(msg, UserWarning, stacklevel=2)
+                # Only map the first name -> index to match astropy handling of name
+                # confusion where hdulist["SCI"] with 2x SCI returns the first.
+            else:
+                self._name_to_index[name] = index
             self._index_to_name[index] = name
 
     def to_hdulist(self, tree):

--- a/tests/jwst/test_schemas.py
+++ b/tests/jwst/test_schemas.py
@@ -33,7 +33,7 @@ SCHEMA_IDS = _get_schema_ids()
 @pytest.fixture(scope="module")
 def known_validators():
 
-    validators = _get_validators(HDUList())[0]
+    validators = _get_validators(HDUList())
     known_validators = set(validators.keys())
     return known_validators
 

--- a/tests/test_asdf_in_fits.py
+++ b/tests/test_asdf_in_fits.py
@@ -205,8 +205,25 @@ def test_non_named_hdus(tmp_path):
     ff[7].name = "FOO"
     ff[7].ver = 2
     tree = {"hdus": [hdu.data for hdu in ff[1:]]}
-    asdf_in_fits.write(fn, tree, ff)
+    with pytest.warns(UserWarning, match="Multiple HDUs share"):
+        asdf_in_fits.write(fn, tree, ff)
 
     with asdf_in_fits.open(fn) as af:
         for i, hdu in enumerate(af.tree["hdus"]):
             assert hdu[0] == i
+
+
+def test_shared_name(tmp_path):
+    fn = tmp_path / "test.fits"
+    # 2 hdus that share names
+    ff = fits.HDUList(
+        [fits.PrimaryHDU(), fits.ImageHDU([0], name="SCI"), fits.ImageHDU([1], name="SCI")]
+    )
+    tree = {"hdus": [hdu.data for hdu in ff[1:]]}
+    with pytest.warns(UserWarning, match="Multiple HDUs share"):
+        asdf_in_fits.write(fn, tree, ff)
+
+    with asdf_in_fits.open(fn) as af:
+        for i, hdu in enumerate(af.tree["hdus"]):
+            # TODO this is wrong but matches main
+            assert hdu[0] == 1


### PR DESCRIPTION
This is an alternative to https://github.com/spacetelescope/stdatamodels/pull/794 based on information learned while reviewing that PR leading to an alternative approach.

Restructure writing in fits_support by:
- expanding FitsContext to act as the "cache" for accessing hdus without using hdulist
- remove some (now) unused private API: _make_hdu, _get_or_make_hdu, _normalize_arrays (combined with datetime conversion tree walk)
- adding a warning when a pre-existing hdulist with ambiguous hdu names is provided for writing. This only impacts asdf_in_fits (no impact on pipeline uses). In the future we should make this warning an error as the resulting file can be unexpected and fail to roundtrip (this is the case on main but with no warning).

Regression tests:
https://github.com/spacetelescope/RegressionTests/actions/runs/32756102529

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
