### PR TITLE
Fits hdu primary

### DIFF
--- a/changes/806.docs.rst
+++ b/changes/806.docs.rst
@@ -1,0 +1,1 @@
+Clarify that ``fits_hdu`` in schemas must be a string.

--- a/docs/source/jwst/datamodels/schemas.rst
+++ b/docs/source/jwst/datamodels/schemas.rst
@@ -156,7 +156,5 @@ have the prefix ``fits_``.
 - ``fits_keyword``: Specifies the FITS keyword to store the value in.
   Must be a string with a maximum length of 8 characters.
 
-- ``fits_hdu``: Specifies the FITS HDU to store the value in.  May be
-  a number (to specify the nth HDU) or a name (to specify the
-  extension with the given ``EXTNAME``).  By default this is set to 0,
-  and therefore refers to the primary HDU.
+- ``fits_hdu``: Specifies the FITS HDU name to store the value in. If
+  not provided PRIMARY is assumed.

--- a/tests/jwst/datamodels/test_schema.py
+++ b/tests/jwst/datamodels/test_schema.py
@@ -21,7 +21,6 @@ def test_data_array(tmp_path):
                     "arr": {
                         "title": "An array of data",
                         "type": "array",
-                        "fits_hdu": ["FOO", "DQ"],
                         "items": {
                             "title": "entry",
                             "type": "object",

--- a/tests/jwst/test_schemas.py
+++ b/tests/jwst/test_schemas.py
@@ -91,3 +91,16 @@ def test_unit_is_fits(schema_id):
             continue
         fits_unit = astropy.units.Unit(unit).to_string("fits")
         assert unit == fits_unit
+
+
+@pytest.mark.parametrize("schema_id", SCHEMA_IDS)
+def test_fits_hdu(schema_id):
+    schema = asdf.schema.load_schema(schema_id)
+
+    for node in asdf.treeutil.iter_tree(schema):
+        if not isinstance(node, dict):
+            continue
+        if "fits_hdu" not in node:
+            continue
+        fits_hdu = node["fits_hdu"]
+        assert isinstance(fits_hdu, str)

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -4,7 +4,7 @@ import asdf.schema
 import numpy as np
 import pytest
 from astropy.io import fits
-from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from stdatamodels import DataModel, fits_support
 
@@ -459,90 +459,6 @@ def test_from_hdulist(tmp_path):
         with FitsModel(hdulist) as dm:
             dm.data  # noqa: B018
         assert not hdulist.fileinfo(0)["file"].closed
-
-
-def test_data_array(tmp_path):
-    file_path = tmp_path / "test.fits"
-    file_path2 = tmp_path / "test2.fits"
-
-    data_array_schema = {
-        "allOf": [
-            asdf.schema.load_schema(
-                "http://example.com/schemas/core_metadata", resolve_references=True
-            ),
-            {
-                "type": "object",
-                "properties": {
-                    "arr": {
-                        "title": "An array of data",
-                        "type": "array",
-                        "fits_hdu": ["FOO", "DQ"],
-                        "items": {
-                            "title": "entry",
-                            "type": "object",
-                            "properties": {
-                                "data": {
-                                    "fits_hdu": "FOO",
-                                    "default": 0.0,
-                                    "max_ndim": 2,
-                                    "datatype": "float64",
-                                },
-                                "dq": {"fits_hdu": "DQ", "default": 1, "datatype": "uint8"},
-                            },
-                        },
-                    }
-                },
-            },
-        ]
-    }
-
-    rng = np.random.default_rng(42)
-    array1 = rng.random((5, 5))
-    array2 = rng.random((5, 5))
-    array3 = rng.random((5, 5))
-
-    with DataModel(schema=data_array_schema) as x:
-        x.arr.append(x.arr.item())
-        x.arr[0].data = array1
-        assert len(x.arr) == 1
-        x.arr.append(x.arr.item(data=array2))
-        assert len(x.arr) == 2
-        x.arr.append({})
-        assert len(x.arr) == 3
-        x.arr[2].data = array3
-        del x.arr[1]
-        assert len(x.arr) == 2
-        x.to_fits(file_path)
-
-    with DataModel(file_path, schema=data_array_schema) as x:
-        assert len(x.arr) == 2
-        assert_array_almost_equal(x.arr[0].data, array1)
-        assert_array_almost_equal(x.arr[1].data, array3)
-
-        del x.arr[0]
-        assert len(x.arr) == 1
-
-        x.arr = []
-        assert len(x.arr) == 0
-        x.arr.append({"data": np.empty((5, 5))})
-        assert len(x.arr) == 1
-        x.arr.extend(
-            [
-                x.arr.item(data=np.empty((5, 5))),
-                x.arr.item(data=np.empty((5, 5)), dq=np.empty((5, 5), dtype=np.uint8)),
-            ]
-        )
-        assert len(x.arr) == 3
-        del x.arr[1]
-        assert len(x.arr) == 2
-        x.to_fits(file_path2, overwrite=True)
-
-    with fits.open(file_path2) as hdulist:
-        x = set()
-        for hdu in hdulist:
-            x.add((hdu.header.get("EXTNAME"), hdu.header.get("EXTVER")))
-
-        assert x == {("FOO", 2), ("FOO", 1), ("ASDF", None), ("DQ", 2), (None, None)}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Based off https://github.com/spacetelescope/stdatamodels/pull/806 since that adds a test for fits_hdu

Fixes: https://github.com/spacetelescope/stdatamodels/issues/803

Replace _assert_non_primary_hdu with a unit test that checks that all array-defined schemas do not attempt to use the PRIMARY hdu.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] If this change affects user-facing code or public API, add news fragment file(s) to `changes/` (see [the changelog instructions](https://github.com/spacetelescope/stdatamodels/blob/main/changes/README.md)).
      Otherwise, add the `no-changelog-entry-needed` label.
- [ ] [run `jwst` regression tests](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) with this branch installed (`"git+https://github.com/<fork>/stdatamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- `<PR#>.breaking.rst`: Add this fragment if your change **breaks public API**, describing what the user needs to change
- `<PR#>.schema.rst`: schema updates
- `<PR#>.feature.rst`
- `<PR#>.bugfix.rst`
- `<PR#>.docs.rst`
- `<PR#>.other.rst`
</details>
